### PR TITLE
FFWEB-1411: Prevent login tracking duplication after customer landed on dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FACT-Finder® Web Components for Magento 2
 
-![Packagist Version](https://img.shields.io/packagist/v/omikron/magento2-factfinder)
-![GitHub contributors](https://img.shields.io/github/contributors/FACT-Finder-Web-Components/magento2-module)
+[![Packagist Version](https://img.shields.io/packagist/v/omikron/magento2-factfinder)](https://packagist.org/packages/omikron/magento2-factfinder)
+[![GitHub contributors](https://img.shields.io/github/contributors/FACT-Finder-Web-Components/magento2-module)](https://github.com/FACT-Finder-Web-Components/magento2-module/graphs/contributors)
 [![Build Status](https://travis-ci.org/FACT-Finder-Web-Components/magento2-module.svg?branch=develop)](https://travis-ci.org/FACT-Finder-Web-Components/magento2-module)
 
 This document helps you integrate the FACT-Finder Web Components SDK into your Magento 2 Shop. In addition, it gives a

--- a/src/Controller/Proxy/Call.php
+++ b/src/Controller/Proxy/Call.php
@@ -4,17 +4,21 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\Controller\Proxy;
 
-use Magento\Framework\App\Action\Context;
-use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\App\Action;
+use Magento\Framework\Controller\Result\JsonFactory as JsonResultFactory;
+use Magento\Framework\Controller\Result\RawFactory as RawResultFactory;
 use Magento\Framework\Exception\NotFoundException;
 use Omikron\Factfinder\Api\ClientInterface;
 use Omikron\Factfinder\Api\Config\CommunicationConfigInterface;
 use Omikron\Factfinder\Exception\ResponseException;
 
-class Call extends \Magento\Framework\App\Action\Action
+class Call extends Action\Action
 {
-    /** @var JsonFactory */
+    /** @var JsonResultFactory */
     private $jsonResultFactory;
+
+    /** @var RawResultFactory */
+    private $rawResultFactory;
 
     /** @var ClientInterface */
     private $apiClient;
@@ -23,13 +27,15 @@ class Call extends \Magento\Framework\App\Action\Action
     private $communicationConfig;
 
     public function __construct(
-        Context $context,
-        JsonFactory $jsonResultFactory,
+        Action\Context $context,
+        JsonResultFactory $jsonResultFactory,
+        RawResultFactory $rawResultFactory,
         ClientInterface $apiClient,
         CommunicationConfigInterface $communicationConfig
     ) {
         parent::__construct($context);
         $this->jsonResultFactory   = $jsonResultFactory;
+        $this->rawResultFactory    = $rawResultFactory;
         $this->apiClient           = $apiClient;
         $this->communicationConfig = $communicationConfig;
     }
@@ -53,7 +59,7 @@ class Call extends \Magento\Framework\App\Action\Action
             ]);
             $result->setData($response);
         } catch (ResponseException $e) {
-            $result->setJsonData($e->getMessage());
+            return $this->rawResultFactory->create()->setContents($e->getMessage());
         }
 
         return $result;

--- a/src/etc/frontend/di.xml
+++ b/src/etc/frontend/di.xml
@@ -21,7 +21,6 @@
     <type name="Omikron\Factfinder\Model\Config\CommunicationParametersProvider">
         <arguments>
             <argument name="parametersSource" xsi:type="array">
-                <item name="user" xsi:type="object">Omikron\Factfinder\Model\SessionData</item>
                 <item name="communication" xsi:type="object">Omikron\Factfinder\Model\Config\CommunicationConfig</item>
                 <item name="behaviour" xsi:type="object">Omikron\Factfinder\Model\Config\Communication\BehaviourConfig</item>
                 <item name="personalization" xsi:type="object">Omikron\Factfinder\Model\Config\Communication\PersonalizationConfig</item>

--- a/src/view/frontend/templates/ff/communication.phtml
+++ b/src/view/frontend/templates/ff/communication.phtml
@@ -11,7 +11,6 @@ $parameters = $viewModel->getParameters((array) $block->getData('communication_p
         factfinder.communication.fieldRoles = <?= /* @noEscape */ $viewModel->getFieldRoles() ?>;
     });
 </script>
-<div data-bind="scope: 'ffcommunication'"></div>
 <script type="text/x-magento-init">
     {
         "ff-communication": {

--- a/src/view/frontend/templates/ff/communication.phtml
+++ b/src/view/frontend/templates/ff/communication.phtml
@@ -14,14 +14,8 @@ $parameters = $viewModel->getParameters((array) $block->getData('communication_p
 <div data-bind="scope: 'ffcommunication'"></div>
 <script type="text/x-magento-init">
     {
-        "*": {
-            "Magento_Ui/js/core/app": {
-                "components": {
-                    "ffcommunication": {
-                        "component": "Omikron_Factfinder/js/view/ffcommunication"
-                    }
-                }
-            }
+        "ff-communication": {
+            "Omikron_Factfinder/js/view/ffcommunication": {}
         }
     }
 </script>

--- a/src/view/frontend/web/js/view/ffcommunication.js
+++ b/src/view/frontend/web/js/view/ffcommunication.js
@@ -1,31 +1,13 @@
-define([
-    'uiComponent',
-    'Magento_Customer/js/customer-data',
-    'jquery'
-], function (Component, customerData, $) {
+define(['Magento_Customer/js/customer-data'], function (customerData) {
     'use strict';
 
-    return Component.extend({
-        /** @inheritdoc */
-        initialize: function () {
-            this._super();
-            var cacheKey               = 'ffcommunication',
-                communicationData      = customerData.get('ffcommunication')(),
-                communicationComponent = $('ff-communication');
-
-            if (!communicationData.loggedIn && !communicationComponent.attr('user-id')) {
-                customerData.reload([cacheKey]).done(function (result) {
-                    var communicationComponent = $('ff-communication'),
-                        uid = result.ffcommunication.uid,
-                        sid = result.ffcommunication.sid;
-
-                    communicationComponent.attr('sid', sid);
-                    if (!!uid) {
-                        communicationComponent.attr('user-id', uid);
-                        customerData.set(cacheKey, Object.assign({loggedIn: true}, result.ffcommunication));
-                    }
-                });
-            }
-        }
-    });
+    return function (config, element) {
+        var sessionData = customerData.get('ffcommunication');
+        sessionData.subscribe(function (data) {
+            if (!data.uid) return;
+            element.userId = data.uid;
+            element.sid = data.sid;
+        });
+        sessionData.valueHasMutated();
+    };
 });

--- a/src/view/frontend/web/js/view/ffcommunication.js
+++ b/src/view/frontend/web/js/view/ffcommunication.js
@@ -5,8 +5,8 @@ define(['Magento_Customer/js/customer-data'], function (customerData) {
         var sessionData = customerData.get('ffcommunication');
         sessionData.subscribe(function (data) {
             if (!data.uid) return;
-            element.userId = data.uid;
             element.sid = data.sid;
+            element.userId = data.uid;
         });
         sessionData.valueHasMutated();
     };

--- a/src/view/frontend/web/js/view/ffcommunication.js
+++ b/src/view/frontend/web/js/view/ffcommunication.js
@@ -9,16 +9,23 @@ define([
         /** @inheritdoc */
         initialize: function () {
             this._super();
-            customerData.reload(['ffcommunication']).done(function (result) {
-                var communication = $('ff-communication'),
-                    uid = result.ffcommunication.uid,
-                    sid = result.ffcommunication.sid;
+            var cacheKey               = 'ffcommunication',
+                communicationData      = customerData.get('ffcommunication')(),
+                communicationComponent = $('ff-communication');
 
-                communication.attr('sid', sid);
-                if (!!uid) {
-                    communication.attr('user-id', uid);
-                }
-            });
+            if (!communicationData.loggedIn && !communicationComponent.attr('user-id')) {
+                customerData.reload([cacheKey]).done(function (result) {
+                    var communicationComponent = $('ff-communication'),
+                        uid = result.ffcommunication.uid,
+                        sid = result.ffcommunication.sid;
+
+                    communicationComponent.attr('sid', sid);
+                    if (!!uid) {
+                        communicationComponent.attr('user-id', uid);
+                        customerData.set(cacheKey, Object.assign({loggedIn: true}, result.ffcommunication));
+                    }
+                });
+            }
         }
     });
 });


### PR DESCRIPTION
- Description:
  Once user-id attribute is set, Web Components sends a request with login tracking. At the moment user id is set sever side by SessionData Parameter provider and also by additional script ffcommunication.js which download current user-id by ajax.
Both approaches are required since,  the block containing ff-communication component is  cached, and after returning to home page after logging in won't affect the ff-communication state (because of cache). So the ffcommunication.js bypassing that with its ajax call for user-id. However if user is redirected to dashboard after logging in, the communication won't be served from cache, but it will be rendered , now containing the user-id attribute. This cause login tracking is fired, and then the ffcommunication.js download the same user-id from the server and also trigger the logging. Which is unnecessary duplication. This change added additional checks to ffcommunication.js which should prevent tracking duplication in described case

- Tested with Magento editions/versions: 
2.3.3
- Tested with PHP versions:
7.1 
