### PR TITLE
 add 'version' as a required param 

### DIFF
--- a/Omikron/Factfinder/Block/FF/Communication.php
+++ b/Omikron/Factfinder/Block/FF/Communication.php
@@ -46,7 +46,7 @@ class Communication extends Template
         $filePath = $this->_moduleDirReader->getModuleDir('etc', 'Omikron_Factfinder') . '/config.xml';
         $defaultValues = $this->_parser->load($filePath)->xmlToArray()['config']['_value']['default']['factfinder'];
 
-        $this->_requiredAttributes = ['url', 'channel', 'sid'];
+        $this->_requiredAttributes = ['url', 'channel', 'sid', 'version'];
 
         $this->_configData = [
             'url' => [


### PR DESCRIPTION
When using the most recent ff-web-components version you will see an error in the javascript console, if the `version` parameter is not present on `<ff-communication>`.