### PR TITLE
use getFlag method for use-cache

### DIFF
--- a/src/Model/Config/Communication/CacheConfig.php
+++ b/src/Model/Config/Communication/CacheConfig.php
@@ -24,7 +24,7 @@ class CacheConfig implements ParametersSourceInterface
     public function getParameters(): array
     {
         return [
-            'use-cache'     => $this->scopeConfig->isSetFlag(self::PATH_USE_CACHE, ScopeInterface::SCOPE_STORES),
+            'use-cache'     => $this->getFlag(self::PATH_USE_CACHE),
             'disable-cache' => $this->getFlag(self::PATH_DISABLE_CACHE),
         ];
     }


### PR DESCRIPTION
- Solves issue: -
- Description: fixes "ERROR ff-communication: Boolean property [useCache] is expected be either true, false or empty, but is [1]. Falling back to false." error in the front end.
- Tested with Magento editions/versions: 2.2.8
- Tested with PHP versions: 7.1