### PR TITLE
Add helper method to get correct sessionId

### DIFF
--- a/Omikron/Factfinder/Block/FF/Communication.php
+++ b/Omikron/Factfinder/Block/FF/Communication.php
@@ -55,8 +55,7 @@ class Communication extends Template
                 'defaultValue' => null
             ],
             'sid' => [
-                //TODO write proper helper method
-                'value' => $tracking->getSessionId() . '1234',
+                'value' => $this->_helper->getCorrectSessionId($tracking->getSessionId()),
                 'type' => 'string',
                 'defaultValue' => null
             ],

--- a/Omikron/Factfinder/Helper/Data.php
+++ b/Omikron/Factfinder/Helper/Data.php
@@ -13,6 +13,7 @@ class Data extends AbstractHelper
 {
     const FRONT_NAME = "FACT-Finder";
     const CUSTOM_RESULT_PAGE = "result";
+    const SESSION_ID_LENGTH = 30;
 
     const PATH_TRACKING_PRODUCT_NUMBER_FIELD_ROLE = 'factfinder/general/tracking_product_number_field_role';
     const PATH_IS_ENABLED = 'factfinder/general/is_enabled';
@@ -424,5 +425,23 @@ class Data extends AbstractHelper
     public function setFieldRoles($value, $store)
     {
         return $this->_resourceConfig->saveConfig(self::PATH_TRACKING_PRODUCT_NUMBER_FIELD_ROLE, $value, 'stores', $store->getId());
+    }
+
+    /**
+     * Get correct sessionId
+     * @param string $sessionId
+     * @return string
+     */
+    public function getCorrectSessionId($sessionId)
+    {
+        while (strlen($sessionId) !== self::SESSION_ID_LENGTH) {
+            if (strlen($sessionId) < self::SESSION_ID_LENGTH) {
+                $sessionId = $sessionId . substr($sessionId, 0, (self::SESSION_ID_LENGTH - strlen($sessionId)));
+            } else if (strlen($sessionId) > self::SESSION_ID_LENGTH) {
+                $sessionId = substr($sessionId, 0, self::SESSION_ID_LENGTH);
+            }
+        }
+
+        return $sessionId;
     }
 }


### PR DESCRIPTION
- Solves issue: getting sessionId with wrong length
- Description: getting correct sessionId (always 30 characters)
- Tested with Magento editions/versions: 2.1.4
- Tested with PHP versions: 7.0.27

### Please note that the source and target branch must be "develop" (details: https://github.com/FACT-Finder-Web-Components/magento2-module/tree/master/.github/CONTRIBUTING.md).