### PR TITLE
allow additional attributes to be direct export fields

### DIFF
--- a/Omikron/Factfinder/Helper/Data.php
+++ b/Omikron/Factfinder/Helper/Data.php
@@ -400,6 +400,18 @@ class Data extends AbstractHelper
     }
 
     /**
+     * Get configuration options telling if additional attributes should be merged and exported as single column or each attribute
+     * should be exported in separate column
+     *
+     * @param $store
+     * @return bool
+     */
+    protected function getAdditionalAttributesExportedInSeparateColumns($store)
+    {
+        return boolval($this->scopeConfig->getValue(self::PATH_DATA_TRANSFER_ATTRIBUTES_SEPARATE_COLUMNS, 'store', $store->getId()));
+    }
+
+    /**
      * Private Getter
      */
 

--- a/Omikron/Factfinder/Model/Export/Product.php
+++ b/Omikron/Factfinder/Model/Export/Product.php
@@ -14,10 +14,11 @@ use Magento\Store\Api\Data\StoreInterface;
  */
 class Product extends AbstractModel
 {
-    const FEED_PATH = 'factfinder/';
-    const FEED_FILE = 'export.';
-    const FEED_FILE_FILETYPE = 'csv';
-    const BATCH_SIZE = 3000;
+    const FEED_PATH                         = 'factfinder/';
+    const FEED_FILE                         = 'export.';
+    const FEED_FILE_FILETYPE                = 'csv';
+    const BATCH_SIZE                        = 3000;
+    const ADDITIONAL_ATTRIBUTES_COLUMN_NAME = 'Attributes';
 
     /** @var \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory */
     protected $productCollectionFactory;
@@ -169,9 +170,13 @@ class Product extends AbstractModel
             'MagentoEntityId'
         ];
 
-        $additionalAttributes = $this->getAdditionalAttributes($store);
-        if (!empty($additionalAttributes)) {
-            $attributes = \array_unique(\array_merge($attributes, explode(',', $additionalAttributes)));
+        if ($this->helperProduct->getAdditionalAttributesExportedInSeparateColumns($store)) {
+            $additionalAttributes = $this->helperProduct->getAdditionalAttributes($store);
+            if (!empty($additionalAttributes)) {
+                $attributes = \array_unique(\array_merge($attributes, explode(',', $additionalAttributes)));
+            }
+        } else {
+            $attributes[]= self::ADDITIONAL_ATTRIBUTES_COLUMN_NAME;
         }
 
         foreach ($attributes as $attribute) {
@@ -179,17 +184,6 @@ class Product extends AbstractModel
         }
 
         return $row;
-    }
-
-    /**
-     * Get the additional attribute fields for the store
-     *
-     * @param \Magento\Store\Api\Data\StoreInterface $store
-     * @return mixed
-     */
-    protected function getAdditionalAttributes($store)
-    {
-        return $this->scopeConfig->getValue(\Omikron\Factfinder\Helper\Product::PATH_DATA_TRANSFER_ADDITIONAL_ATTRIBUTES, 'store', $store->getId());
     }
 
     /**

--- a/Omikron/Factfinder/etc/adminhtml/system.xml
+++ b/Omikron/Factfinder/etc/adminhtml/system.xml
@@ -238,6 +238,11 @@
                     <source_model>Omikron\Factfinder\Model\Source\Attribute</source_model>
                     <comment>Select all attributes which should be exported to the product feed.</comment>
                 </field>
+                <field id="ff_additional_attributes_separate_columns" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Export additional attributes in separate columns</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>Set this option to 'Yes' If You want to have additional attributes exported in separate columns</comment>
+                </field>
                 <field id="ff_product_visibility" translate="label comment" type="multiselect" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Select Product Visibility</label>
                     <comment>Visibility attribute values used in filtering product collection.</comment>

--- a/Omikron/Factfinder/etc/config.xml
+++ b/Omikron/Factfinder/etc/config.xml
@@ -52,6 +52,7 @@
                 <ff_cron_enabled>0</ff_cron_enabled>
                 <ff_cron_import>1</ff_cron_import>
                 <ff_product_visibility>3,4</ff_product_visibility>
+                <ff_additional_attributes_separate_columns>0</ff_additional_attributes_separate_columns>
             </data_transfer>
         </factfinder>
     </default>


### PR DESCRIPTION
This is a PR for #56.

Instead of exporting any additionally selected attributes in the `Attributes` column like so:
```
…|Bundesland=Niedersterreich|Produktmerkmal=bio|Produktmerkmal=vegan|…
```
every selected attribute gets its own column. So
```
ProductNumber;…;MagentoEntityId;Attributes
```
becomes
```
ProductNumber;…;MagentoEntityId;isbn_number;label_product;product_federal_state
```
Additionally, this PR also changes the regular expression of `cleanValue` to allow _any_ letter (including Umlauts etc., see #54).

### Important Note

This will obviously fundamentally change the export file and thus will require a reconfiguration of the fields in the FACT Finder channel.