### PR TITLE
make function protected instead of private

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jaroslawweselski @abognetti
+* @a-laurowski @abognetti

--- a/Omikron/Factfinder/Controller/Export/Export.php
+++ b/Omikron/Factfinder/Controller/Export/Export.php
@@ -63,7 +63,7 @@ class Export extends \Magento\Framework\App\Action\Action
     /**
      * Generate downloadable CSV file
      */
-    private function generateCsvFile()
+    protected function generateCsvFile()
     {
         $data = $this->_productModel->exportProductWithExternalUrl($this->_storeManager->getStore());
 

--- a/Omikron/Factfinder/Helper/Communication.php
+++ b/Omikron/Factfinder/Helper/Communication.php
@@ -80,7 +80,7 @@ class Communication extends AbstractHelper
      * @param \Magento\Store\Api\Data\StoreInterface $store
      * @return array
      */
-    private function checkConnection($store)
+    protected function checkConnection($store)
     {
         $result = [];
         $result['success'] = true;

--- a/Omikron/Factfinder/Helper/Data.php
+++ b/Omikron/Factfinder/Helper/Data.php
@@ -375,7 +375,7 @@ class Data extends AbstractHelper
      * Returns the FACT-Finder password
      * @return mixed
      */
-    private function getPassword()
+    protected function getPassword()
     {
         return $this->scopeConfig->getValue(self::PATH_PASSWORD, 'store');
     }
@@ -384,7 +384,7 @@ class Data extends AbstractHelper
      * Returns the authentication prefix
      * @return mixed
      */
-    private function getAuthenticationPrefix()
+    protected function getAuthenticationPrefix()
     {
         return $this->scopeConfig->getValue(self::PATH_AUTH_PREFIX, 'store');
     }
@@ -393,7 +393,7 @@ class Data extends AbstractHelper
      * Returns the authentication postfix
      * @return mixed
      */
-    private function getAuthenticationPostfix()
+    protected function getAuthenticationPostfix()
     {
         return $this->scopeConfig->getValue(self::PATH_AUTH_POSTFIX, 'store');
     }

--- a/Omikron/Factfinder/Helper/Product.php
+++ b/Omikron/Factfinder/Helper/Product.php
@@ -105,7 +105,7 @@ class Product extends AbstractHelper
      * @param \Magento\Catalog\Model\Product $product
      * @return mixed
      */
-    private function getProductNumber($product)
+    protected function getProductNumber($product)
     {
         return $product->getData('sku');
     }
@@ -116,7 +116,7 @@ class Product extends AbstractHelper
      * @param integer $id
      * @return false|integer
      */
-    private function getProductParentIdByProductId($id)
+    protected function getProductParentIdByProductId($id)
     {
         $parentByChild = $this->catalogProductTypeConfigurable->getParentIdsByChild($id);
         $parentId = false;
@@ -132,7 +132,7 @@ class Product extends AbstractHelper
      * @param \Magento\Catalog\Model\Product $product
      * @return mixed
      */
-    private function getMasterProductNumber($product)
+    protected function getMasterProductNumber($product)
     {
         if ($parentId = $this->getProductParentIdByProductId($product->getId())) {
             $parentProduct = $this->productRepository->getById($parentId);
@@ -148,7 +148,7 @@ class Product extends AbstractHelper
      * @param \Magento\Catalog\Model\Product $product
      * @return mixed
      */
-    private function getName($product)
+    protected function getName($product)
     {
         return $product->getData('name');
     }
@@ -159,7 +159,7 @@ class Product extends AbstractHelper
      * @param \Magento\Catalog\Model\Product $product
      * @return string
      */
-    private function getDescription($product)
+    protected function getDescription($product)
     {
         return $this->cleanValue($product->getData('description'));
     }
@@ -170,7 +170,7 @@ class Product extends AbstractHelper
      * @param \Magento\Catalog\Model\Product $product
      * @return string
      */
-    private function getShort($product)
+    protected function getShort($product)
     {
         return $this->cleanValue($product->getData('short_description'));
     }
@@ -181,7 +181,7 @@ class Product extends AbstractHelper
      * @param \Magento\Catalog\Model\Product $product
      * @return mixed
      */
-    private function getProductUrl($product)
+    protected function getProductUrl($product)
     {
         return $product->getUrlInStore();
     }
@@ -192,7 +192,7 @@ class Product extends AbstractHelper
      * @param \Magento\Catalog\Model\ResourceModel\Product $product
      * @return string
      */
-    private function getImageUrl($product, $store)
+    protected function getImageUrl($product, $store)
     {
 
         $imageId = 'product_thumbnail_image';
@@ -214,7 +214,7 @@ class Product extends AbstractHelper
      * @param \Magento\Catalog\Model\Product $product
      * @return string
      */
-    private function getPrice($product)
+    protected function getPrice($product)
     {
         return number_format(round(floatval($product->getData('price')), 2), 2);
     }
@@ -225,7 +225,7 @@ class Product extends AbstractHelper
      * @param $product
      * @return string
      */
-    private function getCategoryPath($product)
+    protected function getCategoryPath($product)
     {
         $categoryIds = $product->getCategoryIds();
         $path = [];
@@ -250,7 +250,7 @@ class Product extends AbstractHelper
      * @param \Magento\Catalog\Api\Data\CategoryInterface $category
      * @return string
      */
-    private function getCategoryPathByCategory($category) {
+    protected function getCategoryPathByCategory($category) {
         if (in_array($category->getParentId(), [Category::ROOT_CATEGORY_ID, Category::TREE_ROOT_ID])) {
             return '';
         }
@@ -266,7 +266,7 @@ class Product extends AbstractHelper
      * @param \Magento\Catalog\Model\Product $product
      * @return int
      */
-    private function getAvailability($product)
+    protected function getAvailability($product)
     {
         return (int)$product->isAvailable();
     }
@@ -277,7 +277,7 @@ class Product extends AbstractHelper
      * @param \Magento\Catalog\Model\Product $product
      * @return int
      */
-    private function getMagentoEntityId($product)
+    protected function getMagentoEntityId($product)
     {
         return $product->getId();
     }
@@ -289,7 +289,7 @@ class Product extends AbstractHelper
      * @param \Magento\Store\Api\Data\StoreInterface $store
      * @return mixed
      */
-    private function getManufacturer($product, $store)
+    protected function getManufacturer($product, $store)
     {
         return $product->getData($this->scopeConfig->getValue(self::PATH_DATA_TRANSFER_MANUFACTURER, 'store', $store->getId()));
     }
@@ -301,7 +301,7 @@ class Product extends AbstractHelper
      * @param \Magento\Store\Api\Data\StoreInterface $store
      * @return mixed
      */
-    private function getEAN($product, $store)
+    protected function getEAN($product, $store)
     {
         return $product->getData($this->scopeConfig->getValue(self::PATH_DATA_TRANSFER_EAN, 'store', $store->getId()));
     }
@@ -313,7 +313,7 @@ class Product extends AbstractHelper
      * @param \Magento\Store\Api\Data\StoreInterface $store
      * @return mixed
      */
-    private function getAdditionalAttributes($store)
+    protected function getAdditionalAttributes($store)
     {
         return $this->scopeConfig->getValue(self::PATH_DATA_TRANSFER_ADDITIONAL_ATTRIBUTES, 'store', $store->getId());
     }
@@ -325,7 +325,7 @@ class Product extends AbstractHelper
      * @param \Magento\Store\Api\Data\StoreInterface $store
      * @return string
      */
-    private function getAttributes($product, $store)
+    protected function getAttributes($product, $store)
     {
         $data = [];
         $attributesString = '';
@@ -385,7 +385,7 @@ class Product extends AbstractHelper
      *
      * @return string
      */
-    private function cleanValue($value, $isMultiAttributeValue = false)
+    protected function cleanValue($value, $isMultiAttributeValue = false)
     {
         $value = strip_tags(nl2br($value));
         $value = preg_replace("/\r|\n/", "", $value);

--- a/Omikron/Factfinder/Helper/Upload.php
+++ b/Omikron/Factfinder/Helper/Upload.php
@@ -44,7 +44,7 @@ class Upload extends AbstractHelper
      * @param $key
      * @return mixed
      */
-    private function getConfig($key)
+    protected function getConfig($key)
     {
         return $this->scopeConfig->getValue(self::CONFIG_PATH . $key, 'store');
     }

--- a/Omikron/Factfinder/Model/Export/Product.php
+++ b/Omikron/Factfinder/Model/Export/Product.php
@@ -118,7 +118,7 @@ class Product extends AbstractModel
      * @param \Magento\Store\Api\Data\StoreInterface $store
      * @return \Magento\Catalog\Model\ResourceModel\Product\Collection
      */
-    private function getProducts($store)
+    protected function getProducts($store)
     {
         $collection = $this->productCollectionFactory->create();
         $collection->addAttributeToSelect('*');
@@ -136,7 +136,7 @@ class Product extends AbstractModel
      *
      * @return array
      */
-    private function buildFeedRow($product, $store)
+    protected function buildFeedRow($product, $store)
     {
         $row = [];
         $attributes = [
@@ -169,7 +169,7 @@ class Product extends AbstractModel
      *
      * @return array
      */
-    private function writeLine(array $fields)
+    protected function writeLine(array $fields)
     {
         $output = [];
         foreach ($fields as $field) {
@@ -268,7 +268,7 @@ class Product extends AbstractModel
      * @param \Magento\Store\Api\Data\StoreInterface $store
      * @return array
      */
-    private function buildFeed($store)
+    protected function buildFeed($store)
     {
         $output = '';
         $addHeaderCols = true;
@@ -303,7 +303,7 @@ class Product extends AbstractModel
      * @param string $output
      * @return array
      */
-    private function writeFeedToFile($filename, &$output)
+    protected function writeFeedToFile($filename, &$output)
     {
         $result = [];
 
@@ -334,7 +334,7 @@ class Product extends AbstractModel
      * @param $filename
      * @return bool
      */
-    private function deleteFeedFile($filename)
+    protected function deleteFeedFile($filename)
     {
 
         $filePath = self::FEED_PATH . $filename;
@@ -351,7 +351,7 @@ class Product extends AbstractModel
      * @param string $filename
      * @return array
      */
-    private function uploadFeed($filename)
+    protected function uploadFeed($filename)
     {
         $result = [];
 


### PR DESCRIPTION
A lot of functions in a lot of classes are currently defined as `private` instead of `protected`. This makes it impossible to extend these classes and only replace certain methods, instead of the whole class when using
```xml
<preference for="Omikron\Factfinder\…" type="Vendor\Module\…" />
```
in your own module's `di.xml`.

Unless there is a specific reason to make a method `private`, the methods should be `protected` by default.