### PR TITLE
fix count of cart tracking

### DIFF
--- a/Omikron/Factfinder/Helper/Tracking.php
+++ b/Omikron/Factfinder/Helper/Tracking.php
@@ -72,7 +72,7 @@ class Tracking extends AbstractHelper
             'id' => $this->_product->get($this->_helper->getFieldRole('trackingProductNumber'), $product, $this->_store),
             'masterId' => $this->_product->get($this->_helper->getFieldRole('masterArticleNumber'), $product, $this->_store),
             'price' => $this->_product->get('Price', $product, $this->_store),
-            'count' => $amount,
+            'count' => (int) round($amount),
             'sid' => $this->getSessionId(),
             'channel' => $this->getChannel(),
         ];


### PR DESCRIPTION
According to FACT Finder support, the _Tracking.ff_ endpoint expects the _count_ parameter to be an integer without decimals, otherwise the tracking will not work (see Omikron ticket number 11039666).