### PR TITLE
Update Attributes.php

### DIFF
--- a/src/Model/Export/Catalog/ProductField/Attributes.php
+++ b/src/Model/Export/Catalog/ProductField/Attributes.php
@@ -73,6 +73,9 @@ class Attributes implements ProductFieldInterface
                 $values = (array) $product->getAttributeText($attribute->getAttributeCode());
                 break;
             default:
+                if(is_array($value)) {
+                    return [];
+                }
                 $values[] = (string) $value;
                 break;
         }


### PR DESCRIPTION

- Solves issue: 
Preventing an issue when adding to cart in M2, when array to string conversion error occured when hitting the default switch.

- Description: 
The fix was to make the returns from the default switch more uniform and prevent an exception being thrown, when unexpected data is passed through.

- Tested with Magento editions/versions: 
Magento Enterprise 2.3.2

- Tested with PHP versions: 
7.2.14