### PR TITLE
Feature/make message about before test save data more visible

### DIFF
--- a/Omikron/Factfinder/etc/adminhtml/system.xml
+++ b/Omikron/Factfinder/etc/adminhtml/system.xml
@@ -7,7 +7,7 @@
             <resource>Omikron_Factfinder::config</resource>
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Main Settings</label>
-                <comment>Please always save the config in the upper right corner after making changes.</comment>
+                <comment><![CDATA[<div class="message message-notice notice"><div data-ui-id="messages-message-success">Please always save the config in the upper right corner after making changes.</div></div>]]></comment>
                 <field id="is_enabled" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Activate FACT-Finder integration</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
@@ -199,7 +199,7 @@
             </group>
             <group id="data_transfer" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Data export</label>
-                <comment>Please always save the config in the upper right corner after making changes. Especially before using the export-button.</comment>
+                <comment><![CDATA[<div class="message message-notice notice"><div data-ui-id="messages-message-success">Please always save the config in the upper right corner after making changes. Especially before using the export-button.</div></div>]]></comment>
                 <field id="ff_upload_host" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Upload Host</label>
                     <comment>Please specify the FTP server address, where the export file(s) should be uploaded. For example shopname.fact-finder.de. This parameter shouldn't have any trailing slashes and shouldn't be prefixed with ftp://.</comment>


### PR DESCRIPTION
- Solves issue: Adds highlighted messages before save data in admin panel
- Description: 
- Tested with Magento editions/versions: 2.1.4
- Tested with PHP versions: 7.0.27

### Please note that the source and target branch must be "develop" (details: https://github.com/FACT-Finder-Web-Components/magento2-module/tree/master/.github/CONTRIBUTING.md).