### PR TITLE
Provide fallback data provider for custom product types

### DIFF
--- a/src/Model/Export/Catalog/DataProvider.php
+++ b/src/Model/Export/Catalog/DataProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Export\Catalog;
 
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product\Type;
 use Magento\Framework\ObjectManagerInterface;
 use Omikron\Factfinder\Api\Export\DataProviderInterface;
 use Omikron\Factfinder\Api\Export\ExportEntityInterface;
@@ -40,6 +41,7 @@ class DataProvider implements DataProviderInterface
 
     private function entitiesFrom(ProductInterface $product): DataProviderInterface
     {
-        return $this->objectManager->create($this->entityTypes[$product->getTypeId()], ['product' => $product]); // phpcs:ignore
+        $type = $this->entityTypes[$product->getTypeId()] ?? $this->entityTypes[Type::DEFAULT_TYPE];
+        return $this->objectManager->create($type, ['product' => $product]); // phpcs:ignore
     }
 }

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -128,8 +128,6 @@
         <arguments>
             <argument name="entityTypes" xsi:type="array">
                 <item name="simple" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProvider</item>
-                <item name="virtual" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProvider</item>
-                <item name="downloadable" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProvider</item>
                 <item name="configurable" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\ConfigurableDataProvider</item>
                 <item name="grouped" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\GroupedDataProvider</item>
                 <item name="bundle" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\BundleDataProvider</item>


### PR DESCRIPTION
- Description: When using custom product types, the export will break because a corresponding DataProvider is missing. Avoid errors by instantiating the SimpleDataProvider as a fallback instead
- Tested with Magento editions/versions: 2.3.2
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
