### PR TITLE
check for 'error' in Import.ff response

### DIFF
--- a/Omikron/Factfinder/Helper/Communication.php
+++ b/Omikron/Factfinder/Helper/Communication.php
@@ -134,7 +134,7 @@ class Communication extends AbstractHelper
         $response_json = json_decode($this->sendToFF('Import.ff', ['channel' => $channelName, 'type' => 'suggest', 'format' => 'json' , 'quiet' => 'true', 'download' => 'true']), true);
 
         if (is_array($response_json)) {
-            if (isset($response_json['errors']) && is_array($response_json['errors']) && !empty($response_json['errors'])) {
+            if (isset($response_json['errors']) && !empty($response_json['errors'])) {
                 return false;
             }
             elseif (isset($response_json['error']) && !empty($response_json['error'])) {

--- a/Omikron/Factfinder/Helper/Communication.php
+++ b/Omikron/Factfinder/Helper/Communication.php
@@ -132,10 +132,16 @@ class Communication extends AbstractHelper
     public function pushImport($channelName)
     {
         $response_json = json_decode($this->sendToFF('Import.ff', ['channel' => $channelName, 'type' => 'suggest', 'format' => 'json' , 'quiet' => 'true', 'download' => 'true']), true);
-        if(is_array($response_json) && isset($response_json['errors']) && is_array($response_json['errors']) && count($response_json['errors'])) {
-            return false;
-        } else {
-            return true;
+
+        if (is_array($response_json)) {
+            if (isset($response_json['errors']) && is_array($response_json['errors']) && !empty($response_json['errors'])) {
+                return false;
+            }
+            elseif (isset($response_json['error']) && !empty($response_json['error'])) {
+                return false;
+            }
         }
+
+        return true;
     }
 }


### PR DESCRIPTION
### Description

The response from `Import.ff` might be the following:

```
{"error":"\u003cp\u003eIhnen fehlen die nötigen Rechte, um diese Seite zu bearbeiten. Bitte wenden Sie sich an Ihren Administrator.\u003c/p\u003e"}
```

This error would currently go unnoticed, because the `pushImport` function only checks for `errors` in the response, but not for a single `error`.

### Tested with Magento editions/versions: 

2.2.6

### Tested with PHP versions: 

7.1.13