### PR TITLE
Fix missing export attribute selection in backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
-## [1.0.0] - 2019.03.18
+## [Unreleased]
+### Fixed
+- Fix export attribute selection in system config
+
+## [v1.0.0] - 2019.03.18
 ### Added
 - Add CMS export
 
@@ -92,7 +96,8 @@
 ### Added
 - Feed Export: Export feed file is now available via separate link
 
-[Unreleased]:   https://github.com/FACT-Finder-Web-Components/magento2-module/compare/v0.9-beta.11...HEAD
+[Unreleased]:   https://github.com/FACT-Finder-Web-Components/magento2-module/compare/v1.0.0...HEAD
+[v1.0.0]:       https://github.com/FACT-Finder-Web-Components/magento2-module/compare/v0.9-beta.11...v1.0.0
 [v0.9-beta.11]: https://github.com/FACT-Finder-Web-Components/magento2-module/compare/v0.9-beta.10...v0.9-beta.11
 [v0.9-beta.10]: https://github.com/FACT-Finder-Web-Components/magento2-module/compare/v0.9-beta.9...v0.9-beta.10
 [v0.9-beta.9]:  https://github.com/FACT-Finder-Web-Components/magento2-module/compare/v0.9-beta.8...v0.9-beta.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@
 ### Changed
 - Refactor product export
 - Reorganize folder structure: source code is now found under `src`
-- Upgraded Web Components version to 3.1.0
-- Serving javascript files via RequireJS
+- Upgrade Web Components version to 3.1.0
+- Serve JS files using RequireJS
 
 ## [v0.9-beta.11] - 2019.03.01
 ### Changed
 - Drop support for PHP 7.0
 - Replace Communication helper with dedicated models
 - Remove core controller rewrites and perform redirects using event observers
-- Upgraded Web Components version to 3.0
+- Upgrade Web Components version to 3.0
 
 ### Removed
 - ResultRefiner: Use DI or plugins to edit the JSON result

--- a/src/Controller/Result/Index.php
+++ b/src/Controller/Result/Index.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Omikron\Factfinder\Controller\Result;
 
 use Magento\Framework\App\Action\Action;

--- a/src/Model/Config/Source/Attribute.php
+++ b/src/Model/Config/Source/Attribute.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Omikron\Factfinder\Model\Config\Source;
 
 use Magento\Eav\Model\Entity\Attribute\AbstractAttribute as EavAttribute;

--- a/src/Model/Config/Source/Attribute.php
+++ b/src/Model/Config/Source/Attribute.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omikron\Factfinder\Model\Source;
+namespace Omikron\Factfinder\Model\Config\Source;
 
 use Magento\Eav\Model\Entity\Attribute\AbstractAttribute as EavAttribute;
 use Magento\Eav\Model\ResourceModel\Entity\Attribute\CollectionFactory as AttributeCollectionFactory;

--- a/src/Model/Export/BasicAuth.php
+++ b/src/Model/Export/BasicAuth.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Omikron\Factfinder\Model\Export;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;

--- a/src/etc/adminhtml/di.xml
+++ b/src/etc/adminhtml/di.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <type name="Omikron\Factfinder\Model\Source\Attribute">
-        <arguments>
-            <argument name="collectionFactory" xsi:type="object">Omikron\Factfinder\Model\Product\Attribute\CollectionFactory</argument>
-        </arguments>
-    </type>
-
     <type name="Omikron\Factfinder\Controller\Adminhtml\Export\CmsFeed">
         <arguments>
             <argument name="channelProvider" xsi:type="object">Omikron\Factfinder\Model\Config\CmsConfig</argument>
@@ -14,6 +8,11 @@
     <type name="Omikron\Factfinder\Controller\Adminhtml\Export\Feed">
         <arguments>
             <argument name="channelProvider" xsi:type="object">Omikron\Factfinder\Model\Config\CommunicationConfig</argument>
+        </arguments>
+    </type>
+    <type name="Omikron\Factfinder\Model\Config\Source\Attribute">
+        <arguments>
+            <argument name="collectionFactory" xsi:type="object">Omikron\Factfinder\Model\Product\Attribute\CollectionFactory</argument>
         </arguments>
     </type>
 </config>

