### PR TITLE
FFWEB-324: AJAX Add to cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 ## Unreleased
+### Added
+- Add configurable product adding to cart listing.
+WARNING! This functionality is based on additional data exported in product Feed.
+In order to get this work correctly, please export new feed file right after new version is installed
+
 ### Changed
 - Add push FACT-Finder import on cron feed export
 

--- a/src/Model/Export/Catalog/ProductField/Swatches.php
+++ b/src/Model/Export/Catalog/ProductField/Swatches.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Model\Export\Catalog\ProductField;
+
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute;
+use Magento\Catalog\Model\Product;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableProductType;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Swatches\Helper\Data as SwatchHelper;
+use Omikron\Factfinder\Api\Export\Catalog\ProductFieldInterface;
+
+class Swatches implements ProductFieldInterface
+{
+    /** @var SwatchHelper */
+    private $swatchHelper;
+
+    /** @var ConfigurableProductType */
+    private $productType;
+
+    /** @var SerializerInterface */
+    private $serializer;
+
+    public function __construct(
+        SwatchHelper $swatchHelper,
+        ConfigurableProductType $productType,
+        SerializerInterface $serializer
+    ) {
+        $this->swatchHelper = $swatchHelper;
+        $this->productType  = $productType;
+        $this->serializer   = $serializer;
+    }
+
+    public function getValue(Product $product): string
+    {
+        $options = $this->productType->getConfigurableOptions($product);
+        $attributes = $this->productType->getConfigurableAttributes($product)->getItems();
+
+        if (empty($options)) {
+            return '';
+        }
+
+        return $this->serializer->serialize([
+            'product_id' => $product->getId(),
+            'attributes' =>
+                array_reduce($attributes, function ($attributes, Attribute $attribute) use ($options) {
+                    $attributes[$attribute->getAttributeId()] = [
+                        'attribute_label' => $attribute->getProductAttribute()->getFrontendLabel(),
+                        'attribute_id'    => $attribute->getAttributeId(),
+                        'position'        => $attribute->getPosition(),
+                        'options'         =>
+                            array_reduce($options[$attribute->getAttributeId()], function ($options, array $option) use ($attribute) {
+                                ['product_id'   => $productId, 'option_title' => $label, 'value_index'  => $optionId] = $option;
+                                $options[$optionId] = $this->addSwatches((int) $optionId) + [
+                                        'product_id'   => $productId,
+                                        'attribute_id' => $attribute->getAttributeId(),
+                                        'value'        => $label,
+                                        'option_id'    => $optionId
+                                    ];
+
+                                return $options;
+                            })
+                    ];
+
+                    return $attributes;
+                })
+        ]);
+    }
+
+    private function addSwatches(int $optionId): array
+    {
+        $swatchData = $this->swatchHelper->getSwatchesByOptionsId([$optionId]);
+        return isset($swatchData[$optionId]) ? array_intersect_key($swatchData[$optionId], array_flip(['option_id', 'type', 'value'])) : [];
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -31,6 +31,7 @@
                 <item name="ImageURL" xsi:type="string">ImageURL</item>
                 <item name="CategoryPath" xsi:type="string">CategoryPath</item>
                 <item name="Attributes" xsi:type="string">Attributes</item>
+                <item name="Swatches" xsi:type="string">Swatches</item>
             </argument>
         </arguments>
     </virtualType>
@@ -68,6 +69,7 @@
                 <item name="ImageURL" xsi:type="string">ImageURL</item>
                 <item name="CategoryPath" xsi:type="string">CategoryPath</item>
                 <item name="Attributes" xsi:type="string">Attributes</item>
+                <item name="Swatches" xsi:type="string">Swatches</item>
                 <item name="PageId" xsi:type="string">PageId</item>
                 <item name="PageIdentifier" xsi:type="string">PageIdentifier</item>
                 <item name="PageTitle" xsi:type="string">PageTitle</item>
@@ -141,6 +143,7 @@
                 <item name="ImageURL" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage</item>
                 <item name="CategoryPath" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\CategoryPath</item>
                 <item name="Attributes" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\Attributes</item>
+                <item name="Swatches" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\Swatches</item>
             </argument>
         </arguments>
     </type>

--- a/src/view/frontend/requirejs-config.js
+++ b/src/view/frontend/requirejs-config.js
@@ -13,5 +13,5 @@ var config = {
             exports: 'factfinder'
         }
     },
-    deps: ['Omikron_Factfinder/js/search-navigation']
+    deps: ['Omikron_Factfinder/js/search-navigation','Omikron_Factfinder/js/catalog-add-to-cart', 'Omikron_Factfinder/js/swatch-renderer']
 };

