### PR TITLE
Extend proxy path match to include rest API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 - Upgrade Web Components to v3.10.1
 
 ### Fixed
-- Prevent duplicate login tracking when customer data is reloaded
+- Fix handling of REST calls via proxy
 - Fix sorting of campaign blocks on search result page
+- Fix tracking of products with options and submit correct master ID
+- Prevent duplicate login tracking when customer data is reloaded
 
 ## [v1.3.4] - 2019.11.08
 ### Added

--- a/src/Controller/Proxy/Call.php
+++ b/src/Controller/Proxy/Call.php
@@ -44,6 +44,7 @@ class Call extends Action\Action
     {
         // Extract API name from path
         $endpoint = $this->getEndpoint($this->_url->getCurrentUrl());
+        die($endpoint);
         if (!$endpoint) {
             throw new NotFoundException(__('Endpoint missing'));
         }
@@ -67,7 +68,7 @@ class Call extends Action\Action
 
     private function getEndpoint(string $currentUrl): string
     {
-        preg_match('#/([A-Za-z]+\.ff)#', $currentUrl, $match);
+        preg_match('#/([A-Za-z]+\.ff|rest/v[^\?]*)#', $currentUrl, $match);
         return $match[1] ?? '';
     }
 }

--- a/src/Controller/Proxy/Call.php
+++ b/src/Controller/Proxy/Call.php
@@ -44,7 +44,6 @@ class Call extends Action\Action
     {
         // Extract API name from path
         $endpoint = $this->getEndpoint($this->_url->getCurrentUrl());
-        die($endpoint);
         if (!$endpoint) {
             throw new NotFoundException(__('Endpoint missing'));
         }

--- a/src/Test/Integration/Controller/ProxyCallTest.php
+++ b/src/Test/Integration/Controller/ProxyCallTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Test\Integration\Controller;
+
+use Magento\TestFramework\TestCase\AbstractController;
+use Omikron\Factfinder\Api\ClientInterface;
+use Omikron\Factfinder\Model\Client;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ProxyCallTest extends AbstractController
+{
+    /** @var MockObject|ClientInterface */
+    private $apiClient;
+
+    public function test_JSON_endpoints_are_accepted_by_the_proxy_controller()
+    {
+        $this->apiClient->expects($this->atLeastOnce())
+            ->method('sendRequest')
+            ->with($this->stringContains('/Suggest.ff'), $this->anything());
+
+        $this->dispatch('/FACT-Finder/Suggest.ff?query=asd');
+        $this->assertSame($this->getResponse()->getStatusCode(), 200);
+    }
+
+    public function test_Rest_calls_are_accepted_by_the_proxy_controller()
+    {
+        $this->apiClient->expects($this->atLeastOnce())
+            ->method('sendRequest')
+            ->with($this->stringContains('/rest/v1/records/'), $this->anything());
+
+        $this->dispatch('/FACT-Finder/rest/v1/records/my_channel?sid=abc');
+        $this->assertSame($this->getResponse()->getStatusCode(), 200);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->apiClient = $this->createMock(ClientInterface::class);
+        $this->_objectManager->addSharedInstance($this->apiClient, Client::class);
+    }
+
+    protected function tearDown()
+    {
+        $this->_objectManager->removeSharedInstance(Client::class);
+        parent::tearDown();
+    }
+}

--- a/src/Test/Integration/Controller/ProxyCallTest.php
+++ b/src/Test/Integration/Controller/ProxyCallTest.php
@@ -24,7 +24,7 @@ class ProxyCallTest extends AbstractController
         $this->assertSame($this->getResponse()->getStatusCode(), 200);
     }
 
-    public function test_Rest_calls_are_accepted_by_the_proxy_controller()
+    public function test_rest_calls_are_accepted_by_the_proxy_controller()
     {
         $this->apiClient->expects($this->atLeastOnce())
             ->method('sendRequest')
@@ -32,6 +32,13 @@ class ProxyCallTest extends AbstractController
 
         $this->dispatch('/FACT-Finder/rest/v1/records/my_channel?sid=abc');
         $this->assertSame($this->getResponse()->getStatusCode(), 200);
+    }
+
+    public function test_other_request_paths_are_ignored()
+    {
+        $this->apiClient->expects($this->never())->method('sendRequest');
+        $this->dispatch('/FACT-Finder/non-existing-endpoint');
+        $this->assert404NotFound();
     }
 
     protected function setUp()


### PR DESCRIPTION
- Description: Clicks on suggest items trigger a rest API call to the FF server. When the proxy function is active, the match pattern is too restrictive (.ff is expected, which is not the case for rest) and ends in a 404.
- Tested with Magento editions/versions: 2.3.3
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
