### PR TITLE
FFWEB-1367: Remove void return type from plugin target for BC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fixed
+- Fix log plugin compatibility with Magento 2.2.*
+
 ## [v1.3.0] - 2019.08.14
 ### Added
 - Add missing product campaigns on product detail page

--- a/src/Model/Api/Tracking.php
+++ b/src/Model/Api/Tracking.php
@@ -33,7 +33,7 @@ class Tracking
         $this->sessionData         = $sessionData;
     }
 
-    public function execute(string $event, TrackingProductInterface ...$trackingProducts): void
+    public function execute(string $event, TrackingProductInterface ...$trackingProducts)
     {
         $params = [
             'event'    => $event,


### PR DESCRIPTION
- Solves issue: FFWEB-1367
- Description: a `void` return target causes a fatal error in plugin target class. The issue is not present in M2 >= 2.3, but it can be easily solved for BC by removing the return type.
- Tested with Magento editions/versions: 2.2.5
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
