### PR TITLE
add missing page title

### DIFF
--- a/Omikron/Factfinder/view/frontend/layout/factfinder_result_index.xml
+++ b/Omikron/Factfinder/view/frontend/layout/factfinder_result_index.xml
@@ -1,5 +1,6 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
+        <title>Search Results</title>
         <remove src="Omikron_Factfinder::js/search-redirect.js" />
         <css src="Omikron_Factfinder::css/ff/shared-styles.css"/>
         <css src="Omikron_Factfinder::css/ff/template.css"/>


### PR DESCRIPTION
Currently the `factfinder/result/index` route has no page title what soever, resulting in the following `<head>` tag:
```html
<title></title>
```
And of course the page title element within the content will not be there too.