### PR TITLE
Prevent search request before redirecting to result page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Fixed
 - Correctly merge communication params added via layout
+- Prevent search request before redirecting to search result page
 
 ## [v1.3.2] - 2019.08.30
 ### Fixed

--- a/src/view/frontend/web/js/search-navigation.js
+++ b/src/view/frontend/web/js/search-navigation.js
@@ -3,6 +3,7 @@ define(['factfinder', 'mage/url'], function (factfinder, url) {
 
     factfinder.communication.FFCommunicationEventAggregator.addBeforeDispatchingCallback(function (event) {
         if (event.type === 'search' && !isSearchResultPage()) {
+            delete event.type;
             var params = factfinder.common.dictToParameterString(event);
             if (!url.build('')) url.setBaseUrl(BASE_URL || '');
             window.location = url.build(redirectPath + params);


### PR DESCRIPTION
- Solves issue: FFCSPV2-2070
- Description: A search request is accidentally triggered before redirecting a search to the search result page. This PR fixes this issue
- Tested with Magento editions/versions: 2.3.3
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
