### PR TITLE
FFWEB-1291: Price fix for bundle and group products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Fixed
 - baseUrl is now set before window setting location in search-navigation
 - Fix currency code is now taken from store config
-- Fix price 0 export for bundle and grouped product
+- Fix price 0 export for bundle and grouped products
 - Fix use-cache communication parameter value
 
 ## [v1.1.2] - 2019.06.28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 - Fix currency code is now taken from store config
+- Fix price 0 export for bundle and grouped product
+- Fix use-cache communication parameter value
 
 ## [v1.1.2] - 2019.06.28
 ### Changed

--- a/src/Model/Export/Catalog/ProductType/CompositeDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/CompositeDataProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Model\Export\Catalog\ProductType;
+
+class CompositeDataProvider extends SimpleDataProvider
+{
+    public function toArray(): array
+    {
+        return ['Price' => $this->numberFormatter->format($this->product->getPriceInfo()->getPrice('final_price')->getValue())] + parent::toArray();
+    }
+}

--- a/src/Model/Export/Catalog/ProductType/CompositeDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/CompositeDataProvider.php
@@ -8,6 +8,7 @@ class CompositeDataProvider extends SimpleDataProvider
 {
     public function toArray(): array
     {
-        return ['Price' => $this->numberFormatter->format($this->product->getPriceInfo()->getPrice('final_price')->getValue())] + parent::toArray();
+        $price = (float) $this->product->getPriceInfo()->getPrice('final_price')->getValue();
+        return ['Price' => $this->numberFormatter->format($price)] + parent::toArray();
     }
 }

--- a/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
@@ -56,7 +56,7 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
             'Description'   => (string) $this->product->getData('description'),
             'Short'         => (string) $this->product->getData('short_description'),
             'ProductURL'    => (string) $this->product->getUrlInStore(),
-            'Price'         => $this->numberFormatter->format((float) $this->product->getFinalPrice()),
+            'Price'         => $this->numberFormatter->format($this->getPrice()),
             'Brand'         => (string) $this->product->getAttributeText('manufacturer'),
             'Availability'  => (int) $this->product->isAvailable(),
             'MagentoId'     => $this->getId(),
@@ -65,5 +65,12 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
         return array_merge($data, array_map(function (ProductFieldInterface $field): string {
             return $field->getValue($this->product);
         }, $this->productFields));
+    }
+
+    private function getPrice(): float
+    {
+        return (float)($this->product->getFinalPrice() > 0.0
+            ? $this->product->getFinalPrice()
+            : $this->product->getPriceInfo()->getPrice('final_price')->getValue());
     }
 }

--- a/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
@@ -56,7 +56,7 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
             'Description'   => (string) $this->product->getData('description'),
             'Short'         => (string) $this->product->getData('short_description'),
             'ProductURL'    => (string) $this->product->getUrlInStore(),
-            'Price'         => $this->numberFormatter->format($this->getPrice()),
+            'Price'         => $this->numberFormatter->format((float) $this->product->getFinalPrice()),
             'Brand'         => (string) $this->product->getAttributeText('manufacturer'),
             'Availability'  => (int) $this->product->isAvailable(),
             'MagentoId'     => $this->getId(),
@@ -65,12 +65,5 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
         return array_merge($data, array_map(function (ProductFieldInterface $field): string {
             return $field->getValue($this->product);
         }, $this->productFields));
-    }
-
-    private function getPrice(): float
-    {
-        return (float)($this->product->getFinalPrice() > 0.0
-            ? $this->product->getFinalPrice()
-            : $this->product->getPriceInfo()->getPrice('final_price')->getValue());
     }
 }

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -130,8 +130,8 @@
                 <item name="virtual" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProvider</item>
                 <item name="downloadable" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProvider</item>
                 <item name="configurable" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\ConfigurableDataProvider</item>
-                <item name="grouped" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProvider</item>
-                <item name="bundle" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProvider</item>
+                <item name="grouped" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\CompositeDataProvider</item>
+                <item name="bundle" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\CompositeDataProvider</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
- Solves issue: 
#124 
- Description: 
Added fix to price export for bundle and group products
- Tested with Magento editions/versions: 
2.3.0, 2.3.2
- Tested with PHP versions: 
7.2
