### PR TITLE
FFWEB-1206 : Tracking Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [Unreleased]
+### Added
+- Add Logging to tracking exceptions
+### Fixed
+- Fixed exceptions thrown by Tracking if FACT-Finder connection could not be established
+
 ## [v1.1.0] - 2019.04.05
 ### Added
 - Replace main navigation with the `<ff-navigation>` component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
-## [Unreleased]
+## Unreleased
 ### Added
-- Add Logging to tracking exceptions
+- Add logging to tracking exceptions
+
 ### Fixed
-- Fixed exceptions thrown by Tracking if FACT-Finder connection could not be established
+- Skip tracking if the FACT-Finder integration is disabled in the backend
 
 ## [v1.1.0] - 2019.04.05
 ### Added

--- a/src/Observer/BaseTracking.php
+++ b/src/Observer/BaseTracking.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Observer;
 
 use Magento\Catalog\Model\Product;
-use Magento\Store\Model\StoreManagerInterface;
+use Omikron\Factfinder\Api\Config\CommunicationConfigInterface;
 use Omikron\Factfinder\Api\Data\TrackingProductInterfaceFactory;
 use Omikron\Factfinder\Api\FieldRolesInterface;
 use Omikron\Factfinder\Model\Api\Tracking;
@@ -21,19 +21,19 @@ abstract class BaseTracking
     /** @var FieldRolesInterface */
     protected $fieldRoles;
 
-    /** @var StoreManagerInterface */
-    private $storeManager;
+    /** @var CommunicationConfigInterface  */
+    protected $config;
 
     public function __construct(
         Tracking $tracking,
         TrackingProductInterfaceFactory $trackingProductFactory,
         FieldRolesInterface $fieldRoles,
-        StoreManagerInterface $storeManager
+        CommunicationConfigInterface $config
     ) {
         $this->tracking               = $tracking;
         $this->trackingProductFactory = $trackingProductFactory;
         $this->fieldRoles             = $fieldRoles;
-        $this->storeManager           = $storeManager;
+        $this->config                 = $config;
     }
 
     protected function getProductData(string $roleName, Product $product): string

--- a/src/Observer/Tracking/AddToCart.php
+++ b/src/Observer/Tracking/AddToCart.php
@@ -12,15 +12,18 @@ class AddToCart extends BaseTracking implements ObserverInterface
 {
     public function execute(Observer $observer)
     {
-        $request = $observer->getData('request');
-        $product = $observer->getData('product');
-        $qty     = (int) ($request->getParam('qty') ?: 1);
-
-        $this->tracking->execute('cart', $this->trackingProductFactory->create([
-            'trackingNumber'      => $this->getProductData('trackingProductNumber', $product),
-            'masterArticleNumber' => $this->getProductData('masterArticleNumber', $product),
-            'price'               => $product->getFinalPrice($qty),
-            'count'               => $qty,
-        ]));
+        if ($this->config->isChannelEnabled()) {
+            $request = $observer->getData('request');
+            $product = $observer->getData('product');
+            $qty     = (int) ($request->getParam('qty') ?: 1);
+            $this->tracking->execute('cart', $this->trackingProductFactory->create(
+                [
+                    'trackingNumber'      => $this->getProductData('trackingProductNumber', $product),
+                    'masterArticleNumber' => $this->getProductData('masterArticleNumber', $product),
+                    'price'               => $product->getFinalPrice($qty),
+                    'count'               => $qty,
+                ]
+            ));
+        }
     }
 }

--- a/src/Observer/Tracking/Checkout.php
+++ b/src/Observer/Tracking/Checkout.php
@@ -14,18 +14,22 @@ class Checkout extends BaseTracking implements ObserverInterface
 {
     public function execute(Observer $observer)
     {
-        /** @var Quote $cart */
-        $cart = $observer->getData('quote');
-
-        $trackingProducts = array_map(function (Item $item) {
-            return $this->trackingProductFactory->create([
-                'trackingNumber'      => $this->getProductData('trackingProductNumber', $item->getProduct()),
-                'masterArticleNumber' => $this->getProductData('masterArticleNumber', $item->getProduct()),
-                'price'               => $item->getPrice(),
-                'count'               => $item->getQty(),
-            ]);
-        }, $cart->getAllVisibleItems());
-
-        $this->tracking->execute('checkout', ...$trackingProducts);
+        if ($this->config->isChannelEnabled()) {
+            /** @var Quote $cart */
+            $cart             = $observer->getData('quote');
+            $trackingProducts = array_map(
+                function (Item $item) {
+                    return $this->trackingProductFactory->create(
+                        [
+                            'trackingNumber'      => $this->getProductData('trackingProductNumber', $item->getProduct()),
+                            'masterArticleNumber' => $this->getProductData('masterArticleNumber', $item->getProduct()),
+                            'price'               => $item->getPrice(),
+                            'count'               => $item->getQty(),
+                        ]
+                    );
+                }, $cart->getAllVisibleItems()
+            );
+            $this->tracking->execute('checkout', ...$trackingProducts);
+        }
     }
 }

