### PR TITLE
Github Issue #79: CSS classes/styles too genera

### DIFF
--- a/Omikron/Factfinder/view/frontend/templates/ff/suggest.phtml
+++ b/Omikron/Factfinder/view/frontend/templates/ff/suggest.phtml
@@ -33,7 +33,7 @@
                     <a href="{{attributes.deeplink}}" data-redirect="{{attributes.deeplink}}" data-redirect-target="_blank">
                         <img data-image="{{{suggestions.image}}}">
                         <div class="product-center">
-                            <div class="product-name">{{{name}}}</div>
+                            <div class="ff-product-name">{{{name}}}</div>
                             <div>Shipping</div>
                             <div>Rating</div>
                         </div>

--- a/Omikron/Factfinder/view/frontend/web/css/ff/suggest.css
+++ b/Omikron/Factfinder/view/frontend/web/css/ff/suggest.css
@@ -1,4 +1,4 @@
-.ff-suggest {
+#ffSuggestContainerWrapper  {
     background-color: white;
     box-shadow: 1px 1px 10px lightgrey;
 }
@@ -31,7 +31,7 @@
     float: left;
 }
 
-.product-name {
+.ff-product-name {
     width: 300px;
     position: relative;
     text-overflow: ellipsis;


### PR DESCRIPTION
- Solves issue:
#79  
- Description: 
 Change `product-name`  CSS class to `ff-product-name` in order to differ from its origin Magento 2 class
- Tested with Magento editions/versions: 
2.2.6
- Tested with PHP versions: 
7.1