### PR TITLE
Prevent errors during connection test when fields are disabled

### DIFF
--- a/src/Controller/Adminhtml/TestConnection/TestConnection.php
+++ b/src/Controller/Adminhtml/TestConnection/TestConnection.php
@@ -6,7 +6,10 @@ namespace Omikron\Factfinder\Controller\Adminhtml\TestConnection;
 
 use Magento\Backend\App\Action;
 use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\Phrase;
 use Omikron\Factfinder\Api\Config\AuthConfigInterface;
+use Omikron\Factfinder\Api\Config\CommunicationConfigInterface;
+use Omikron\Factfinder\Exception\ResponseException;
 use Omikron\Factfinder\Model\Api\CredentialsFactory;
 use Omikron\Factfinder\Model\Api\TestConnection as ApiConnectionTest;
 
@@ -27,29 +30,35 @@ class TestConnection extends Action
     /** @var AuthConfigInterface */
     private $authConfig;
 
+    /** @var CommunicationConfigInterface */
+    private $communicationConfig;
+
     public function __construct(
         Action\Context $context,
         JsonFactory $jsonResultFactory,
         CredentialsFactory $credentialsFactory,
         AuthConfigInterface $authConfig,
+        CommunicationConfigInterface $communicationConfig,
         ApiConnectionTest $testConnection
     ) {
         parent::__construct($context);
-        $this->jsonResultFactory  = $jsonResultFactory;
-        $this->credentialsFactory = $credentialsFactory;
-        $this->testConnection     = $testConnection;
-        $this->authConfig         = $authConfig;
+        $this->jsonResultFactory   = $jsonResultFactory;
+        $this->credentialsFactory  = $credentialsFactory;
+        $this->testConnection      = $testConnection;
+        $this->authConfig          = $authConfig;
+        $this->communicationConfig = $communicationConfig;
     }
 
     public function execute()
     {
-        $message = __('Connection successfully established.');
+        $message = new Phrase('Connection successfully established.');
 
         try {
-            $request = $this->getRequest();
-            $params  = $this->getCredentials($request->getParams()) + ['channel' => $request->getParam('channel')];
-            $this->testConnection->execute($request->getParam('address'), $params);
-        } catch (\Exception $e) {
+            $request   = $this->getRequest();
+            $params    = $this->getCredentials($request->getParams()) + ['channel' => $request->getParam('channel')];
+            $serverUrl = $request->getParam('address', $this->communicationConfig->getAddress());
+            $this->testConnection->execute($serverUrl, $params);
+        } catch (ResponseException $e) {
             $message = $e->getMessage();
         }
 
@@ -59,13 +68,13 @@ class TestConnection extends Action
     private function getCredentials(array $params): array
     {
         // The password wasn't edited, load it from config
-        if ($params['password'] === $this->obscuredValue) {
+        if (!isset($params['password']) || $params['password'] === $this->obscuredValue) {
             $params['password'] = $this->authConfig->getPassword();
         }
 
         $params += [
-            'prefix'  => $params['authentication_prefix'],
-            'postfix' => $params['authentication_postfix'],
+            'prefix'  => $params['authentication_prefix'] ?? $this->authConfig->getAuthenticationPrefix(),
+            'postfix' => $params['authentication_postfix'] ?? $this->authConfig->getAuthenticationPostfix(),
         ];
         return $this->credentialsFactory->create($params)->toArray();
     }

--- a/src/Test/Unit/Controller/Adminhtml/TestConnection/TestConnectionTest.php
+++ b/src/Test/Unit/Controller/Adminhtml/TestConnection/TestConnectionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Controller\Adminhtml\TestConnection;
+
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\Result\Json as JsonResult;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Omikron\Factfinder\Api\Config\AuthConfigInterface;
+use Omikron\Factfinder\Api\Config\CommunicationConfigInterface;
+use Omikron\Factfinder\Model\Api\Credentials;
+use Omikron\Factfinder\Model\Api\CredentialsFactory;
+use Omikron\Factfinder\Model\Api\TestConnection as ApiConnectionTest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class TestConnectionTest extends TestCase
+{
+    /** @var TestConnection */
+    private $controller;
+
+    /** @var MockObject|RequestInterface */
+    private $request;
+
+    public function test_prevent_errors_without_post_data()
+    {
+        $this->request->method('getParam')->willReturn('foobar');
+        $this->request->method('getParams')->willReturn([]);
+        $this->controller->execute();
+        $this->assertNull($this->getExpectedException());
+    }
+
+    protected function setUp()
+    {
+        $credentialsFactory = $this->getMockBuilder(CredentialsFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $credentialsFactory->method('create')->willReturn($this->createMock(Credentials::class));
+
+        $this->request = $this->createMock(RequestInterface::class);
+
+        $this->controller = new TestConnection(
+            $this->createConfiguredMock(Context::class, ['getRequest' => $this->request]),
+            $this->createConfiguredMock(JsonFactory::class, ['create' => $this->createMock(JsonResult::class)]),
+            $credentialsFactory,
+            $this->createMock(AuthConfigInterface::class),
+            $this->createMock(CommunicationConfigInterface::class),
+            $this->createMock(ApiConnectionTest::class)
+        );
+    }
+}


### PR DESCRIPTION
- Description: When backend fields are disabled (e.g. prod mode when config is locked in the env.php) no POST data is sent for those values. Provide default values when this happens.
- Tested with Magento editions/versions: 2.3
- Tested with PHP versions: >=7.1

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
