### PR TITLE
Add Console Command for exporting products

### DIFF
--- a/src/Console/Command/ExportProducts.php
+++ b/src/Console/Command/ExportProducts.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Console\Command;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\App\State;
+use Magento\Framework\Filesystem;
+use Omikron\Factfinder\Model\Api\PushImport;
+use Omikron\Factfinder\Model\Export\FeedFactory as FeedGeneratorFactory;
+use Omikron\Factfinder\Model\FtpUploader;
+use Omikron\Factfinder\Model\StoreEmulation;
+use Omikron\Factfinder\Model\Stream\CsvFactory;
+use Omikron\Factfinder\Model\Config\CommunicationConfig;
+
+class ExportProducts extends \Symfony\Component\Console\Command\Command
+{
+    /** @var ScopeConfigInterface */
+    private $scopeConfig;
+
+    /** @var StoreEmulation */
+    private $storeEmulation;
+
+    /** @var FeedGeneratorFactory */
+    private $feedGeneratorFactory;
+
+    /** @var StoreManagerInterface */
+    private $storeManager;
+
+    /** @var CommunicationConfig */
+    private $communicationConfig;
+
+    /** @var CsvFactory */
+    private $csvFactory;
+
+    /** @var FtpUploader */
+    private $ftpUploader;
+
+    /** @var string */
+    private $feedType;
+
+    /** @var PushImport */
+    private $pushImport;
+
+    /** @var State */
+    private $state;
+
+    /** @var Filesystem */
+    private $filesystem;
+
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        StoreManagerInterface $storeManager,
+        FeedGeneratorFactory $feedFactory,
+        StoreEmulation $emulation,
+        CsvFactory $csvFactory,
+        FtpUploader $ftpUploader,
+        CommunicationConfig $communicationConfig,
+        PushImport $pushImport,
+        State $state,
+        Filesystem $filesystem,
+        string $name = null)
+    {
+        $this->scopeConfig = $scopeConfig;
+        $this->storeManager = $storeManager;
+        $this->feedGeneratorFactory = $feedFactory;
+        $this->storeEmulation = $emulation;
+        $this->csvFactory = $csvFactory;
+        $this->ftpUploader = $ftpUploader;
+        $this->communicationConfig = $communicationConfig;
+        $this->pushImport = $pushImport;
+        $this->state = $state;
+        $this->filesystem = $filesystem;
+        parent::__construct($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('factfinder:export:products')->setDescription('Export Factfinder Product Data as CSV file');
+
+        $this->addOption('store', 's', InputOption::VALUE_OPTIONAL, 'Store ID or Store Code');
+        $this->addOption('skip-ftp-upload', null, InputOption::VALUE_OPTIONAL, 'Skip FTP Upload');
+        $this->addOption('skip-push-import', null, InputOption::VALUE_OPTIONAL, 'Skip Push Import');
+
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->state->setAreaCode('frontend');
+
+        if ($storeId = $input->getOption('store')) {
+            $storeIds = [$this->storeManager->getStore($storeId)->getId()];
+        } else {
+            $storeIds = array_map(
+                function ($store) {
+                    return $store->getId();
+                },
+                $this->storeManager->getStores()
+            );
+        }
+        foreach ($storeIds as $storeId) {
+            $this->storeEmulation->runInStore(
+                (int)$storeId,
+                function () use ($storeId, $input, $output) {
+                    if ($this->communicationConfig->isChannelEnabled((int)$storeId)) {
+                        $filename = "export.{$this->communicationConfig->getChannel()}.csv";
+                        $stream = $this->csvFactory->create(['filename' => "factfinder/{$filename}"]);
+                        $this->feedGeneratorFactory->create('product')->generate($stream);
+                        $path = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR)
+                            ->getAbsolutePath('factfinder' . DIRECTORY_SEPARATOR . $filename);
+                        $output->writeln("Store $storeId: File $path has been generated.");
+                        if (!$input->getOption('skip-ftp-upload')
+                            && $this->scopeConfig->getValue('factfinder/data_transfer/ff_upload_host')) {
+                            $this->ftpUploader->upload($filename, $stream);
+                            $output->writeln("Store $storeId: File $filename has been uploaded to FTP.");
+                        }
+                        if (!$input->getOption('skip-push-import')) {
+                            if ($this->pushImport->execute((int)$storeId)) {
+                                $output->writeln("Store $storeId: Push Import for File $filename has been triggered.");
+                            }
+                        }
+                    }
+                }
+            );
+        }
+    }
+}

--- a/src/Console/Command/ExportProducts.php
+++ b/src/Console/Command/ExportProducts.php
@@ -41,9 +41,6 @@ class ExportProducts extends \Symfony\Component\Console\Command\Command
     /** @var FtpUploader */
     private $ftpUploader;
 
-    /** @var string */
-    private $feedType;
-
     /** @var PushImport */
     private $pushImport;
 
@@ -63,9 +60,9 @@ class ExportProducts extends \Symfony\Component\Console\Command\Command
         CommunicationConfig $communicationConfig,
         PushImport $pushImport,
         State $state,
-        Filesystem $filesystem,
-        string $name = null)
-    {
+        Filesystem $filesystem
+    ) {
+        parent::__construct();
         $this->scopeConfig = $scopeConfig;
         $this->storeManager = $storeManager;
         $this->feedGeneratorFactory = $feedFactory;
@@ -76,7 +73,6 @@ class ExportProducts extends \Symfony\Component\Console\Command\Command
         $this->pushImport = $pushImport;
         $this->state = $state;
         $this->filesystem = $filesystem;
-        parent::__construct($name);
     }
 
     /**

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -209,4 +209,11 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\Console\CommandListInterface">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="omikron_factfinder_export_products" xsi:type="object">Omikron\Factfinder\Console\Command\ExportProducts</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
- Description: Adds a console command "factfinder:export:products" for exporting products to CSV file. This is especially useful during development, but maybe also for custom exporting strategies. You can define a store view too if you want.
- Tested with Magento editions/versions: 2.3.2 Commerce
- Tested with PHP versions: 7.1.26

