### PR TITLE
fix getter for manufacturer

### DIFF
--- a/Omikron/Factfinder/Helper/Product.php
+++ b/Omikron/Factfinder/Helper/Product.php
@@ -291,7 +291,9 @@ class Product extends AbstractHelper
      */
     private function getManufacturer($product, $store)
     {
-        return $product->getData($this->scopeConfig->getValue(self::PATH_DATA_TRANSFER_MANUFACTURER, 'store', $store->getId()));
+        $attr = $this->eavConfig->getAttribute('catalog_product', 'manufacturer');
+        $optionId = $product->getData($this->scopeConfig->getValue(self::PATH_DATA_TRANSFER_MANUFACTURER, 'store', $store->getId()));
+        return \html_entity_decode($attr->getSource()->getOptionText($optionId));
     }
 
     /**


### PR DESCRIPTION
Currently the `Omikron\Factfinder\Helper\Product::getManufacturer` function only returns an option _ID_ and not the actual value of the manufacturer. Thus the manufacturer does not actually get exported to FACT Finder.

The `html_entity_decode` is necessary because `$attr->getSource()->getOptionText()` returns the value with encoded HTML entities - which isn't suitable for the FACT Finder export.