### PR TITLE
FFWEB-1367: Ensure compatibility with Magento 2.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## Unreleased
+## [v1.3.2] - 2019.08.30
 ### Fixed
 - Fix tracking model compatibility with Magento 2.2.*
 
@@ -152,6 +152,7 @@
 ### Added
 - Feed Export: Export feed file is now available via separate link
 
+[v1.3.2]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v1.3.2
 [v1.3.1]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v1.3.1
 [v1.3.0]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v1.3.0
 [v1.2.0]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fixed
+- Fix tracking model compatibility with Magento 2.2.*
+
 ## [v1.3.1] - 2019.08.19
 ### Fixed
 - Fix log plugin compatibility with Magento 2.2.*

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -43,6 +43,9 @@
             <property name="requiredSpacesBeforeColon" value="0" />
         </properties>
     </rule>
+    <rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace">
+        <exclude-pattern>*.phtml</exclude-pattern>
+    </rule>
     <rule ref="Squiz.Functions.GlobalFunction">
         <exclude-pattern>*Test.php</exclude-pattern>
     </rule>

--- a/src/Model/Api/Tracking.php
+++ b/src/Model/Api/Tracking.php
@@ -33,7 +33,11 @@ class Tracking
         $this->sessionData         = $sessionData;
     }
 
-    public function execute(string $event, TrackingProductInterface ...$trackingProducts)
+    /**
+     * @param string                     $event
+     * @param TrackingProductInterface[] $trackingProducts
+     */
+    public function execute(string $event, array $trackingProducts)
     {
         $params = [
             'event'    => $event,

--- a/src/Observer/Tracking/AddToCart.php
+++ b/src/Observer/Tracking/AddToCart.php
@@ -19,11 +19,11 @@ class AddToCart extends BaseTracking implements ObserverInterface
         $request = $observer->getData('request');
         $product = $observer->getData('product');
         $qty     = (int) ($request->getParam('qty') ?: 1);
-        $this->tracking->execute('cart', $this->trackingProductFactory->create([
+        $this->tracking->execute('cart', [$this->trackingProductFactory->create([
             'trackingNumber'      => $this->getProductData('trackingProductNumber', $product),
             'masterArticleNumber' => $this->getProductData('masterArticleNumber', $product),
             'price'               => $product->getFinalPrice($qty),
             'count'               => $qty,
-        ]));
+        ])]);
     }
 }

--- a/src/Observer/Tracking/Checkout.php
+++ b/src/Observer/Tracking/Checkout.php
@@ -30,6 +30,6 @@ class Checkout extends BaseTracking implements ObserverInterface
             ]);
         }, $cart->getAllVisibleItems());
 
-        $this->tracking->execute('checkout', ...$trackingProducts);
+        $this->tracking->execute('checkout', $trackingProducts);
     }
 }

--- a/src/Test/Unit/Model/Api/TrackingTest.php
+++ b/src/Test/Unit/Model/Api/TrackingTest.php
@@ -54,7 +54,7 @@ class TrackingTest extends TestCase
                 ],
             ]);
 
-        $this->tracking->execute('checkout', ...$trackingProducts);
+        $this->tracking->execute('checkout', $trackingProducts);
     }
 
     /**
@@ -68,7 +68,7 @@ class TrackingTest extends TestCase
             ->method('sendRequest')
             ->with($this->anything(), $this->logicalNot(new ArraySubset(['products' => [['userId' => 0]]])));
 
-        $this->tracking->execute('checkout', ...$trackingProducts);
+        $this->tracking->execute('checkout', $trackingProducts);
     }
 
     public function trackingProductProvider(): array

--- a/src/Test/Unit/Observer/AddToCartTest.php
+++ b/src/Test/Unit/Observer/AddToCartTest.php
@@ -67,7 +67,7 @@ class AddToCartTest extends TestCase
             ])->willReturn($this->createMock(TrackingProductInterface::class));
 
         $this->trackingMock->expects($this->once())->method('execute')
-            ->with($this->isType('string'), $this->isInstanceOf(TrackingProductInterface::class));
+            ->with($this->isType('string'), $this->containsOnlyInstancesOf(TrackingProductInterface::class));
 
         $this->addToCart->execute($this->observerMock);
     }

--- a/src/Test/Unit/Observer/CheckoutTest.php
+++ b/src/Test/Unit/Observer/CheckoutTest.php
@@ -45,7 +45,7 @@ class CheckoutTest extends TestCase
 
         $this->trackingMock->expects($this->once())
             ->method('execute')
-            ->with($this->isType('string'), $this->isInstanceOf(TrackingProductInterface::class));
+            ->with($this->isType('string'), $this->containsOnlyInstancesOf(TrackingProductInterface::class));
 
         $this->checkoutObserver->execute(new Observer(['quote' => $quoteMock]));
     }


### PR DESCRIPTION
- Solves issue: FFWEB-1367
- Description: Remove variadic argument from method signature
- Tested with Magento editions/versions: CE 2.2.5
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
