### PR TITLE
do not use the "version"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     "suggest": {
     },
     "type": "magento2-module",
-    "version": "v0.9-beta.5",
     "license": [
     ],
     "autoload": {


### PR DESCRIPTION
Defining the "version" in the composer.json is not necessary when using VCS tags (as it is done here in this repository) and it is actually recommended __not__ to use it in that case: https://getcomposer.org/doc/04-schema.md#version

> Optional if the package repository can infer the version from somewhere, such as the VCS tag name in the VCS repository. __In that case it is also recommended to omit it.__

> __Specifying the version yourself will most likely end up creating problems at some point due to human error.__