### PR TITLE
add u flag for preg_replace

### DIFF
--- a/Omikron/Factfinder/Helper/Product.php
+++ b/Omikron/Factfinder/Helper/Product.php
@@ -476,7 +476,7 @@ class Product extends AbstractHelper
 
         if ($isMultiAttributeValue) {
             // do not allow special chars in values
-            $value = preg_replace('/([^\pL0-9 -])+/', '', $value);
+            $value = preg_replace('/([^\pL0-9 -])+/u', '', $value);
             // reduce multiple spaces to one
             $value = preg_replace('/\s\s+/', ' ', $value);
         }


### PR DESCRIPTION
## Description

In https://github.com/FACT-Finder-Web-Components/magento2-module/pull/84 I introduced a change to the `cleanValue` function, to allow any letter - including special characters like Umlauts. However, this currently breaks the encoding. e.g. 
```
Österreich
```
will be converted to
```
Ãsterreich
```
Adding the `u` pattern modifier to the regular expression (http://php.net/manual/en/reference.pcre.pattern.modifiers.php) fixes the issue.

However, this also means that only `utf-8` strings will be matched now ... anything else simply returns an empty string.

May be there is a better way to handle this?

## Tested with Magento editions/versions: 

2.2.7

## Tested with PHP versions: 

7.1.26