### PR TITLE
make getFilteredProductCollection function protected

### DIFF
--- a/Omikron/Factfinder/Model/Export/Product.php
+++ b/Omikron/Factfinder/Model/Export/Product.php
@@ -290,7 +290,7 @@ class Product extends AbstractModel
      * @param StoreInterface $store
      * @return Collection
      */
-    private function getFilteredProductCollection($store)
+    protected function getFilteredProductCollection($store)
     {
         /** @var Collection $collection */
         return $this->productCollectionFactory


### PR DESCRIPTION
In our case we do not want to filter the products by their visibility status. However, since the function is `private` we cannot easily extend and replace the class and this method.