### PR TITLE
FFWEB-1297: Added setBaseUrl before building it by URL utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 - Fix currency code is now taken from store config
+- baseUrl is now set before window setting location in search-navigation
 
 ## [v1.1.2] - 2019.06.28
 ### Changed

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,7 +18,6 @@
         <exclude-pattern>*/Plugin/*</exclude-pattern>
         <exclude-pattern>*/Setup/*</exclude-pattern>
     </rule>
-    <rule ref="Generic.Files.ByteOrderMark" />
     <rule ref="Generic.Files.LineLength">
         <exclude-pattern>*.phtml</exclude-pattern>
         <exclude-pattern>*Test.php</exclude-pattern>
@@ -48,5 +47,4 @@
         <exclude-pattern>*Test.php</exclude-pattern>
     </rule>
     <rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired" />
-    <rule ref="Zend.Files.ClosingTag" />
 </ruleset>

--- a/src/view/frontend/web/js/search-navigation.js
+++ b/src/view/frontend/web/js/search-navigation.js
@@ -4,7 +4,7 @@ define(['factfinder', 'mage/url', 'matchMedia', 'jquery'], function (factfinder,
     factfinder.communication.FFCommunicationEventAggregator.addBeforeDispatchingCallback(function (event) {
         if ((event.type === 'search' || event.type === 'navigation-search') && !isSearchResultPage()) {
             var params = factfinder.common.dictToParameterString(event);
-            url.setBaseUrl(BASE_URL);
+            if (!url.build('')) url.setBaseUrl(BASE_URL || '');
             window.location = url.build(redirectPath + params);
         }
         hideMenu();

--- a/src/view/frontend/web/js/search-navigation.js
+++ b/src/view/frontend/web/js/search-navigation.js
@@ -4,6 +4,7 @@ define(['factfinder', 'mage/url', 'matchMedia', 'jquery'], function (factfinder,
     factfinder.communication.FFCommunicationEventAggregator.addBeforeDispatchingCallback(function (event) {
         if ((event.type === 'search' || event.type === 'navigation-search') && !isSearchResultPage()) {
             var params = factfinder.common.dictToParameterString(event);
+            url.setBaseUrl(BASE_URL);
             window.location = url.build(redirectPath + params);
         }
         hideMenu();


### PR DESCRIPTION
- Solves issue: 
#138 
- Description: 
Call setBaseUrl before building it prevent situations when baseUrl variable is null
- Tested with Magento editions/versions: 
2.2.8, 2.3.2
- Tested with PHP versions: 
7.2

