### PR TITLE
BUGFIX/FFWEB-920 add missing ampersand character

### DIFF
--- a/Omikron/Factfinder/Helper/Tracking.php
+++ b/Omikron/Factfinder/Helper/Tracking.php
@@ -123,7 +123,7 @@ class Tracking extends AbstractHelper
         }
 
         // concatenate get parameters of ordered articles
-        $params .= implode("&", $paramsCollection);
+        $params .= '&' .implode("&", $paramsCollection);
 
         // track checkout event
         $this->_communication->sendToFF(self::API_NAME, $params);


### PR DESCRIPTION
- Solves issue: 
Tracking won't work on checkout as there is an ampersand character missing between parameters channel and sid
- Tested with Magento editions/versions: 
2.2.2+
- Tested with PHP versions: 
5.6, 7.1