### PR TITLE
FFWEB-1029 : Add <ff-campaign-redirect> component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @a-laurowski @abognetti
+* @a-laurowski @fmarangi

--- a/Omikron/Factfinder/Model/Export/Product.php
+++ b/Omikron/Factfinder/Model/Export/Product.php
@@ -290,7 +290,7 @@ class Product extends AbstractModel
      * @param StoreInterface $store
      * @return Collection
      */
-    private function getFilteredProductCollection($store)
+    protected function getFilteredProductCollection($store)
     {
         /** @var Collection $collection */
         return $this->productCollectionFactory

--- a/Omikron/Factfinder/view/frontend/templates/ff/campaign.phtml
+++ b/Omikron/Factfinder/view/frontend/templates/ff/campaign.phtml
@@ -15,7 +15,7 @@
         </div>
     </ff-campaign-advisor-question>
 </ff-campaign-advisor>
-
+<ff-campaign-redirect></ff-campaign-redirect>
 <ff-campaign-feedbacktext label="myfeedbackcampaign" unresolved>
     {{text}}
     <!--or mixed content-->


### PR DESCRIPTION
- Description: 
Add <ff-campaign-redirect> in order to make redirect campaigns works
- Tested with Magento editions/versions: 
 2.2.6
- Tested with PHP versions: 
7.1
