### PR TITLE
Check current configuration before switching layout on category pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Fixed
 - The ASN is now compatible with IE11
+- Check current configuration before switching layout on category pages
 
 ## [v1.3.3] - 2019.10.21
 ### Changed

--- a/src/Model/Config/FeatureConfig.php
+++ b/src/Model/Config/FeatureConfig.php
@@ -6,22 +6,28 @@ namespace Omikron\Factfinder\Model\Config;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
+use Omikron\Factfinder\Api\Config\CommunicationConfigInterface;
 use Omikron\Factfinder\Api\Config\FeatureConfigInterface;
 
 class FeatureConfig implements FeatureConfigInterface
 {
-    private const CONFIG_PATH_USE_FOR_CATEGORIES = 'factfinder/general/use_for_categories';
+    private const PATH_USE_FOR_CATEGORIES = 'factfinder/general/use_for_categories';
+
+    /** @var CommunicationConfigInterface */
+    private $communicationConfig;
 
     /** @var ScopeConfigInterface */
-    private $config;
+    private $scopeConfig;
 
-    public function __construct(ScopeConfigInterface $config)
+    public function __construct(ScopeConfigInterface $scopeConfig, CommunicationConfigInterface $communicationConfig)
     {
-        $this->config = $config;
+        $this->scopeConfig         = $scopeConfig;
+        $this->communicationConfig = $communicationConfig;
     }
 
     public function useForCategories(): bool
     {
-        return $this->config->isSetFlag(self::CONFIG_PATH_USE_FOR_CATEGORIES, ScopeInterface::SCOPE_STORES);
+        return $this->communicationConfig->isChannelEnabled()
+            && $this->scopeConfig->isSetFlag(self::PATH_USE_FOR_CATEGORIES, ScopeInterface::SCOPE_STORES);
     }
 }

--- a/src/Test/Unit/Model/Config/FeatureConfigTest.php
+++ b/src/Test/Unit/Model/Config/FeatureConfigTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Model\Config;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+use Omikron\Factfinder\Api\Config\CommunicationConfigInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class FeatureConfigTest extends TestCase
+{
+    /** @var FeatureConfig */
+    private $testee;
+
+    /** @var ScopeConfigInterface|MockObject */
+    private $scopeConfig;
+
+    /** @var CommunicationConfigInterface|MockObject */
+    private $communicationConfig;
+
+    /**
+     * @testdox Categories should be rendered with FACT-Finder only if the integration AND the feature are active
+     * @testWith [false, false, false]
+     *           [true, false, false]
+     *           [false, true, false]
+     *           [true, true, true]
+     */
+    public function test_use_for_categories(bool $generalConfig, bool $featureConfig, bool $expected)
+    {
+        $this->communicationConfig->method('isChannelEnabled')->willReturn($generalConfig);
+        $this->scopeConfig->method('isSetFlag')
+            ->with('factfinder/general/use_for_categories', ScopeInterface::SCOPE_STORES)
+            ->willReturn($featureConfig);
+
+        $this->assertSame($expected, $this->testee->useForCategories());
+    }
+
+    protected function setUp()
+    {
+        $this->scopeConfig         = $this->createMock(ScopeConfigInterface::class);
+        $this->communicationConfig = $this->createMock(CommunicationConfigInterface::class);
+
+        $this->testee = new FeatureConfig($this->scopeConfig, $this->communicationConfig);
+    }
+}


### PR DESCRIPTION
- Description: Even with FF disabled the layout switch on category pages would take place
- Tested with Magento editions/versions: 2.3
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
