### PR TITLE
FFWEB-1353: Product campaign on PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Added
+- Add missing product campaigns on product detail page
+
 ## [v1.2.0] - 2019.07.24
 ### Added
 - Add data providers for bundle and grouped products

--- a/src/view/frontend/layout/catalog_product_view.xml
+++ b/src/view/frontend/layout/catalog_product_view.xml
@@ -18,5 +18,13 @@
                 </arguments>
             </block>
         </referenceContainer>
+
+        <referenceBlock name="factfinder.feedbacktext">
+            <arguments>
+                <argument name="flag" xsi:type="string">is-product-campaign</argument>
+            </arguments>
+        </referenceBlock>
+
+        <move element="factfinder.feedbacktext" destination="content" after="factfinder.campaign.product" />
     </body>
 </page>

--- a/src/view/frontend/layout/catalog_product_view.xml
+++ b/src/view/frontend/layout/catalog_product_view.xml
@@ -2,6 +2,11 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.product" template="Omikron_Factfinder::ff/campaign-product.phtml">
+                <arguments>
+                    <argument name="view_model" xsi:type="object">Omikron\Factfinder\ViewModel\ProductBasedComponent</argument>
+                </arguments>
+            </block>
             <block class="Magento\Framework\View\Element\Template" name="factfinder.recommendation" ifconfig="factfinder/components/ff_recommendation" template="Omikron_Factfinder::ff/recommendation.phtml">
                 <arguments>
                     <argument name="view_model" xsi:type="object">Omikron\Factfinder\ViewModel\ProductBasedComponent</argument>

--- a/src/view/frontend/layout/default.xml
+++ b/src/view/frontend/layout/default.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
+        <block class="Magento\Framework\View\Element\Template" name="factfinder.feedbacktext" ifconfig="factfinder/components/ff_campaign" template="Omikron_Factfinder::ff/campaign-feedbacktext.phtml" />
+
         <referenceContainer name="after.body.start">
             <block class="Magento\Framework\View\Element\Template" name="factfinder.communication" ifconfig="factfinder/general/is_enabled" template="Omikron_Factfinder::ff/communication.phtml" before="-">
                 <arguments>

--- a/src/view/frontend/layout/factfinder_result_index.xml
+++ b/src/view/frontend/layout/factfinder_result_index.xml
@@ -38,6 +38,7 @@
             </container>
         </referenceContainer>
 
+        <move element="factfinder.feedbacktext" destination="content" after="factfinder.campaign" />
         <move element="product.info.stock.sku" destination="product.info.price" after="product.price.final" />
         <move element="top.search" destination="content" before="factfinder.breadcrumb" />
     </body>

--- a/src/view/frontend/templates/ff/campaign-feedbacktext.phtml
+++ b/src/view/frontend/templates/ff/campaign-feedbacktext.phtml
@@ -1,0 +1,2 @@
+<?php /** @var Magento\Framework\View\Element\Template $block */ ?>
+<ff-campaign-feedbacktext label="<?= $block->escapeHtml($block->getLabel()) ?>" <?= /* @noEscape */ $block->getFlag() ?> unresolved>{{text}}</ff-campaign-feedbacktext>

--- a/src/view/frontend/templates/ff/campaign-product.phtml
+++ b/src/view/frontend/templates/ff/campaign-product.phtml
@@ -1,0 +1,6 @@
+<?php
+/** @var Magento\Framework\View\Element\Template $block */
+/** @var Omikron\Factfinder\ViewModel\ProductBasedComponent $viewModel */
+$viewModel = $block->getViewModel();
+?>
+<ff-campaign-product record-id="<?= $block->escapeHtmlAttr($viewModel->getProduct()->getSku()) ?>"></ff-campaign-product>

--- a/src/view/frontend/templates/ff/campaign.phtml
+++ b/src/view/frontend/templates/ff/campaign.phtml
@@ -14,8 +14,3 @@
     </ff-campaign-advisor-question>
 </ff-campaign-advisor>
 <ff-campaign-redirect></ff-campaign-redirect>
-<ff-campaign-feedbacktext label="myfeedbackcampaign" unresolved>
-    {{{text}}}
-    <!--or mixed content-->
-    <!--<div>{{text}}</div>-->
-</ff-campaign-feedbacktext>

--- a/src/view/frontend/templates/ff/recommendation.phtml
+++ b/src/view/frontend/templates/ff/recommendation.phtml
@@ -3,7 +3,7 @@
 /** @var Omikron\Factfinder\ViewModel\ProductBasedComponent $viewModel */
 $viewModel = $block->getViewModel();
 ?>
-<ff-recommendation record-id="<?= $block->escapeHtmlAttr($viewModel->getProduct()->getSku()) ?>" unresolved>
+<ff-recommendation <?php if ($viewModel): ?>record-id="<?= $block->escapeHtmlAttr($viewModel->getProduct()->getSku()) ?>" <?php endif; ?>unresolved>
     <div class="block upsell" data-limit="0" data-shuffle="0">
         <div class="block-title title">
             <strong id="block-upsell-heading" role="heading" aria-level="2"><?= $block->escapeHtml(__('Recommendations')) ?></strong>
@@ -18,8 +18,7 @@ $viewModel = $block->getViewModel();
                                     <a href="{{record.ProductURL}}" class="product photo product-item-photo">
                                         <span class="product-image-container">
                                             <span class="product-image-wrapper">
-                                            <img class="product-image-photo" src="{{record.ImageURL}}" data-image="{{record.ImageURL}}"
-                                                 data-image-onerror="<?= $block->escapeUrl($viewModel->getProductImagePlaceholder()) ?>"/>
+                                                <img class="product-image-photo" alt="{{record.Name}} " data-image="{{record.ImageURL}}" />
                                             </span>
                                         </span>
                                     </a>


### PR DESCRIPTION
- Solves issue: FFWEB-1353
- Description: Add missing product campaign on product detail page
- Tested with Magento editions/versions: 2.3.2
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