--- a/src/view/frontend/templates/ff/record-list.phtml
+++ b/src/view/frontend/templates/ff/record-list.phtml
@@ -3,17 +3,10 @@
 /** @var Omikron\Factfinder\ViewModel\ProductBasedComponent $viewModel */
 $viewModel = $block->getViewModel();
 ?>
-<script type="text/x-magento-init">
-    {
-        ".product_addtocart_form": {
-            "catalogAddToCart": {
-                "bindSubmit": true
-            }
-        }
-    }
-</script>
+
 <ff-record-list unresolved>
     <ff-record>
+
         <img data-image data-image-onerror="<?= $block->escapeUrl($viewModel->getProductImagePlaceholder()) ?>" />
         <div class="recordContent">
             <div class="brand">{{record.Manufacturer}}</div>
@@ -21,23 +14,31 @@ $viewModel = $block->getViewModel();
                 {{record.Name}}
             </a>
             <div class="description">{{record.Description}}</div>
-            <a class="toProduct" data-redirect="{{record.ProductURL}}" data-redirect-target="_blank" data-anchor="{{record.ProductURL}}">
-                <?= $block->escapeHtml(__('Product Page')) ?>
-            </a>
             <div class="productInfo">
                 <?php if ($viewModel->isAddToCartEnabled()): ?>
                     <div class="addCartLink basketIcon">
-                        <form action="<?= $block->escapeUrl($viewModel->getAddToCartUrl()) ?>" method="post" class="product_addtocart_form" novalidate="novalidate">
+                        <form id="{{record.Master}}" action="<?= $block->escapeUrl($viewModel->getAddToCartUrl()) ?>" method="post" class="product_addtocart_form" novalidate="novalidate">
                             <?= /* @noEscape */ $block->getBlockHtml('formkey') ?>
-                            <input type="hidden" name="product" value="{{record.MagentoId}}" />
+                            <div class="swatch-opt-{{record.MagentoId}}">
+                                {{{record.Swatches}}}
+                            </div>
+                            <div class="price-box">
+                                <span class="price">{{record.Price}}</span>
+                            </div>
                             <button data-track type="submit" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>" class="action primary tocart">
                                 <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
                             </button>
                         </form>
                     </div>
+                <?php else: ?>
+                    <div class="price-box">
+                        <span class="price">{{record.Price}}</span>
+                    </div>
                 <?php endif; ?>
-                <span class="price">{{record.Price}}</span>
             </div>
+            <a class="toProduct" data-redirect="{{record.ProductURL}}" data-redirect-target="_blank" data-anchor="{{record.ProductURL}}">
+                <?= $block->escapeHtml(__('Product Page')) ?>
+            </a>
         </div>
     </ff-record>
 </ff-record-list>

--- a/src/view/frontend/web/js/catalog-add-to-cart.js
+++ b/src/view/frontend/web/js/catalog-add-to-cart.js
@@ -1,0 +1,22 @@
+define([
+    'factfinder',
+    'jquery',
+    'Omikron_Factfinder/js/swatch-renderer',
+    'catalogAddToCart'
+], function (factfinder, $, swatchRenderer) {
+    factfinder.communication.ResultDispatcher.subscribe('records', function (records) {
+        records.forEach(function ({record}) {record.Swatches = swatchRenderer(record);});
+    });
+
+    document.body.addEventListener('submit', function (event) {
+        event.preventDefault();
+        if (event.target.classList.contains('product_addtocart_form')) {
+            $(event.target).catalogAddToCart().trigger('submit');
+        }
+    }, false);
+
+    // scroll to top after adding to cart
+    $(document).on('ajax:addToCart', function (e) {
+        scrollTo(0, 0);
+    });
+});

