### PR TITLE
Fix/ffweb 1302 currency code fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fixed
+- Fix currency code is now taken from store config
+
 ## [v1.1.2] - 2019.06.28
 ### Changed
 - Upgrade Web Components to v3.4.0

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "php": "^7.1",
     "magento/framework": ">=101.0.0",
     "magento/module-catalog": ">=102.0.0",
-    "magento/module-directory": ">=102.0.0",
     "magento/module-configurable-product": ">=100.2.0",
+    "magento/module-directory": ">=100.3.0",
     "magento/module-store": ">=100.2.0",
     "magento/zendframework1": "^1.13"
   },

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "php": "^7.1",
     "magento/framework": ">=101.0.0",
     "magento/module-catalog": ">=102.0.0",
+    "magento/module-directory": ">=102.0.0",
     "magento/module-configurable-product": ">=100.2.0",
     "magento/module-store": ">=100.2.0",
     "magento/zendframework1": "^1.13"

--- a/src/Model/Config/Communication/CurrencyConfig.php
+++ b/src/Model/Config/Communication/CurrencyConfig.php
@@ -5,23 +5,23 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Config\Communication;
 
 use Magento\Directory\Model\Currency;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Locale\ResolverInterface;
+use Magento\Store\Model\ScopeInterface;
 use Omikron\Factfinder\Api\Config\ParametersSourceInterface;
 
 class CurrencyConfig implements ParametersSourceInterface
 {
+    /** @var ScopeConfigInterface */
+    private $scopeConfig;
+
     /** @var ResolverInterface */
     private $localeResolver;
 
-    /** @var Currency */
-    private $currency;
-
-    public function __construct(
-        ResolverInterface $localeResolver,
-        Currency $currency
-    ) {
+    public function __construct(ScopeConfigInterface $scopeConfig, ResolverInterface $localeResolver)
+    {
+        $this->scopeConfig    = $scopeConfig;
         $this->localeResolver = $localeResolver;
-        $this->currency       = $currency;
     }
 
     public function getParameters(): array
@@ -34,8 +34,7 @@ class CurrencyConfig implements ParametersSourceInterface
 
     private function getCurrencyCode(): string
     {
-        $currencies = $this->currency->getConfigDefaultCurrencies();
-        return reset($currencies );
+        return (string) $this->scopeConfig->getValue(Currency::XML_PATH_CURRENCY_DEFAULT, ScopeInterface::SCOPE_STORES);
     }
 
     private function getCurrencyCountryCode(): string

--- a/src/Model/Config/Communication/CurrencyConfig.php
+++ b/src/Model/Config/Communication/CurrencyConfig.php
@@ -4,28 +4,22 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\Model\Config\Communication;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\CurrencyInterface;
+use Magento\Directory\Model\Currency;
 use Magento\Framework\Locale\ResolverInterface;
 use Omikron\Factfinder\Api\Config\ParametersSourceInterface;
 
 class CurrencyConfig implements ParametersSourceInterface
 {
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
-
     /** @var ResolverInterface */
     private $localeResolver;
 
-    /** @var CurrencyInterface */
+    /** @var Currency */
     private $currency;
 
     public function __construct(
-        ScopeConfigInterface $scopeConfig,
         ResolverInterface $localeResolver,
-        CurrencyInterface $currency
+        Currency $currency
     ) {
-        $this->scopeConfig    = $scopeConfig;
         $this->localeResolver = $localeResolver;
         $this->currency       = $currency;
     }
@@ -40,7 +34,8 @@ class CurrencyConfig implements ParametersSourceInterface
 
     private function getCurrencyCode(): string
     {
-        return $this->currency->getShortName();
+        $currencies = $this->currency->getConfigDefaultCurrencies();
+        return reset($currencies );
     }
 
     private function getCurrencyCountryCode(): string

--- a/src/Test/Unit/Model/Config/Source/AttributeTest.php
+++ b/src/Test/Unit/Model/Config/Source/AttributeTest.php
@@ -58,7 +58,7 @@ class AttributeTest extends TestCase
         $this->sourceModel = new Attribute($this->attributeCollectionFactory);
     }
 
-    private function createAttribute(?string $value, ?string $label): MockObject
+    private function createAttribute(?string $value, ?string $label)
     {
         return $this->createConfiguredMock(EavAttribute::class, [
             'getAttributeCode'        => $value,


### PR DESCRIPTION
- Solves issue: 
#142 
- Description: 
Currency code is now taken from store config
- Tested with Magento editions/versions: 
2.2.8, 2.3.2
- Tested with PHP versions: 
7.1, 7.2

