### PR TITLE
FFWEB-915 : Use catalog rule prices when exporting product prices

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# [Unreleased]
+# ADD
+-  Added possibility to export prices for specific customer groups. If multiple groups are selected, prices are exported in a multi attribute format like |0=109.99|1=99.99|2=95.99| where 0,1,2 are the identifiers of selected customer groups
 # v0.9-beta.10
 ## ADD
 - Added possibility to enable FACT-Finder server responses logging

--- a/Omikron/Factfinder/Helper/Product/PriceProvider.php
+++ b/Omikron/Factfinder/Helper/Product/PriceProvider.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Helper\Product;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Pricing\Price\RegularPrice;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\ConfigurableProduct\Pricing\Price\LowestPriceOptionsProvider;
+use Magento\CatalogRule\Model\Rule;
+
+class PriceProvider
+{
+   /** @var LowestPriceOptionsProvider  */
+    protected $lowestPriceOptionsProvider;
+
+   /** @var Rule  */
+    protected $ruleModel;
+
+    public function __construct(LowestPriceOptionsProvider $lowestPriceOptionsProvider, Rule $ruleModel)
+    {
+        $this->lowestPriceOptionsProvider = $lowestPriceOptionsProvider;
+        $this->ruleModel                  = $ruleModel;
+    }
+
+    /**
+     * @param  ProductInterface $product
+     * @param  array            $customerGroups
+     * @return array
+     */
+    public function collectPricesForProduct(ProductInterface $product, array $customerGroups) : array
+    {
+        $prices = [];
+        foreach ($customerGroups as $group) {
+            if ($product->getTypeId() == Configurable::TYPE_CODE) {
+                foreach ($this->lowestPriceOptionsProvider->getProducts($product) as $simple) {
+                    $prices [$group] = $this->calculateLowestPriceForProduct($simple, $group);
+                }
+            } else {
+                $prices [$group] = $this->calculateLowestPriceForProduct($product, $group);
+            }
+        }
+
+        return $prices;
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param int              $customerGroup
+     * @return string
+     */
+    protected function calculateLowestPriceForProduct(ProductInterface $product, int $customerGroup) : string
+    {
+        $product->setCustomerGroupId($customerGroup);
+        $regularPrice     = $product->getPriceInfo()->getPrice(RegularPrice::PRICE_CODE)->getValue();
+        $catalogRulePrice = $this->ruleModel->calcProductPriceRule($product, $regularPrice);
+
+        return $catalogRulePrice > 0.00 ? $this->formatPrice($catalogRulePrice) : $this->formatPrice($regularPrice);
+    }
+
+    /**
+     * @param float $price
+     * @return string
+     */
+    protected function formatPrice(float $price) : string
+    {
+        return number_format(round(floatval($price), 2), 2);
+    }
+}

--- a/Omikron/Factfinder/Model/Source/CustomerGroup.php
+++ b/Omikron/Factfinder/Model/Source/CustomerGroup.php
@@ -1,0 +1,52 @@
+<?php
+namespace Omikron\Factfinder\Model\Source;
+
+use Magento\Customer\Api\GroupRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Data\OptionSourceInterface;
+
+/**
+ * Class CustomerGroup
+ */
+class CustomerGroup implements OptionSourceInterface
+{
+    /**
+     * @var GroupRepositoryInterface
+     */
+    protected $customerGroupRepository;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    protected $searchCriteriaBuilder;
+
+    /**
+     * CustomerGroup constructor.
+     *
+     * @param GroupRepositoryInterface $groupRepository
+     * @param SearchCriteriaBuilder    $criteriaBuilder
+     */
+    public function __construct(GroupRepositoryInterface $groupRepository, SearchCriteriaBuilder $criteriaBuilder)
+    {
+        $this->customerGroupRepository = $groupRepository;
+        $this->searchCriteriaBuilder = $criteriaBuilder;
+    }
+
+    /**
+     * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function toOptionArray()
+    {
+        $customerGroups = [];
+        $groups         = $this->customerGroupRepository->getList($this->searchCriteriaBuilder->create());
+        foreach ($groups->getItems() as $group) {
+            $customerGroups[] = [
+                'label' => $group->getCode(),
+                'value' => $group->getId(),
+            ];
+        }
+
+        return $customerGroups;
+    }
+}

--- a/Omikron/Factfinder/Test/Unit/Helper/Product/PriceProviderTest.php
+++ b/Omikron/Factfinder/Test/Unit/Helper/Product/PriceProviderTest.php
@@ -1,0 +1,124 @@
+<?php
+// @codingStandardsIgnoreFile
+
+namespace Omikron\Factfinder\Test\Unit\Helper\Product;
+
+use Magento\Catalog\Model\Product;
+use Magento\ConfigurableProduct\Pricing\Price\LowestPriceOptionsProvider;
+use Magento\CatalogRule\Model\Rule;
+use Magento\Framework\Pricing\PriceInfo\Base;
+use Magento\Framework\Pricing\Price\PriceInterface;
+use Omikron\Factfinder\Helper\Product\PriceProvider;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+
+class PriceProviderTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var LowestPriceOptionsProvider | \PHPUnit_Framework_MockObject_MockObject */
+    protected $lowestPriceOptionsProviderMock;
+
+    /** @var Rule | \PHPUnit_Framework_MockObject_MockObject */
+    protected $ruleModelMock;
+
+    /** @var Product | \PHPUnit_Framework_MockObject_MockObject */
+    protected $productMock;
+
+    /** @var PriceProvider */
+    protected $priceProvider;
+
+    public function testCalculatePriceFromConfigurableProductNoCatalogRules()
+    {
+        $lowestPriceProduct = [$this->createProductMock('simple', 20)];
+        $this->lowestPriceOptionsProviderMock->method('getProducts')->willReturn($lowestPriceProduct);
+        $configurableProductMock =  $this->createProductMock('configurable', 0);
+
+        $prices = $this->priceProvider->collectPricesForProduct($configurableProductMock, [1, 2, 3]);
+
+        $this->assertSame([1 => '20.00', 2 => '20.00', 3 => '20.00'], $prices, 'Prices should be equal to 20 as the lower price option ');
+    }
+
+    public function testCalculatePriceFromConfigurableProductCatalogRulesApplied()
+    {
+        $productMocks [] = $this->createProductMock('simple', 20);
+        $this->ruleModelMock->method('calcProductPriceRule')->willReturnOnConsecutiveCalls(15.00, 12.00, 12.00);
+        $this->lowestPriceOptionsProviderMock->method('getProducts')->willReturn($productMocks);
+        $productMocks = $this->createProductMock('configurable', 0);
+        $prices = $this->priceProvider->collectPricesForProduct($productMocks, [1, 2, 3]);
+
+        $this->assertSame([1 => '15.00', 2 => '12.00', 3 => '12.00'], $prices, 'Returned product prices should be equal to calculated product price rule');
+    }
+
+    public function testGetPriceFromSimpleProductNoCatalogRules ()
+    {
+        $this->lowestPriceOptionsProviderMock->expects($this->never())->method('getProducts');
+        $productMock = $this->createProductMock('simple', 55);
+        $prices = $this->priceProvider->collectPricesForProduct($productMock, [1, 2, 3]);
+        $this->ruleModelMock->expects($this->never())->method('calcProductPriceRule');
+
+        $this->assertSame([1 => '55.00', 2 => '55.00', 3 => '55.00'], $prices, 'Returned product prices should be equal to calculated product price rule');
+    }
+
+    public function testGetPriceFromSimpleProductCatalogRulesApplied()
+    {
+        $this->lowestPriceOptionsProviderMock->expects($this->never())->method('getProducts');
+        $this->ruleModelMock->method('calcProductPriceRule')->willReturnOnConsecutiveCalls(45.00, 45.00, 40.00);
+        $productMock = $this->createProductMock('simple', 55);
+        $prices = $this->priceProvider->collectPricesForProduct($productMock, [1, 2, 3]);
+
+        $this->assertSame([1 => '45.00', 2 => '45.00', 3 => '40.00'], $prices);
+    }
+
+    public function testCorrectNumberOfPricesAreFetched()
+    {
+        $productMocks [] = $this->createProductMock('simple', 20);
+        $this->ruleModelMock->method('calcProductPriceRule')->willReturnOnConsecutiveCalls(1, 2, 3, 4, 5, 6);
+        $this->lowestPriceOptionsProviderMock->method('getProducts')->willReturn($productMocks);
+        $this->ruleModelMock->expects($this->exactly(3))->method('calcProductPriceRule');
+        $productMock = $this->createProductMock('simple', 0);
+        $prices = $this->priceProvider->collectPricesForProduct($productMock, [1, 2, 3]);
+
+        $this->assertEquals(3, count($prices));
+    }
+
+    public function testRegularPriceIsTakenWhenCatalogRulePriceIsZero()
+    {
+        $this->lowestPriceOptionsProviderMock->expects($this->never())->method('getProducts');
+        $this->ruleModelMock->method('calcProductPriceRule')->willReturnOnConsecutiveCalls(0.00, 0.00, 20.00);
+        $productMock = $this->createProductMock('simple', 35);
+        $prices = $this->priceProvider->collectPricesForProduct($productMock, [1, 2, 3]);
+
+        $this->assertSame([1 => '35.00', 2 => '35.00', 3 => '20.00'], $prices, '0.00 prices should not be taken into account');
+    }
+
+    /**
+     * @param string $typeId
+     * @param float  $price
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createProductMock($typeId, $price)
+    {
+        $productMock   = $this->createMock(Product::class);
+        $priceInfoMock = $this->createMock(Base::class);
+        $priceMock     = $this->createMock(PriceInterface::class);
+        $priceMock->method('getValue')->willReturn($price);
+        $productMock->method('getTypeId')->willReturn($typeId);
+        $priceInfoMock->method('getPrice')->willReturn($priceMock);
+        $productMock->method('getPriceInfo')->willReturn($priceInfoMock);
+
+        return $productMock;
+    }
+
+    protected function setUp()
+    {
+        $this->lowestPriceOptionsProviderMock = $this->createMock(LowestPriceOptionsProvider::class);
+        $this->ruleModelMock                  = $this->createMock(Rule::class);
+        $this->priceProvider                  = (new ObjectManager($this))
+            ->getObject(
+                \Omikron\Factfinder\Helper\Product\PriceProvider::class,
+                [
+                    'lowestPriceOptionsProvider' => $this->lowestPriceOptionsProviderMock,
+                    'ruleModel'                  => $this->ruleModelMock,
+                ]
+            );
+    }
+}

--- a/Omikron/Factfinder/etc/adminhtml/system.xml
+++ b/Omikron/Factfinder/etc/adminhtml/system.xml
@@ -255,6 +255,13 @@
                 </field>
                 <field id="ff_push_import_enabled" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Automatic Import of product data</label>
+                <field id="ff_price_customer_group" translate="label comment" type="multiselect" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Select Customer groups for price export</label>
+                    <comment>Diffrent prices for selected customer groups will be exported. In order to have specific prices displayed for proper customer groups You need also to have MultiPricesSearchCallback defined at Fact Finder</comment>
+                    <source_model>Omikron\Factfinder\Model\Source\CustomerGroup</source_model>
+                </field>
+                <field id="ff_cron_import" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Automatic Import of productdata</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Runs an automatic import of the product data to the FACT-Finder servers, after the FTP upload is finished.</comment>
                 </field>

--- a/Omikron/Factfinder/etc/config.xml
+++ b/Omikron/Factfinder/etc/config.xml
@@ -56,6 +56,7 @@
                 <ff_push_import_type>suggest</ff_push_import_type>
                 <ff_product_visibility>3,4</ff_product_visibility>
                 <ff_additional_attributes_separate_columns>0</ff_additional_attributes_separate_columns>
+                <ff_price_customer_group>0</ff_price_customer_group>
             </data_transfer>
             <basic_auth_data_transfer>
                 <ff_upload_url_password backend_model="Magento\Config\Model\Config\Backend\Encrypted" />


### PR DESCRIPTION
Description: 
*  Price is now export now respecting active catalog rules which can be applied to product.  By default catalog rules are calculated for non logged group but customer can choose more of them. If so, prices are exported in a multi-attribute format

- Tested with Magento editions/versions: 
2.2.2+
- Tested with PHP versions: 
7.1