--- a/src/view/frontend/web/js/swatch-renderer.js
+++ b/src/view/frontend/web/js/swatch-renderer.js
@@ -1,0 +1,115 @@
+define(['underscore'], function (_) {
+    'use strict';
+
+    document.body.addEventListener('click', function ({target}) {
+        if (target.classList.contains('swatch-option')) {
+            let optionId = target.getAttribute('option-id'),
+                attributeId = target.getAttribute('attribute-id'),
+                attributeSelector = target.getAttribute('product-id') + '-' + attributeId,
+                notSelected;
+
+            target.classList.add('selected');
+            document.getElementById(attributeSelector).value = optionId;
+            notSelected = [...document.querySelectorAll('.swatch-option')].filter(function (el) {
+                return el.getAttribute('option-id') !== optionId && el.getAttribute('attribute-id') === attributeId;
+            });
+
+            notSelected.forEach(function (el) {
+                el.classList.remove('selected');
+            })
+        }
+    }, false);
+
+    /**
+     *
+     * @param attributeLabel
+     * @param attributeId
+     * @param innerFn
+     * @returns {string}
+     * @private
+     */
+    function _renderAttributeContainer(attributeLabel, attributeId, innerFn) {
+        return `<div class="swatch-attribute ${attributeId}" attribute-id="${attributeId}">
+            <span class="swatch-attribute-label">${attributeLabel}</span>
+            <div class="swatch-attribute-options clearfix">`
+            + innerFn() + '</div></div>'
+    }
+
+    /**
+     *
+     * @param product_id
+     * @returns {string}
+     * @private
+     */
+    function _renderProductInput(product_id) {
+        return `<input type="hidden" name="product" value="${product_id}"/>`;
+    }
+
+    /**
+     *
+     * @param attribute_id
+     * @param product_id
+     * @returns {string}
+     * @private
+     */
+    function _renderOptionInput({attribute_id, product_id}) {
+        return `<input type="hidden" id=${product_id + '-' + attribute_id} name="super_attribute[${attribute_id}]"/>`;
+    }
+
+    /**
+     *
+     * @param type
+     * @param product_id
+     * @param value
+     * @param attribute_id
+     * @param option_id
+     * @returns {string}
+     * @private
+     */
+    function _renderSwatch({type, product_id, value, attribute_id, option_id}) {
+        let isColor = (parseInt(type) === 1),
+            style = isColor ? `background: ${value} no-repeat center; background-size: initial;` : '';
+        return `<div class="swatch-option ${isColor ? 'color' : 'text'}" option-id="${option_id}" attribute-id="${attribute_id}"
+            product-id="${product_id}" style="${style}">${!isColor ? value : ''}</div>`;
+    }
+
+    /**
+     *
+     * @returns {function(*): string}
+     * @private
+     */
+    function _sortAttributes(attributes) {
+        return _.sortBy(attributes, function (attribute) {
+            return parseInt(attribute.position, 10);
+        });
+    }
+
+    /**
+     * Render swatches for single product in record list.
+     *
+     * @param {Object} record - FACT-Finder search result single record object
+     * @return {String}
+     */
+    return function (record) {
+        let html, rawSwatchData, attribute_id, optionId, attribute_label, optionData, options;
+        try {
+            rawSwatchData = JSON.parse(record.Swatches);
+            html = Object.entries(_sortAttributes(rawSwatchData.attributes)).reduce(function (html, attribute) {
+                [, {attribute_label, attribute_id, options}] = attribute;
+                html += _renderAttributeContainer(attribute_label, attribute_id, function () {
+                    html = Object.entries(options).reduce(function (optionsHtml, option) {
+                        [optionId, optionData] = option;
+                        optionsHtml += _renderSwatch(optionData);
+                        return optionsHtml;
+                    }, '');
+                    return html += _renderOptionInput(optionData);
+                });
+                return html + _renderProductInput(rawSwatchData.product_id);
+            }, '');
+        } catch (e) {
+            html = _renderProductInput(record.MagentoId);
+        }
+
+        return html;
+    }
+});


### PR DESCRIPTION
Description:
Added possibility to add configurable product to cart in record list
Product are now always added to cart via AJAX (It worked only for first product page before)
Tested with Magento editions/versions:
2.3.1
Tested with PHP versions:
7.1