### PR TITLE
fix typo in "Communication" class name

### DIFF
--- a/Omikron/Factfinder/CustomerData/FF/Comumnication.php
+++ b/Omikron/Factfinder/CustomerData/FF/Comumnication.php
@@ -7,9 +7,9 @@ use Omikron\Factfinder\Helper\Data as FactfinderHelper;
 use Omikron\Factfinder\Helper\Tracking;
 
 /**
- * Class Comumnication
+ * Class Communication
  */
-class Comumnication implements SectionSourceInterface
+class Communication implements SectionSourceInterface
 {
     /**
      * @var Tracking

--- a/Omikron/Factfinder/etc/frontend/di.xml
+++ b/Omikron/Factfinder/etc/frontend/di.xml
@@ -18,7 +18,7 @@
     <type name="Magento\Customer\CustomerData\SectionPoolInterface">
         <arguments>
             <argument name="sectionSourceMap" xsi:type="array">
-                <item name="ffcommunication" xsi:type="string">Omikron\Factfinder\CustomerData\FF\Comumnication</item>
+                <item name="ffcommunication" xsi:type="string">Omikron\Factfinder\CustomerData\FF\Communication</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Small typo in one of the last PRs.