### PR TITLE
Fix server address not being retrieved from store specific configuration

### DIFF
--- a/src/Model/Config/CommunicationConfig.php
+++ b/src/Model/Config/CommunicationConfig.php
@@ -40,7 +40,7 @@ class CommunicationConfig implements CommunicationConfigInterface, ParametersSou
 
     public function getAddress(): string
     {
-        return (string) $this->scopeConfig->getValue(self::PATH_ADDRESS);
+        return (string) $this->scopeConfig->getValue(self::PATH_ADDRESS, ScopeInterface::SCOPE_STORES);
     }
 
     public function isChannelEnabled(int $scopeId = null): bool


### PR DESCRIPTION
- Solves issue: Server address is always taken from global configuration, not from store specific or website specific configuration
- Description: Added "stores" parameter to ScopeConfig::getValue()
- Tested with Magento editions/versions: 2.3.2 Commerce
- Tested with PHP versions: 7.1.26

