### PR TITLE
FFWEB-1007 : Remove 'keep-filter' parameter from module configuration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,9 @@
 - Add missing title to `factfinder_result_index` site
 - Exclude FACT-Finder Web Components js script from minification
 
+## CHANGE
+- Remove 'keep-filters' parameter from module configuration
+
 #ADD
 - Added possibility to export additional attributes in separate columns
 - Adds possibility to configure frequency of feed file generation by Cron

--- a/Omikron/Factfinder/Block/FF/Communication.php
+++ b/Omikron/Factfinder/Block/FF/Communication.php
@@ -104,11 +104,6 @@ class Communication extends Template
                 'type' => 'string',
                 'defaultValue' => $defaultValues['advanced']['add_tracking_params']
             ],
-            'keep-filters' => [
-                'value' => $this->_helper->getKeepFilters(),
-                'type' => 'boolean',
-                'defaultValue' => $defaultValues['advanced']['keep_filters']
-            ],
             'keep-url-params' => [
                 'value' => $this->_helper->getKeepUrlParams(),
                 'type' => 'string',

--- a/Omikron/Factfinder/Helper/Data.php
+++ b/Omikron/Factfinder/Helper/Data.php
@@ -244,15 +244,6 @@ class Data extends AbstractHelper
     }
 
     /**
-     * Returns the keep-filters configuration
-     * @return mixed
-     */
-    public function getKeepFilters()
-    {
-        return $this->scopeConfig->getValue('factfinder/advanced/keep_filters', 'store');
-    }
-
-    /**
      * Returns the keep-url-params configuration
      * @return mixed
      */

--- a/Omikron/Factfinder/etc/adminhtml/system.xml
+++ b/Omikron/Factfinder/etc/adminhtml/system.xml
@@ -80,11 +80,6 @@
                     <label>add-tracking-params</label>
                     <comment>With this property you can deliver standard parameters which are attached to every tracking request. Example: param1=abc,param2=xyz.</comment>
                 </field>
-                <field id="keep_filters" translate="label" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>keep-filters</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>With this property you can determine if filters (which where set before the search, e.g. via ASN) should be kept or discarded.</comment>
-                </field>
                 <field id="keep_url_params" translate="label" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>keep-url-params</label>
                     <comment>Determines if parameters which are written into the URL should be kept.</comment>


### PR DESCRIPTION
- Solves issue: 
Disable possibility to set 'keep-filters' param as it cause bug on Search requests with active filters with encoded special characters
- Tested with Magento editions/versions: 
2.2.6 +
- Tested with PHP versions: 
7.1