### PR TITLE
Enable translations in store emulation

### DIFF
--- a/src/Model/StoreEmulation.php
+++ b/src/Model/StoreEmulation.php
@@ -28,8 +28,8 @@ class StoreEmulation
         try {
             $this->emulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
 
-            $area = $this->areaList->getArea(\Magento\Framework\App\Area::AREA_FRONTEND);
-            $area->load(\Magento\Framework\App\Area::PART_TRANSLATE);
+            $area = $this->areaList->getArea(Area::AREA_FRONTEND);
+            $area->load(Area::PART_TRANSLATE);
 
             $proceed();
         } finally {

--- a/src/Model/StoreEmulation.php
+++ b/src/Model/StoreEmulation.php
@@ -5,22 +5,32 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model;
 
 use Magento\Framework\App\Area;
+use Magento\Framework\App\AreaList;
 use Magento\Store\Model\App\Emulation;
 
 class StoreEmulation
 {
     /** @var Emulation */
     private $emulation;
+    /**
+     * @var AreaList
+     */
+    private $areaList;
 
-    public function __construct(Emulation $emulation)
+    public function __construct(Emulation $emulation, AreaList $areaList)
     {
         $this->emulation = $emulation;
+        $this->areaList = $areaList;
     }
 
     public function runInStore(int $storeId, callable $proceed)
     {
         try {
             $this->emulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
+
+            $area = $this->areaList->getArea(\Magento\Framework\App\Area::AREA_FRONTEND);
+            $area->load(\Magento\Framework\App\Area::PART_TRANSLATE);
+
             $proceed();
         } finally {
             $this->emulation->stopEnvironmentEmulation();


### PR DESCRIPTION
- Solves issue: If you use the Magento translation function `__` in an exported field, translation didn't work if you started the export from the command line.
- Tested with Magento editions/versions: 2.3.3 Commerce
- Tested with PHP versions: 7.1.26

