### PR TITLE
exclude web components JavaScript from minification

### DIFF
--- a/Omikron/Factfinder/Plugin/ExcludeFilesFromMinification.php
+++ b/Omikron/Factfinder/Plugin/ExcludeFilesFromMinification.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Omikron\Factfinder\Plugin;
+
+use Magento\Framework\View\Asset\Minification;
+
+/**
+ * Plugin to exclude web components JavaScript files from minification
+ *
+ * @package Omikron\Factfinder\Plugin
+ */
+class ExcludeFilesFromMinification
+{
+    public function afterGetExcludes(Minification $subject, array $result, $contentType)
+    {
+        if ($contentType == 'js') {
+            $result[] = 'Omikron_Factfinder/ff-web-components/dist/elements.build';
+        }
+        return $result;
+    }
+}

--- a/Omikron/Factfinder/etc/di.xml
+++ b/Omikron/Factfinder/etc/di.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\View\Asset\Minification">
+        <plugin name="omikron.factfinder.excludefilesfromminification" type="Omikron\Factfinder\Plugin\ExcludeFilesFromMinification" />
+    </type>
+</config>


### PR DESCRIPTION
If the configuration `dev/js/minify_files` is set to `1` then FACT Finder will not work in the front end in production mode. This is because during deployment Magento 2 will automatically minify the `elements.build.js` file and rename it to `elements.build.min.js`. However, [elements.build_with_dependencies.html](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/v0.9-beta.8/Omikron/Factfinder/view/frontend/web/ff-web-components/dist/elements.build_with_dependencies.html) includes this JavaScript file hard coded via
```html
<script src="elements.build.js" defer=""></script>
```
Thus it cannot be loaded under the previously mentioned circumstances, because that file will not exist anymore.
```
Loading failed for the <script> with source “https://example.org/static/version1545225976/frontend/Vendor/theme/de_DE/Omikron_Factfinder/ff-web-components/dist/elements.build.js”.
```
This pull request adds a plugin that programmatically adds the `ff-web-components/dist/elements.build` resource to the exclusion list for the minification process. See also https://magento.stackexchange.com/a/198480/37461