### PR TITLE
add disable-single-hit-redirect to configuration

### DIFF
--- a/Omikron/Factfinder/Block/FF/Communication.php
+++ b/Omikron/Factfinder/Block/FF/Communication.php
@@ -173,7 +173,12 @@ class Communication extends Template
                 'value' => $this->_helper->getSearchImmediate(),
                 'type' => 'boolean',
                 'defaultValue' => $defaultValues['advanced']['search_immediate']
-            ]
+            ],
+            'disable-single-hit-redirect'=> [
+                'value' => $this->_helper->getDisableSingleHitRedirect(),
+                'type' => 'boolean',
+                'defaultValue' => $defaultValues['advanced']['disable_single_hit_redirect']
+            ],
         ];
 
         // always enable "search-immediate" when on result page

--- a/Omikron/Factfinder/Helper/Data.php
+++ b/Omikron/Factfinder/Helper/Data.php
@@ -189,6 +189,15 @@ class Data extends AbstractHelper
     }
 
     /**
+     * Returns the disable-single-hit-redirect configuration
+     * @return mixed
+     */
+    public function getDisableSingleHitRedirect()
+    {
+        return $this->scopeConfig->getValue('factfinder/advanced/disable_single_hit_redirect', 'store');
+    }
+
+    /**
      * Returns the use-url-parameter configuration
      * @return mixed
      */

--- a/Omikron/Factfinder/etc/adminhtml/system.xml
+++ b/Omikron/Factfinder/etc/adminhtml/system.xml
@@ -143,6 +143,11 @@
                     <label>seo-prefix</label>
                     <comment>The seo-prefix is used to show a piece of path between your domain the actual seo-path. E.g. domain.com/prefix/seoPath</comment>
                 </field>
+                <field id="disable_single_hit_redirect" translate="label" type="select" sortOrder="210" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>disable-single-hit-redirect</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>If true, disables the automatic redirect to the product detail page if only one record is found.</comment>
+                </field>
             </group>
             <group id="components" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Activated Web-Components</label>

--- a/Omikron/Factfinder/etc/config.xml
+++ b/Omikron/Factfinder/etc/config.xml
@@ -34,6 +34,7 @@
                 <use_browser_history>1</use_browser_history>
                 <use_seo>0</use_seo>
                 <seo_prefix></seo_prefix>
+                <disable_single_hit_redirect>0</disable_single_hit_redirect>
             </advanced>
             <components>
                 <ff_suggest>0</ff_suggest>


### PR DESCRIPTION
### Description

This PR adds the `disable-single-hit-redirect` `ff-communication` property to the configuration options within Magento.

### Tested with Magento editions/versions

2.2.6

### Tested with PHP versions

7.1.13

### Side note

Honestly I find this feature to be extremely irritating. It feels like an error occurred, if you do a search and suddenly you are on the detail page of some product instead of seeing the search result. There is no feedback that this is the only search result. Thus I feel like this option should not be enabled by default and renamed to `enable-single-hit-redirect` accodingly within FACT Finder.