### PR TITLE
FFWEB-1528: Filtering categories fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Unreleased
 ### Fixed
 - Remove typo in campaign template which prevents the rendering
-- Fixed filterCategory was not encoded correctly for categories with at least two words i n name when using Proxy
+- Fixed filterCategory was not encoded correctly for categories with at least two words in name when using Proxy
 
 ## [v1.4.0] - 2019.12.17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Unreleased
 ### Fixed
 - Remove typo in campaign template which prevents the rendering
-- Fixed filterCategory was not encoded correctly for categories with at least two words in name when using Proxy
+- Fixed filterCategory not encoded correctly for categories with more words in name when using Proxy
 
 ## [v1.4.0] - 2019.12.17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Fixed
 - Remove typo in campaign template which prevents the rendering
+- Fixed filterCategory was not encoded correctly for categories with at least two words i n name when using Proxy
 
 ## [v1.4.0] - 2019.12.17
 ### Changed

--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -31,5 +31,4 @@
         </properties>
     </rule>
     <rule ref="rulesets/unusedcode.xml" />
-
 </ruleset>

--- a/src/Controller/Proxy/Call.php
+++ b/src/Controller/Proxy/Call.php
@@ -57,7 +57,7 @@ class Call extends Action\Action
         $result = $this->jsonResultFactory->create();
         try {
             $endpoint = $this->communicationConfig->getAddress() . '/' . $endpoint;
-            $params   = $this->parameterUtils->fixedGetParams($this->getRequest());
+            $params   = $this->parameterUtils->fixedGetParams($this->getRequest()->getParams());
             $response = $this->apiClient->sendRequest($endpoint, $params);
             $this->_eventManager->dispatch('ff_proxy_post_dispatch', [
                 'endpoint' => $endpoint,

--- a/src/Controller/Proxy/Call.php
+++ b/src/Controller/Proxy/Call.php
@@ -11,6 +11,7 @@ use Magento\Framework\Exception\NotFoundException;
 use Omikron\Factfinder\Api\ClientInterface;
 use Omikron\Factfinder\Api\Config\CommunicationConfigInterface;
 use Omikron\Factfinder\Exception\ResponseException;
+use Omikron\Factfinder\Model\Http\ParameterUtils;
 
 class Call extends Action\Action
 {
@@ -26,18 +27,23 @@ class Call extends Action\Action
     /** @var CommunicationConfigInterface */
     private $communicationConfig;
 
+    /** @var ParameterUtils */
+    private $parameterUtils;
+
     public function __construct(
         Action\Context $context,
         JsonResultFactory $jsonResultFactory,
         RawResultFactory $rawResultFactory,
         ClientInterface $apiClient,
-        CommunicationConfigInterface $communicationConfig
+        CommunicationConfigInterface $communicationConfig,
+        ParameterUtils $parameterUtils
     ) {
         parent::__construct($context);
         $this->jsonResultFactory   = $jsonResultFactory;
         $this->rawResultFactory    = $rawResultFactory;
         $this->apiClient           = $apiClient;
         $this->communicationConfig = $communicationConfig;
+        $this->parameterUtils      = $parameterUtils;
     }
 
     public function execute()
@@ -51,10 +57,11 @@ class Call extends Action\Action
         $result = $this->jsonResultFactory->create();
         try {
             $endpoint = $this->communicationConfig->getAddress() . '/' . $endpoint;
-            $response = $this->apiClient->sendRequest($endpoint, $this->getRequest()->getParams());
+            $params   = $this->parameterUtils->fixedGetParams($this->getRequest());
+            $response = $this->apiClient->sendRequest($endpoint, $params);
             $this->_eventManager->dispatch('ff_proxy_post_dispatch', [
                 'endpoint' => $endpoint,
-                'params'   => $this->getRequest()->getParams(),
+                'params'   => $params,
                 'response' => &$response,
             ]);
             $result->setData($response);

--- a/src/Model/Http/ParameterUtils.php
+++ b/src/Model/Http/ParameterUtils.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Model\Http;
+
+use Magento\Framework\App\RequestInterface;
+
+class ParameterUtils
+{
+    public function fixedGetParams(RequestInterface $request): array
+    {
+        $params = $request->getParams();
+        return array_combine(array_map(function ($key) {
+            return boolval(preg_match('/^filter(.*)ROOT/', $key)) ? str_replace('_', '+', $key) : $key;
+        }, array_keys($params)), array_values($params));
+    }
+}

--- a/src/Model/Http/ParameterUtils.php
+++ b/src/Model/Http/ParameterUtils.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\Model\Http;
 
-use Magento\Framework\App\RequestInterface;
-
 class ParameterUtils
 {
-    public function fixedGetParams(RequestInterface $request): array
+    public function fixedGetParams(array $params): array
     {
-        $params = $request->getParams();
-        return array_combine(array_map(function ($key) {
-            return boolval(preg_match('/^filter(.*)ROOT/', $key)) ? str_replace('_', '+', $key) : $key;
+        return array_combine(array_map(function (string $key): string {
+            return preg_match('#^filter(.*?)ROOT/#', $key) ? str_replace('_', '+', $key) : $key;
         }, array_keys($params)), array_values($params));
     }
 }

--- a/src/Test/Unit/Model/Http/ParameterUtilsTest.php
+++ b/src/Test/Unit/Model/Http/ParameterUtilsTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\Model\Http;
 
-use Magento\Framework\App\RequestInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ParameterUtilsTest extends TestCase
@@ -13,17 +11,15 @@ class ParameterUtilsTest extends TestCase
     /** @var ParameterUtils */
     private $paramUtils;
 
-    private $requestMock;
-
     public function test_fixed_get_params_should_replace_underscore_with_plus_for_any_tree_type_parameter()
     {
         $lvl2CategoryFilterName = 'filterCategoryPathROOT/First_Category';
-        $params = [
+
+        $fixedParams = $this->paramUtils->fixedGetParams([
             'filterCategoryPathROOT' => 'First Category',
-            $lvl2CategoryFilterName => 'Second Category',
-        ];
-        $this->requestMock->expects($this->once())->method('getParams')->willReturn($params);
-        $fixedParams = $this->paramUtils->fixedGetParams($this->requestMock);
+            $lvl2CategoryFilterName  => 'Second Category',
+        ]);
+
         $this->assertArrayHasKey(
             str_replace('_', '+', $lvl2CategoryFilterName),
             $fixedParams,
@@ -34,6 +30,5 @@ class ParameterUtilsTest extends TestCase
     protected function setUp()
     {
         $this->paramUtils = new ParameterUtils();
-        $this->requestMock =  $this->createMock(RequestInterface::class);
     }
 }

--- a/src/Test/Unit/Model/Http/ParameterUtilsTest.php
+++ b/src/Test/Unit/Model/Http/ParameterUtilsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Model\Http;
+
+use Magento\Framework\App\RequestInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ParameterUtilsTest extends TestCase
+{
+    /** @var ParameterUtils */
+    private $paramUtils;
+
+    private $requestMock;
+
+    public function test_fixed_get_params_should_replace_underscore_with_plus_for_any_tree_type_parameter()
+    {
+        $lvl2CategoryFilterName = 'filterCategoryPathROOT/First_Category';
+        $params = [
+            'filterCategoryPathROOT' => 'First Category',
+            $lvl2CategoryFilterName => 'Second Category',
+        ];
+        $this->requestMock->expects($this->once())->method('getParams')->willReturn($params);
+        $fixedParams = $this->paramUtils->fixedGetParams($this->requestMock);
+        $this->assertArrayHasKey(
+            str_replace('_', '+', $lvl2CategoryFilterName),
+            $fixedParams,
+            'filterCategory parameters should have "_" changed to "+"'
+        );
+    }
+
+    protected function setUp()
+    {
+        $this->paramUtils = new ParameterUtils();
+        $this->requestMock =  $this->createMock(RequestInterface::class);
+    }
+}


### PR DESCRIPTION
- Description: 
Fixed filterCategory was not encoded correctly for categories with at least two words i n name when using Proxy
- Tested with Magento editions/versions: 
2.3.2
- Tested with PHP versions: 
7.1
