### PR TITLE
Make members protected instead of private

### DIFF
--- a/src/Model/SessionData.php
+++ b/src/Model/SessionData.php
@@ -12,7 +12,7 @@ use Omikron\Factfinder\Api\SessionDataInterface;
 class SessionData implements SessionDataInterface, SectionSourceInterface, ParametersSourceInterface
 {
     /** @var CustomerSession */
-    private $customerSession;
+    protected $customerSession;
 
     public function __construct(CustomerSession $customerSession) // phpcs:ignore
     {
@@ -48,7 +48,7 @@ class SessionData implements SessionDataInterface, SectionSourceInterface, Param
         ];
     }
 
-    private function getCorrectSessionId(string $sessionId, int $length = 30): string
+    protected function getCorrectSessionId(string $sessionId, int $length = 30): string
     {
         $sessionId = $sessionId ?: sha1(uniqid('', true));
         $sessionId = str_repeat($sessionId, intdiv($length, strlen($sessionId)) + 1);


### PR DESCRIPTION
We need to replace and extend the SessionData class - however, the `private` members make it more inconvenient to actually extend it. I don't think there is a particular reason to make these members `private`?
