### PR TITLE
FFWEB-1374 : Fix merge communication parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fixed
+- Correctly merge communication params added via layout
+
 ## [v1.3.2] - 2019.08.30
 ### Fixed
 - Fix tracking model compatibility with Magento 2.2.*

--- a/src/Test/Unit/Model/Export/Cms/Field/ImageTest.php
+++ b/src/Test/Unit/Model/Export/Cms/Field/ImageTest.php
@@ -25,7 +25,7 @@ class ImageTest extends TestCase
         $pageMock = $this->createConfiguredMock(PageInterface::class, ['getContent' => $this->content]);
         $imageUrl = $this->imageField->getValue($pageMock);
 
-        $this->assertEquals('http://magento-test.factfinder.de/media/image/cms.png', $imageUrl);
+        $this->assertSame('http://magento-test.factfinder.de/media/image/cms.png', $imageUrl);
     }
 
     protected function setUp()

--- a/src/Test/Unit/Model/FieldRolesTest.php
+++ b/src/Test/Unit/Model/FieldRolesTest.php
@@ -68,8 +68,8 @@ class FieldRolesTest extends TestCase
         ]);
         $brandAttributeValue  = $this->fieldRoles->fieldRoleToAttribute($productMock, 'brand');
         $masterAttributeValue = $this->fieldRoles->fieldRoleToAttribute($productMock, 'masterArticleNumber');
-        $this->assertEquals('Product brand', $brandAttributeValue);
-        $this->assertEquals('sku-1', $masterAttributeValue);
+        $this->assertSame('Product brand', $brandAttributeValue);
+        $this->assertSame('sku-1', $masterAttributeValue);
     }
 
     protected function setUp()

--- a/src/Test/Unit/ViewModel/CommunicationTest.php
+++ b/src/Test/Unit/ViewModel/CommunicationTest.php
@@ -26,13 +26,6 @@ class CommunicationTest extends TestCase
 
     public function test_get_parameters_filter_null_values()
     {
-        $this->parametersProviderMock->method('getParameters')->willReturn([
-            'url'       => 'http://some-url',
-            'version'   => '7.3',
-            'user-id'   => null,
-            'channel'   => 'some-channel',
-            'use-cache' => 'true'
-        ]);
         $this->assertArrayNotHasKey('user-sid', $this->communication->getParameters());
     }
 
@@ -42,7 +35,7 @@ class CommunicationTest extends TestCase
         $parameters  = $this->communication->getParameters($blockParams);
 
         $this->assertArrayHasKey('add-params', $parameters);
-        $this->assertEquals('param1=123,param2=abc', $parameters['add-params']);
+        $this->assertSame('param1=123,param2=abc', $parameters['add-params']);
     }
 
     public function test_multiple_boolean_values_will_be_overwritten()
@@ -51,7 +44,7 @@ class CommunicationTest extends TestCase
         $parameters  = $this->communication->getParameters($blockParams);
 
         $this->assertArrayHasKey('use-cache', $parameters);
-        $this->assertEquals('false', $parameters['use-cache']);
+        $this->assertSame('false', $parameters['use-cache']);
     }
 
     protected function setUp()

--- a/src/Test/Unit/ViewModel/CommunicationTest.php
+++ b/src/Test/Unit/ViewModel/CommunicationTest.php
@@ -27,13 +27,31 @@ class CommunicationTest extends TestCase
     public function test_get_parameters_filter_null_values()
     {
         $this->parametersProviderMock->method('getParameters')->willReturn([
-            'url'     => 'http://some-url',
-            'version' => '7.3',
-            'user-id' => null,
-            'channel' => 'some-channel',
+            'url'       => 'http://some-url',
+            'version'   => '7.3',
+            'user-id'   => null,
+            'channel'   => 'some-channel',
+            'use-cache' => 'true'
         ]);
-
         $this->assertArrayNotHasKey('user-sid', $this->communication->getParameters());
+    }
+
+    public function test_get_parameters_will_implode_arrays()
+    {
+        $blockParams = ['add-params' => 'param1=123'];
+        $parameters  = $this->communication->getParameters($blockParams);
+
+        $this->assertArrayHasKey('add-params', $parameters);
+        $this->assertEquals('param1=123,param2=abc', $parameters['add-params']);
+    }
+
+    public function test_multiple_boolean_values_will_be_overwritten()
+    {
+        $blockParams = ['use-cache' => 'false'];
+        $parameters  = $this->communication->getParameters($blockParams);
+
+        $this->assertArrayHasKey('use-cache', $parameters);
+        $this->assertEquals('false', $parameters['use-cache']);
     }
 
     protected function setUp()
