### PR TITLE
filters collection for not visible products

### DIFF
--- a/Omikron/Factfinder/Model/Export/Product.php
+++ b/Omikron/Factfinder/Model/Export/Product.php
@@ -110,6 +110,7 @@ class Product extends AbstractModel
     {
         $collection = $this->productCollectionFactory->create();
         $collection->addAttributeToSelect('*');
+        $collection->addFieldToFilter('visibility',['neq' => \Magento\Catalog\Model\Product\Visibility::VISIBILITY_NOT_VISIBLE]);
         $collection->setStore($store);
         
         return $collection;


### PR DESCRIPTION
- Solves issue: 
No backend url in export csv column _ProductUrl_ anymore

- Description: 
The Extension loads data like store url for each product. For not visible products a backend url returns. The fix adds a filter to the collection that fetch all products. The collection contains only visible elements.

- Tested with Magento editions/versions: 
2.1.4

- Tested with PHP versions: 
5.6.31

### Please note that the source and target branch must be "develop" (details: https://github.com/FACT-Finder-Web-Components/magento2-module/tree/master/.github/CONTRIBUTING.md).