### PR TITLE
FFWEB-1047: Only make product attributes exportable

### DIFF
--- a/Omikron/Factfinder/Model/Source/Attribute.php
+++ b/Omikron/Factfinder/Model/Source/Attribute.php
@@ -2,50 +2,27 @@
 
 namespace Omikron\Factfinder\Model\Source;
 
-/**
- * Class Attribute
- * @package Omikron\Factfinder\Model\Source
- */
-class Attribute
-{
-    /* @var \Magento\Eav\Model\ResourceModel\Entity\Attribute\Collection */
-    protected $_attributeCollection;
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute as EavAttribute;
+use Magento\Eav\Model\ResourceModel\Entity\Attribute\CollectionFactory as AttributeCollectionFactory;
+use Magento\Framework\Data\OptionSourceInterface;
 
-    /**
-     * Attribute constructor.
-     * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\Collection $attributeCollection
-     */
-    public function __construct(
-        \Magento\Eav\Model\ResourceModel\Entity\Attribute\Collection $attributeCollection
-    )
+class Attribute implements OptionSourceInterface
+{
+    /** @var AttributeCollectionFactory */
+    private $collectionFactory;
+
+    public function __construct(AttributeCollectionFactory $collectionFactory)
     {
-        $this->_attributeCollection = $attributeCollection;
+        $this->collectionFactory = $collectionFactory;
     }
 
-    /**
-     * Generate an array of option attributes
-     * @return array
-     */
     public function toOptionArray()
     {
-        $options = [
-            [
-                'value' => '',
-                'label' => ''
-            ]
-        ];
-
-        $attributeCollection = $this->_attributeCollection->load()->getItems();
-
-        foreach ($attributeCollection as $attribute) {
-            $options[] = [
-                'value' => $attribute->getAttributeCode(),
-                'label' => $attribute->getAttributeCode()
-            ];
-        }
-
-        asort($options);
-
-        return $options;
+        $collection = $this->collectionFactory->create();
+        $collection->setOrder('attribute_code', 'ASC');
+        $options = array_map(function (EavAttribute $attribute): array {
+            return ['value' => $attribute->getAttributeCode(), 'label' => $attribute->getAttributeCode()];
+        }, $collection->getItems());
+        return array_merge([['value' => '', 'label' => '']], $options);
     }
 }

--- a/Omikron/Factfinder/Model/Source/Attribute.php
+++ b/Omikron/Factfinder/Model/Source/Attribute.php
@@ -20,9 +20,11 @@ class Attribute implements OptionSourceInterface
     {
         $collection = $this->collectionFactory->create();
         $collection->setOrder('attribute_code', 'ASC');
+
         $options = array_map(function (EavAttribute $attribute): array {
             return ['value' => $attribute->getAttributeCode(), 'label' => $attribute->getAttributeCode()];
         }, $collection->getItems());
+
         return array_merge([['value' => '', 'label' => '']], $options);
     }
 }

--- a/Omikron/Factfinder/Model/Source/FFVersion.php
+++ b/Omikron/Factfinder/Model/Source/FFVersion.php
@@ -4,6 +4,7 @@ namespace Omikron\Factfinder\Model\Source;
 
 /**
  * Class FFVersion
+ *
  * @package Omikron\Factfinder\Model\Source
  */
 class FFVersion implements \Magento\Framework\Option\ArrayInterface
@@ -17,7 +18,7 @@ class FFVersion implements \Magento\Framework\Option\ArrayInterface
     {
         return [
             ['value' => '7.2', 'label' => __('7.2')],
-            ['value' => '7.3', 'label' => __('7.3')]
+            ['value' => '7.3', 'label' => __('7.3')],
         ];
     }
 
@@ -30,7 +31,7 @@ class FFVersion implements \Magento\Framework\Option\ArrayInterface
     {
         return [
             '7.2' => __('7.2'),
-            '7.3' => __('7.3')
+            '7.3' => __('7.3'),
         ];
     }
 }

--- a/Omikron/Factfinder/etc/adminhtml/di.xml
+++ b/Omikron/Factfinder/etc/adminhtml/di.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Omikron\Factfinder\Model\Source\Attribute">
+        <arguments>
+            <argument name="collectionFactory" xsi:type="object">Omikron\Factfinder\Model\Product\Attribute\CollectionFactory</argument>
+        </arguments>
+    </type>
+</config>

--- a/Omikron/Factfinder/etc/di.xml
+++ b/Omikron/Factfinder/etc/di.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <virtualType name="Omikron\Factfinder\Model\Product\Attribute\CollectionFactory" type="Magento\Eav\Model\ResourceModel\Entity\Attribute\CollectionFactory">
+        <arguments>
+            <argument name="instanceName" xsi:type="string">Magento\Catalog\Model\ResourceModel\Product\Attribute\Collection</argument>
+        </arguments>
+    </virtualType>
+
     <type name="Magento\Framework\View\Asset\Minification">
         <plugin name="omikron.factfinder.excludefilesfromminification" type="Omikron\Factfinder\Plugin\ExcludeFilesFromMinification" />
     </type>


### PR DESCRIPTION
- Solves issue: FFWEB-1047
- Description: In system configuration, all EAV attributes (incl. customer and category attributes) are available in the selectors. Only offer product attributes for the moment. 
- Tested with Magento editions/versions: 2.2.6, 2.3
- Tested with PHP versions: 7.2
