### PR TITLE
do not use self-closing tag

### DIFF
--- a/src/view/frontend/templates/ff/communication.phtml
+++ b/src/view/frontend/templates/ff/communication.phtml
@@ -4,7 +4,7 @@
 $viewModel  = $block->getViewModel();
 $parameters = ((array) $block->getData('communication_parameters')) + $viewModel->getParameters();
 ?>
-<ff-communication<?php foreach ($parameters as $key => $value) /* @noEscape */ echo sprintf(' %s="%s"', $key, $block->escapeHtmlAttr($value)) ?> />
+<ff-communication<?php foreach ($parameters as $key => $value) /* @noEscape */ echo sprintf(' %s="%s"', $key, $block->escapeHtmlAttr($value)) ?>></ff-communication>
 <!-- Set FieldRoles -->
 <script>
     document.addEventListener('ffReady', function () {


### PR DESCRIPTION
The current implementation of the `<ff-communication>` element causes the following HTML5 validation errors:

> Self-closing syntax (`/>`) used on a non-void HTML element. Ignoring the slash and treating as a start tag.

> End tag for `body` seen, but there were unclosed elements.

> Unclosed element `ff-communication`.