--- a/src/Test/Unit/Observer/AddToCartTest.php
+++ b/src/Test/Unit/Observer/AddToCartTest.php
@@ -74,7 +74,7 @@ class AddToCartTest extends TestCase
     public function test_no_tracking_if_integration_is_disabled()
     {
         $this->configMock->method('isChannelEnabled')->willReturn(false);
-        $this->trackingMock->expects($this->any())->method('execute');
+        $this->trackingMock->expects($this->never())->method('execute');
         $this->addToCart->execute($this->observerMock);
     }
 

--- a/src/Test/Unit/Observer/AddToCartTest.php
+++ b/src/Test/Unit/Observer/AddToCartTest.php
@@ -50,6 +50,7 @@ class AddToCartTest extends TestCase
         $this->configMock->method('isChannelEnabled')->willReturn(true);
         $this->requestMock->method('getParam')->with('qty')->willReturn(0);
         $this->productMock->method('getFinalPrice')->with(1)->willReturn(9.99);
+
         $this->fieldRolesMock->expects($this->exactly(2))
             ->method('fieldRoleToAttribute')->willReturnMap([
                 [$this->productMock, 'trackingProductNumber', '1'],
@@ -71,7 +72,7 @@ class AddToCartTest extends TestCase
         $this->addToCart->execute($this->observerMock);
     }
 
-    public function test_no_tracking_if_integration_is_disabled()
+    public function test_tracking_is_skipped_if_the_integration_is_disabled()
     {
         $this->configMock->method('isChannelEnabled')->willReturn(false);
         $this->trackingMock->expects($this->never())->method('execute');

--- a/src/Test/Unit/Observer/AddToCartTest.php
+++ b/src/Test/Unit/Observer/AddToCartTest.php
@@ -42,8 +42,12 @@ class AddToCartTest extends TestCase
     /** @var AddToCart */
     private $addToCart;
 
+    /** @var MockObject|CommunicationConfigInterface */
+    private $configMock;
+
     public function test_execute_track_event_successfully()
     {
+        $this->configMock->method('isChannelEnabled')->willReturn(true);
         $this->requestMock->method('getParam')->with('qty')->willReturn(0);
         $this->productMock->method('getFinalPrice')->with(1)->willReturn(9.99);
         $this->fieldRolesMock->expects($this->exactly(2))
@@ -67,6 +71,13 @@ class AddToCartTest extends TestCase
         $this->addToCart->execute($this->observerMock);
     }
 
+    public function test_no_tracking_if_integration_is_disabled()
+    {
+        $this->configMock->method('isChannelEnabled')->willReturn(false);
+        $this->trackingMock->expects($this->any())->method('execute');
+        $this->addToCart->execute($this->observerMock);
+    }
+
     protected function setUp()
     {
         $this->storeMock      = $this->createMock(StoreInterface::class);
@@ -75,6 +86,7 @@ class AddToCartTest extends TestCase
         $this->requestMock    = $this->createMock(RequestInterface::class);
         $this->productMock    = $this->createMock(Product::class);
         $this->observerMock   = $this->createMock(Observer::class);
+        $this->configMock     = $this->createMock(CommunicationConfigInterface::class);
 
         $this->trackingProductFactoryMock = $this->getMockBuilder(TrackingProductInterfaceFactory::class)
             ->disableOriginalConstructor()
@@ -95,7 +107,7 @@ class AddToCartTest extends TestCase
             $this->trackingMock,
             $this->trackingProductFactoryMock,
             $this->fieldRolesMock,
-            $this->createConfiguredMock(CommunicationConfigInterface::class, ['isChannelEnabled' => true ])
+            $this->configMock
         );
     }
 }

--- a/src/Test/Unit/Observer/AddToCartTest.php
+++ b/src/Test/Unit/Observer/AddToCartTest.php
@@ -8,7 +8,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Store\Api\Data\StoreInterface;
-use Magento\Store\Model\StoreManagerInterface;
+use Omikron\Factfinder\Api\Config\CommunicationConfigInterface;
 use Omikron\Factfinder\Api\Data\TrackingProductInterface;
 use Omikron\Factfinder\Api\Data\TrackingProductInterfaceFactory;
 use Omikron\Factfinder\Api\FieldRolesInterface;
@@ -95,7 +95,7 @@ class AddToCartTest extends TestCase
             $this->trackingMock,
             $this->trackingProductFactoryMock,
             $this->fieldRolesMock,
-            $this->createConfiguredMock(StoreManagerInterface::class, ['getStore' => $this->storeMock])
+            $this->createConfiguredMock(CommunicationConfigInterface::class, ['isChannelEnabled' => true ])
         );
     }
 }

--- a/src/Test/Unit/Observer/CheckoutTest.php
+++ b/src/Test/Unit/Observer/CheckoutTest.php
@@ -8,7 +8,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Framework\Event\Observer;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Item;
-use Magento\Store\Model\StoreManagerInterface;
+use Omikron\Factfinder\Api\Config\CommunicationConfigInterface;
 use Omikron\Factfinder\Api\Data\TrackingProductInterface;
 use Omikron\Factfinder\Api\Data\TrackingProductInterfaceFactory;
 use Omikron\Factfinder\Api\FieldRolesInterface;
