### PR TITLE
allow PHP 7.1 and higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "omikron/magento2-factfinder",
     "description": "FACTFinder Webcomponents SDK",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0",
+        "php": "^5.5 || ^7.0",
         "magento/magento-composer-installer": "*"
     },
     "suggest": {


### PR DESCRIPTION
I do not see any reasons, why this module should not be allowed to use with PHP 7.1 and higher.