### PR TITLE
move factfinder.communication to after.body.start

### DIFF
--- a/Omikron/Factfinder/view/frontend/layout/default.xml
+++ b/Omikron/Factfinder/view/frontend/layout/default.xml
@@ -9,10 +9,7 @@
 
     <referenceContainer name="after.body.start">
         <block ifconfig="factfinder/general/is_enabled" name="prevent.fouc.css" template="Omikron_Factfinder::ff/styles.phtml"/>
-    </referenceContainer>
-
-    <referenceContainer name="header.panel">
-        <block ifconfig="factfinder/general/is_enabled" class="Omikron\Factfinder\Block\FF\Communication" name="factfinder.communication" template="Omikron_Factfinder::ff/communication.phtml"/>
+        <block ifconfig="factfinder/general/is_enabled" class="Omikron\Factfinder\Block\FF\Communication" name="factfinder.communication" before="-" template="Omikron_Factfinder::ff/communication.phtml"/>
     </referenceContainer>
 
     <!-- init BlockClassManager -->


### PR DESCRIPTION
The `header.panel` container might not be available in all themes, thus the important `<ff-communication>` block might not be inserted into the layout. The `after.body.start` position will always be present (as far as I know). There is no reason for the `<ff-communication>` element to be inside any actual DOM element. It should be one of the first elements on the page.