@@ -41,6 +59,15 @@ class CommunicationTest extends TestCase
         $this->parametersProviderMock = $this->createMock(CommunicationParametersProvider::class);
         $this->fieldRolesMock         = $this->createMock(FieldRolesInterface::class);
         $this->serializerMock         = $this->createMock(SerializerInterface::class);
+
+        $this->parametersProviderMock->method('getParameters')->willReturn([
+            'url'        => 'http://some-url',
+            'version'    => '7.3',
+            'user-id'    => null,
+            'channel'    => 'some-channel',
+            'use-cache'  => 'true',
+            'add-params' => 'param2=abc',
+        ]);
 
         $this->communication = new Communication(
             $this->fieldRolesMock,

--- a/src/ViewModel/Communication.php
+++ b/src/ViewModel/Communication.php
@@ -39,7 +39,7 @@ class Communication implements ArgumentInterface
 
     public function getFieldRoles(): string
     {
-        return (string)$this->serializer->serialize($this->fieldRoles->getFieldRoles());
+        return (string) $this->serializer->serialize($this->fieldRoles->getFieldRoles());
     }
 
     private function mergeParameters(array $params): string

--- a/src/ViewModel/Communication.php
+++ b/src/ViewModel/Communication.php
@@ -30,13 +30,20 @@ class Communication implements ArgumentInterface
         $this->serializer         = $serializer;
     }
 
-    public function getParameters(): array
+    public function getParameters(array $blockParams = []): array
     {
-        return array_filter($this->parametersProvider->getParameters(), 'boolval');
+        return array_map(function ($element) {
+            return is_array($element) ? $this->mergeParameters($element) : $element;
+        }, array_filter(array_merge_recursive($blockParams, $this->parametersProvider->getParameters()), 'boolval'));
     }
 
     public function getFieldRoles(): string
     {
-        return (string) $this->serializer->serialize($this->fieldRoles->getFieldRoles());
+        return (string)$this->serializer->serialize($this->fieldRoles->getFieldRoles());
+    }
+
+    private function mergeParameters(array $params): string
+    {
+        return !empty(array_intersect(['true', 'false'], $params)) ? $params[0] : implode(',', $params);
     }
 }

--- a/src/view/frontend/templates/ff/communication.phtml
+++ b/src/view/frontend/templates/ff/communication.phtml
@@ -2,7 +2,7 @@
 /** @var Magento\Framework\View\Element\Template $block */
 /** @var Omikron\Factfinder\ViewModel\Communication $viewModel */
 $viewModel  = $block->getViewModel();
-$parameters = ((array) $block->getData('communication_parameters')) + $viewModel->getParameters();
+$parameters = $viewModel->getParameters((array) $block->getData('communication_parameters'));
 ?>
 <ff-communication<?php foreach ($parameters as $key => $value) /* @noEscape */ echo sprintf(' %s="%s"', $key, $block->escapeHtmlAttr($value)) ?>></ff-communication>
 <!-- Set FieldRoles -->


### PR DESCRIPTION
- Solves issue: 
 Connection parameters passed from config and from layout are now correctly merged
- Description: 
Previously communication parameters are merged using array + operator which makes the values from first array were taken and from second were ommited.  Right now parameters with string values are merged (separated by comma) and in case of boolean values, the value passed from layout is taken.  This could be observed while using custom 'add-params' values while navigating to category page
- Tested with Magento editions/versions: 
2.3.2
- Tested with PHP versions: 
7.1

