### PR TITLE
FFWEB-1314: Allow empty multiselect fields in system configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add push FACT-Finder import on cron feed export
 
 ### Fixed
+- Allow empty multiselect fields in system configuration
 - baseUrl is now set before window setting location in search-navigation
 - Fix currency code is now taken from store config
 - Fix price 0 export for bundle and grouped products

--- a/src/etc/adminhtml/system/cms.xml
+++ b/src/etc/adminhtml/system/cms.xml
@@ -35,6 +35,7 @@
             <label>Pages Blacklist</label>
             <comment>Selected pages will not be exported</comment>
             <source_model>Magento\Cms\Model\Config\Source\Page</source_model>
+            <can_be_empty>1</can_be_empty>
             <depends>
                 <field id="ff_cms_export_enabled">1</field>
             </depends>

--- a/src/etc/adminhtml/system/data_transfer.xml
+++ b/src/etc/adminhtml/system/data_transfer.xml
@@ -21,6 +21,7 @@
             <label>Select Additional Attributes</label>
             <source_model>Omikron\Factfinder\Model\Config\Source\Attribute</source_model>
             <comment>Select all attributes which should be exported to the product feed.</comment>
+            <can_be_empty>1</can_be_empty>
         </field>
         <field id="ff_createfeed" translate="label comment" type="button" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Generate Export File</label>


### PR DESCRIPTION
- Solves issue: #144
- Description: Add missing attribute in system.xml to allow empty multiselect fields
- Tested with Magento editions/versions: 2.3.2
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
