### PR TITLE
FFWEB-1540: unset ff_no_redirect for search performed on product page

### DIFF
--- a/src/view/frontend/web/js/search-navigation.js
+++ b/src/view/frontend/web/js/search-navigation.js
@@ -6,6 +6,7 @@ define(['factfinder', 'mage/url'], function (factfinder, url) {
             delete event.type;
             var params = factfinder.common.dictToParameterString(event);
             if (!url.build('')) url.setBaseUrl(BASE_URL || '');
+            factfinder.common.localStorage.setItem('ff_no_redirect');
             window.location = url.build(redirectPath + params);
         }
     });


### PR DESCRIPTION
- Description: 
Performing custom search with only one record returned, should case redirect (by default). However, due to guard in web components to prevents redirection after getting back (using back button on browser), single hit redirect works after every second call. This change removes that "guard" on search request performed on non-result page.
- Tested with Magento editions/versions: 
2.3.2
- Tested with PHP versions: 
7.1