### PR TITLE
Fixes product export cronjob dependency injection issue

### DIFF
--- a/src/etc/crontab.xml
+++ b/src/etc/crontab.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="default">
-        <job name="factfinder_feed_export" instance="Omikron\Factfinder\Cron\Feed" method="execute">
+        <job name="factfinder_feed_export" instance="ProductExportCron" method="execute">
             <schedule>0 1 * * *</schedule>
         </job>
+        <!--<job name="factfinder_cms_feed_export" instance="CmsExportCron" method="execute">
+            <schedule>0 1 * * *</schedule>
+        </job>-->
     </group>
 </config>

--- a/src/etc/crontab/di.xml
+++ b/src/etc/crontab/di.xml
@@ -2,11 +2,13 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <virtualType name="ProductExportCron" type="Omikron\Factfinder\Cron\Feed">
         <arguments>
+            <argument name="channelProvider" xsi:type="object">Omikron\Factfinder\Model\Config\CommunicationConfig</argument>
             <argument name="type" xsi:type="string">product</argument>
         </arguments>
     </virtualType>
     <virtualType name="CmsExportCron" type="Omikron\Factfinder\Cron\Feed">
         <arguments>
+            <argument name="channelProvider" xsi:type="object">Omikron\Factfinder\Model\Config\CmsConfig</argument>
             <argument name="type" xsi:type="string">cms</argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
- Solves issue: 
#130
- Description: 

Fixes product export cronjob dependency injection issue.
Also adds a second (commented out) cronjob for CMS export.

The CMS export cronjob is commented out because there isn't
configuration for the system.xml yet and  I don't actually
know if the CMS cron functionallity is finished yet.
- Tested with Magento editions/versions: 
Magento Commerce 2.3.1
- Tested with PHP versions: 
7.1