### PR TITLE
FFWEB-936 : Export correct configurable product price

### DIFF
--- a/Omikron/Factfinder/Helper/Product.php
+++ b/Omikron/Factfinder/Helper/Product.php
@@ -216,7 +216,7 @@ class Product extends AbstractHelper
      */
     private function getPrice($product)
     {
-        return number_format(round(floatval($product->getData('price')), 2), 2);
+        return number_format(round(floatval($product->getFinalPrice()), 2), 2);
     }
 
     /**


### PR DESCRIPTION
Magento2 doesn't requires user to store configurable product price as configurable product is in fact a virtual entity. Prices are stored in simple product. Getting configurable product is now fixed and now it's a lowest simple product price  (respecting the Magento2 pricing mechanism)

- Tested with Magento editions/versions: 
2.2.2+
- Tested with PHP versions: 
7.1