### PR TITLE
fix product urls

### DIFF
--- a/Omikron/Factfinder/Helper/Product.php
+++ b/Omikron/Factfinder/Helper/Product.php
@@ -50,7 +50,7 @@ class Product extends AbstractHelper
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
-        \Magento\Catalog\Helper\Image $imageHelperFactory,
+        \Magento\Catalog\Helper\ImageFactory $imageHelperFactory,
         \Magento\Eav\Model\Config $eavConfig,
         \Magento\Catalog\Model\ProductRepository $productRepository,
         \Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable $catalogProductTypeConfigurable,
@@ -220,10 +220,9 @@ class Product extends AbstractHelper
      */
     protected function getImageUrl($product, $store)
     {
-
         $imageId = 'product_thumbnail_image';
         /**@var \Magento\Catalog\Helper\Image $image */
-        $image = $this->imageHelperFactory->init($product, $imageId, ['type' => 'thumbnail'])
+        $image = $this->imageHelperFactory->create()->init($product, $imageId, ['type' => 'thumbnail'])
             ->constrainOnly(true)
             ->keepAspectRatio(true)
             ->keepTransparency(true)
@@ -231,7 +230,6 @@ class Product extends AbstractHelper
             ->resize(200, 200);
 
         return $image->getUrl();
-
     }
 
     /**

--- a/Omikron/Factfinder/Model/Export/Product.php
+++ b/Omikron/Factfinder/Model/Export/Product.php
@@ -52,6 +52,9 @@ class Product extends AbstractModel
     /** @var \Magento\Framework\App\Filesystem\DirectoryList */
     protected $directoryList;
 
+    /** @var  \Magento\Store\Model\App\Emulation */
+    protected $appEmulation;
+
     /**
      * Product constructor.
      * @param \Magento\Framework\Model\Context $context
@@ -66,9 +69,10 @@ class Product extends AbstractModel
      * @param \Omikron\Factfinder\Helper\Data $helperData
      * @param \Omikron\Factfinder\Helper\Communication $helperCommunication
      * @param \Omikron\Factfinder\Helper\Product $helperProduct
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager,
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Framework\File\Csv $csvWriter
      * @param \Magento\Framework\App\Filesystem\DirectoryList $directoryList
+     * @param \Magento\Store\Model\App\Emulation $appEmulation
      * @param array $data
      */
     public function __construct(
@@ -87,6 +91,7 @@ class Product extends AbstractModel
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Framework\File\Csv $csvWriter,
         \Magento\Framework\App\Filesystem\DirectoryList $directoryList,
+        \Magento\Store\Model\App\Emulation $appEmulation,
         array $data = []
     )
     {
@@ -102,6 +107,7 @@ class Product extends AbstractModel
         $this->storeManager = $storeManager;
         $this->csvWriter = $csvWriter;
         $this->directoryList = $directoryList;
+        $this->appEmulation = $appEmulation;
 
         parent::__construct(
             $context,
@@ -286,6 +292,8 @@ class Product extends AbstractModel
      */
     protected function buildFeed($store)
     {
+        $this->appEmulation->startEnvironmentEmulation($store->getId(), \Magento\Framework\App\Area::AREA_FRONTEND, true);
+
         $output        = [];
         $addHeaderCols = true;
         $productCount  = $this->getFilteredProductCollection($store)->getSize();
@@ -296,7 +304,6 @@ class Product extends AbstractModel
 
             /** @var \Magento\Catalog\Model\Product $product */
             foreach ($products as $product) {
-                $product->setStoreId($store->getId());
                 $rowData = $this->buildFeedRow($product, $store);
 
                 if ($addHeaderCols) {
@@ -309,6 +316,8 @@ class Product extends AbstractModel
 
             $currentOffset += $products->count();
         }
+
+        $this->appEmulation->stopEnvironmentEmulation();
 
         return $output;
     }


### PR DESCRIPTION
This PR reverts #67 and instead uses an approach with `\Magento\Store\Model\App\Emulation`. In the back end - or via the CLI - there is no other way of generating the product image URLs with the store's correct domain. You have to emulate a front end context with the respective store ID. This also automatically generates the correct product URL without having to set the store ID to the product.