--- a/src/etc/adminhtml/system/data_transfer.xml
+++ b/src/etc/adminhtml/system/data_transfer.xml
@@ -1,50 +1,43 @@
 <?xml version="1.0"?>
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
-    <group id="data_transfer" translate="label" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
+    <group id="data_transfer" translate="label comment" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
         <label>Data export</label>
-        <comment>
-            <![CDATA[<div class="message message-notice notice"><div data-ui-id="messages-message-success">Please always save the config in the upper right corner after making changes. Especially before using the export-button.</div></div>]]></comment>
-        <field id="ff_upload_host" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0"
-               showInStore="0">
+        <comment><![CDATA[<div class="message message-notice notice"><div data-ui-id="messages-message-success">Please always save the config in the upper right corner after making changes. Especially before using the export-button.</div></div>]]></comment>
+        <field id="ff_upload_host" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
             <label>Upload Host</label>
-            <comment>Please specify the FTP server address, where the export file(s) should be uploaded. For example
+            <comment>
+                Please specify the FTP server address, where the export file(s) should be uploaded. For example
                 shopname.fact-finder.de. This parameter shouldn't have any trailing slashes and shouldn't be prefixed
                 with ftp://.
             </comment>
         </field>
-        <field id="ff_upload_user" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0"
-               showInStore="0">
+        <field id="ff_upload_user" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
             <label>Upload User</label>
         </field>
-        <field id="ff_upload_password" translate="label" type="password" sortOrder="30" showInDefault="1"
-               showInWebsite="0" showInStore="0">
+        <field id="ff_upload_password" translate="label" type="password" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
             <label>Upload Password</label>
         </field>
-        <field id="ff_createfeed" translate="label comment" type="button" sortOrder="100" showInDefault="1"
-               showInWebsite="1" showInStore="1">
+        <field id="ff_additional_attributes" translate="label comment" type="multiselect" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Select Additional Attributes</label>
+            <source_model>Omikron\Factfinder\Model\Config\Source\Attribute</source_model>
+            <comment>Select all attributes which should be exported to the product feed.</comment>
+        </field>
+        <field id="ff_createfeed" translate="label comment" type="button" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Generate Export File</label>
             <frontend_model>Omikron\Factfinder\Block\Adminhtml\System\Config\Button\Feed</frontend_model>
-            <comment>On buttonclick CSV exports of all your products will be generated and uploaded to the specified FTP
-                Server.
-            </comment>
+            <comment>On buttonclick CSV exports of all your products will be generated and uploaded to the specified FTP Server.</comment>
         </field>
-        <field id="ff_update_field_roles" translate="label comment" type="button" sortOrder="100" showInDefault="1"
-               showInWebsite="1" showInStore="1">
+        <field id="ff_update_field_roles" translate="label comment" type="button" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Update Field Roles</label>
             <frontend_model>Omikron\Factfinder\Block\Adminhtml\System\Config\Button\UpdateFieldRoles</frontend_model>
-            <comment>On buttonclick Field Roles set in FACT-Finder backend will be stored in module configuration
-            </comment>
+            <comment>On buttonclick Field Roles set in FACT-Finder backend will be stored in module configuration</comment>
         </field>
-        <field id="ff_push_import_enabled" translate="label" type="select" sortOrder="110" showInDefault="1"
-               showInWebsite="1" showInStore="1">
+        <field id="ff_push_import_enabled" translate="label comment" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Automatic Import of product data</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <comment>Runs an automatic import of the product data to the FACT-Finder servers, after the FTP upload is
-                finished.
-            </comment>
+            <comment>Runs an automatic import of the product data to the FACT-Finder servers, after the FTP upload is finished.</comment>
         </field>
-        <field id="ff_push_import_type" translate="label" type="multiselect" sortOrder="120" showInDefault="1"
-               showInWebsite="1" showInStore="1">
+        <field id="ff_push_import_type" translate="label" type="multiselect" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Pushed import types</label>
             <options>
                 <option label="Data">data</option>
@@ -55,6 +48,7 @@
             </depends>
         </field>
     </group>
+
     <group id="basic_auth_data_transfer" translate="label" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
         <label>Http Export</label>
         <field id="ff_upload_url_user" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">


### PR DESCRIPTION
- Description: By accident in 1.0 we dropped the export attribute selection in the backend. This PR restores the previous status
- Tested with Magento editions/versions: 2.3
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
