### PR TITLE
 keep_url_params should be select input field

### DIFF
--- a/Omikron/Factfinder/etc/adminhtml/system.xml
+++ b/Omikron/Factfinder/etc/adminhtml/system.xml
@@ -84,8 +84,9 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>With this property you can determine if filters (which where set before the search, e.g. via ASN) should be kept or discarded.</comment>
                 </field>
-                <field id="keep_url_params" translate="label" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="keep_url_params" translate="label" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>keep-url-params</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Determines if parameters which are written into the URL should be kept.</comment>
                 </field>
                 <field id="use_asn" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
- Solves issue: 
- Description: keep_url_params config should have boolean input field in admin backend
- Tested with Magento editions/versions: 2.1.5
- Tested with PHP versions: 7.1