### PR TITLE
Only add products to index which are active in current store.

### DIFF
--- a/src/Model/Export/Catalog/Products.php
+++ b/src/Model/Export/Catalog/Products.php
@@ -9,6 +9,7 @@ use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Store\Model\StoreManagerInterface;
 
 class Products implements \IteratorAggregate
 {
@@ -18,16 +19,21 @@ class Products implements \IteratorAggregate
     /** @var SearchCriteriaBuilder */
     private $searchCriteriaBuilder;
 
+    /** @var StoreManagerInterface */
+    private $storeManager;
+
     /** @var int */
     private $batchSize;
 
     public function __construct(
         ProductRepositoryInterface $productRepository,
         SearchCriteriaBuilder $searchCriteriaBuilder,
+        StoreManagerInterface $storeManager,
         int $batchSize = 300
     ) {
         $this->productRepository     = $productRepository;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->storeManager          = $storeManager;
         $this->batchSize             = $batchSize;
     }
 
@@ -52,6 +58,7 @@ class Products implements \IteratorAggregate
     {
         return $this->searchCriteriaBuilder
             ->addFilter('status', Status::STATUS_ENABLED)
+            ->addFilter('store_id', $this->storeManager->getStore()->getId())
             ->addFilter('visibility', Visibility::VISIBILITY_NOT_VISIBLE, 'neq')
             ->setPageSize($this->batchSize)
             ->setCurrentPage($page);


### PR DESCRIPTION
- Solves issue: 
Products which do not belong to a website are being indexed and thus show up in the search results with invalid links

- Description: 
This PR adds a filter for the current store to the product collection used for indexing

- Tested with Magento editions/versions: 
Magento Commerce 2.3.2

- Tested with PHP versions: 
7.1.26