### PR TITLE
REWORKED/FFWEB-904: FF\Communication block disables FPC cache for a whole site

### DIFF
--- a/Omikron/Factfinder/CustomerData/FF/Communication.php
+++ b/Omikron/Factfinder/CustomerData/FF/Communication.php
@@ -2,7 +2,6 @@
 namespace Omikron\Factfinder\CustomerData\FF;
 
 use Magento\Customer\CustomerData\SectionSourceInterface;
-use Omikron\Factfinder\Block\FF\Communication as CommunicationBlock;
 use Omikron\Factfinder\Helper\Data as FactfinderHelper;
 use Omikron\Factfinder\Helper\Tracking;
 
@@ -22,25 +21,17 @@ class Communication implements SectionSourceInterface
     protected $factfinderHelper;
 
     /**
-     * @var CommunicationBlock
-     */
-    protected $communicationBlock;
-
-    /**
      * Comunication constructor.
      * @param FactfinderHelper $factfinderHelper
      * @param Tracking $tracking
-     * @param CommunicationBlock $communicationBlock
      */
     public function __construct(
         FactfinderHelper $factfinderHelper,
-        Tracking $tracking,
-        CommunicationBlock $communicationBlock
+        Tracking $tracking
     )
     {
         $this->factfinderHelper = $factfinderHelper;
-        $this->tracking = $tracking;
-        $this->communicationBlock = $communicationBlock;
+        $this->tracking         = $tracking;
     }
 
     /**
@@ -50,6 +41,13 @@ class Communication implements SectionSourceInterface
      */
     public function getSectionData()
     {
-        return ['component' => $this->communicationBlock->getWebComponent()];
+        return
+            [
+                'attributes' =>
+                    [
+                        'uid' => $this->tracking->getUserId(),
+                        'sid' => $this->factfinderHelper->getCorrectSessionId($this->tracking->getSessionId())
+                    ]
+            ];
     }
 }

--- a/Omikron/Factfinder/etc/frontend/sections.xml
+++ b/Omikron/Factfinder/etc/frontend/sections.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Customer:etc/sections.xsd">
-    <action name="*">
+    <action name="customer/account/logout"/>
+    <action name="customer/account/loginPost"/>
+    <action name="customer/account/createPost"/>
+    <action name="customer/ajax/login">
         <section name="ffcommunication"/>
     </action>
 </config>

--- a/Omikron/Factfinder/view/frontend/templates/ff/communication.phtml
+++ b/Omikron/Factfinder/view/frontend/templates/ff/communication.phtml
@@ -1,6 +1,14 @@
 <?php
-/** @var \Omikron\Factfinder\Block\FF\Communication $block */
-?>
+/** @var $this \Omikron\Factfinder\Block\FF\Communication */
+echo $this->getWebComponent(); ?>
+<!-- Set FieldRoles -->
+<script>
+    document.addEventListener("ffReady", function () {
+        factfinder.communication.fieldRoles =
+        <?php echo $this->getFieldRoles(); ?>
+        ;
+    });
+</script>
 <div data-bind="scope: 'ffcommunication'">
     <script type="text/x-magento-init">
             {
@@ -8,10 +16,7 @@
                     "Magento_Ui/js/core/app": {
                         "components": {
                             "ffcommunication": {
-                                "component": "Omikron_Factfinder/js/view/ffcommunication",
-                                 "config": {
-                                    "fieldRoles": <?= /* @escapeNotVerified */ $block->getFieldRoles() ?>
-                                }
+                                "component": "Omikron_Factfinder/js/view/ffcommunication"
                             }
                         }
                     }

--- a/Omikron/Factfinder/view/frontend/web/js/view/ffcommunication.js
+++ b/Omikron/Factfinder/view/frontend/web/js/view/ffcommunication.js
@@ -9,22 +9,15 @@ define([
         /** @inheritdoc */
         initialize: function () {
             this._super();
-            let getRoles = this.getFieldRoles.bind(this);
-
             customerData.reload(['ffcommunication']).done(function (result) {
-                $('body').prepend(result.ffcommunication.component);
-            });
+                let uid = result.ffcommunication.attributes.uid,
+                    sid = result.ffcommunication.attributes.sid;
 
-            document.addEventListener("ffReady", function () {
-                factfinder.communication.fieldRoles = getRoles();
+                $('ff-communication').attr('sid', sid);
+                if (uid !== null) {
+                    $('ff-communication').attr('uid', uid);
+                }
             });
-        },
-
-        /**
-         * @return JSON
-         */
-        getFieldRoles: function () {
-            return this.fieldRoles;
         },
     });
 });


### PR DESCRIPTION
- Solves issue: 
#46 
- Description: 
 download only attributes sid and uid via ajax instead of whole component
- Tested with Magento editions/versions: 
2.2.2+
- Tested with PHP versions: 
5.6,7.1
