### PR TITLE
Remove campaign name from default template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fixed
+- Remove typo in campaign template which prevents the rendering
+
 ## [v1.4.0] - 2019.12.17
 ### Changed
 - Upgrade Web Components to v3.11.1

--- a/src/view/frontend/templates/ff/campaign-advisor.phtml
+++ b/src/view/frontend/templates/ff/campaign-advisor.phtml
@@ -1,5 +1,5 @@
 <?php /** @var Magento\Framework\View\Element\Template $block */ ?>
-<ff-campaign-advisor name="myadvisorcampaign" unresolved>
+<ff-campaign-advisor unresolved>
     <ff-campaign-advisor-question>
         <span>
             <h1 data-question>{{{text}}}</h1>


### PR DESCRIPTION
- Description: The presence of a name restricts the template to a given campaign. Remove the name to allow all campaigns to be displayed using the standard template.
- Tested with Magento editions/versions: 2.3.3
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