@@ -58,7 +58,7 @@ class CheckoutTest extends TestCase
             $this->trackingMock,
             $this->trackingProductFactoryMock,
             $this->createMock(FieldRolesInterface::class),
-            $this->createMock(StoreManagerInterface::class)
+            $this->createConfiguredMock(CommunicationConfigInterface::class, ['isChannelEnabled' => true ])
         );
     }
 }

--- a/src/Test/Unit/Observer/CheckoutTest.php
+++ b/src/Test/Unit/Observer/CheckoutTest.php
@@ -52,7 +52,7 @@ class CheckoutTest extends TestCase
     public function test_no_tracking_if_integration_is_disabled()
     {
         $this->configMock->method('isChannelEnabled')->willReturn(false);
-        $this->trackingMock->expects($this->any())->method('execute');
+        $this->trackingMock->expects($this->never())->method('execute');
         $this->checkoutObserver->execute(new Observer(['quote' => $this->createMock(Quote::class)]));
     }
 

--- a/src/Test/Unit/Observer/CheckoutTest.php
+++ b/src/Test/Unit/Observer/CheckoutTest.php
@@ -24,11 +24,15 @@ class CheckoutTest extends TestCase
     /** @var MockObject|TrackingProductInterfaceFactory */
     private $trackingProductFactoryMock;
 
+    /** @var MockObject|CommunicationConfigInterface */
+    private $configMock;
+
     /** @var Checkout */
     private $checkoutObserver;
 
     public function test_execute_should_call_tracking_with_parameters_of_correct_type()
     {
+        $this->configMock->method('isChannelEnabled')->willReturn(true);
         $quoteMock = $this->createConfiguredMock(Quote::class, ['getAllVisibleItems' => [
             $this->createConfiguredMock(Item::class, ['getProduct' => $this->createMock(Product::class)]),
             $this->createConfiguredMock(Item::class, ['getProduct' => $this->createMock(Product::class)]),
@@ -45,10 +49,17 @@ class CheckoutTest extends TestCase
         $this->checkoutObserver->execute(new Observer(['quote' => $quoteMock]));
     }
 
+    public function test_no_tracking_if_integration_is_disabled()
+    {
+        $this->configMock->method('isChannelEnabled')->willReturn(false);
+        $this->trackingMock->expects($this->any())->method('execute');
+        $this->checkoutObserver->execute(new Observer(['quote' => $this->createMock(Quote::class)]));
+    }
+
     protected function setUp()
     {
         $this->trackingMock = $this->createMock(Tracking::class);
-
+        $this->configMock = $this->createMock(CommunicationConfigInterface::class);
         $this->trackingProductFactoryMock = $this->getMockBuilder(TrackingProductInterfaceFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
@@ -58,7 +69,7 @@ class CheckoutTest extends TestCase
             $this->trackingMock,
             $this->trackingProductFactoryMock,
             $this->createMock(FieldRolesInterface::class),
-            $this->createConfiguredMock(CommunicationConfigInterface::class, ['isChannelEnabled' => true ])
+            $this->configMock
         );
     }
 }

--- a/src/Test/Unit/Observer/CheckoutTest.php
+++ b/src/Test/Unit/Observer/CheckoutTest.php
@@ -33,6 +33,7 @@ class CheckoutTest extends TestCase
     public function test_execute_should_call_tracking_with_parameters_of_correct_type()
     {
         $this->configMock->method('isChannelEnabled')->willReturn(true);
+
         $quoteMock = $this->createConfiguredMock(Quote::class, ['getAllVisibleItems' => [
             $this->createConfiguredMock(Item::class, ['getProduct' => $this->createMock(Product::class)]),
             $this->createConfiguredMock(Item::class, ['getProduct' => $this->createMock(Product::class)]),
@@ -49,7 +50,7 @@ class CheckoutTest extends TestCase
         $this->checkoutObserver->execute(new Observer(['quote' => $quoteMock]));
     }
 
-    public function test_no_tracking_if_integration_is_disabled()
+    public function test_tracking_is_skipped_if_the_integration_is_disabled()
     {
         $this->configMock->method('isChannelEnabled')->willReturn(false);
         $this->trackingMock->expects($this->never())->method('execute');

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -116,6 +116,9 @@
         <plugin name="logPushImportExceptions" type="Omikron\Factfinder\Plugin\LogExceptions" />
     </type>
     <type name="Omikron\Factfinder\Model\Api\Tracking">
+        <plugin name="logTrackingExceptions" type="Omikron\Factfinder\Plugin\LogExceptions" />
+    </type>
+    <type name="Omikron\Factfinder\Model\Api\Tracking">
         <arguments>
             <argument name="factFinderClient" xsi:type="object">Omikron\Factfinder\Model\TrackingEventClient</argument>
         </arguments>


### PR DESCRIPTION

- Solves issue:  
 Silenced the responseException from FACT-Finder on Tracking when connection could not be established.
 Disable tracking when FACT-Finder integration is disable

- Tested with Magento editions/versions: 
2.3.1
- Tested with PHP versions: 
7.1

