### PR TITLE
set store ID on product

### DIFF
--- a/Omikron/Factfinder/Model/Export/Product.php
+++ b/Omikron/Factfinder/Model/Export/Product.php
@@ -296,6 +296,7 @@ class Product extends AbstractModel
 
             /** @var \Magento\Catalog\Model\Product $product */
             foreach ($products as $product) {
+                $product->setStoreId($store->getId());
                 $rowData = $this->buildFeedRow($product, $store);
 
                 if ($addHeaderCols) {


### PR DESCRIPTION
- Solves issue: Product URL and product image URL currently contain the domain of the default store, rather than the one from the actually processed store
- Description: By setting the store ID on the product object, the correct URL for the product URL and product image URL will be returned.
- Tested with Magento editions/versions: 2.2.6
- Tested with PHP versions: 7.1.13