### PR TITLE
Enforce correct category path order in ViewModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Changed
 - Upgrade Web Components to version 3.11.4
 
+### Fixed
+- Enforce correct category path order in ViewModel
+
 ## [v1.4.1] - 2020.01.28
 ### Fixed
 - Remove typo in campaign template which prevents the rendering

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "magento/zendframework1": "^1.13"
   },
   "require-dev": {
-    "magento/magento-coding-standard": "^4.0",
+    "magento/magento-coding-standard": "^5.0",
     "pdepend/pdepend": ">=2.5.1",
     "phpmd/phpmd": "^2.7",
     "phpunit/phpunit": ">=6.1 <8.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,17 +20,17 @@
     <rule ref="Generic.ControlStructures.InlineControlStructure.NotAllowed">
         <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
-    <rule ref="Generic.Formatting.SpaceAfterCast" />
-    <rule ref="Generic.Metrics.CyclomaticComplexity">
-        <exclude-pattern>*/Setup/*</exclude-pattern>
-    </rule>
-    <rule ref="Magento2.Files.LineLength">
+    <rule ref="Generic.Files.LineLength">
         <exclude-pattern>*.phtml</exclude-pattern>
         <exclude-pattern>*Test.php</exclude-pattern>
         <properties>
             <property name="lineLimit" value="120" />
             <property name="absoluteLineLimit" value="0" />
         </properties>
+    </rule>
+    <rule ref="Generic.Formatting.SpaceAfterCast" />
+    <rule ref="Generic.Metrics.CyclomaticComplexity">
+        <exclude-pattern>*/Setup/*</exclude-pattern>
     </rule>
     <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
         <exclude-pattern>*Test.php</exclude-pattern>

--- a/src/Test/Unit/ViewModel/CategoryPathTest.php
+++ b/src/Test/Unit/ViewModel/CategoryPathTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\ViewModel;
+
+use Magento\Catalog\Model\Category;
+use Magento\Framework\Registry;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CategoryPathTest extends TestCase
+{
+    /** @var CategoryPath */
+    private $categoryPath;
+
+    /** @var MockObject|Category */
+    private $currentCategory;
+
+    public function test_category_path_is_correctly_sorted()
+    {
+        $this->currentCategory->method('getParentCategories')
+            ->willReturn([$this->category('C', 3), $this->category('A', 1), $this->category('B', 2)]);
+
+        $value = 'filterCategoryPathROOT=A,filterCategoryPathROOT%2FA=B,filterCategoryPathROOT%2FA%2FB=C';
+        $this->assertSame($value, $this->categoryPath->getValue());
+    }
+
+    protected function setUp()
+    {
+        $this->currentCategory = $this->createMock(Category::class);
+        $registry              = new Registry();
+        $this->categoryPath    = new CategoryPath($registry);
+        $registry->register('current_category', $this->currentCategory);
+    }
+
+    private function category(string $name, int $level): Category
+    {
+        return $this->createConfiguredMock(Category::class, ['getName' => $name, 'getLevel' => $level]);
+    }
+}

--- a/src/ViewModel/CategoryPath.php
+++ b/src/ViewModel/CategoryPath.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\ViewModel;
 
-use Magento\Catalog\Model\Category;
+use Magento\Catalog\Api\Data\CategoryInterface as Category;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 

--- a/src/ViewModel/CategoryPath.php
+++ b/src/ViewModel/CategoryPath.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\ViewModel;
 
-use Magento\Catalog\Api\Data\CategoryInterface as Category;
+use Magento\Catalog\Model\Category;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 

--- a/src/ViewModel/CategoryPath.php
+++ b/src/ViewModel/CategoryPath.php
@@ -33,11 +33,25 @@ class CategoryPath implements ArgumentInterface
     {
         $path  = 'ROOT';
         $value = $this->initial;
-        foreach ($this->getCurrentCategory()->getParentCategories() as $item) {
+        foreach ($this->getParentCategories($this->getCurrentCategory()) as $item) {
             $value[] = sprintf("filter{$this->param}%s=%s", $path, urlencode($item->getName()));
             $path    .= urlencode('/' . $item->getName());
         }
         return implode(',', $value);
+    }
+
+    /**
+     * @param Category $category
+     *
+     * @return Category[]
+     */
+    private function getParentCategories(Category $category): array
+    {
+        $categories = $category->getParentCategories();
+        usort($categories, function (Category $a, Category $b): int {
+            return $a->getLevel() - $b->getLevel();
+        });
+        return $categories;
     }
 
     private function getCurrentCategory(): Category

--- a/src/view/frontend/templates/ff/recommendation.phtml
+++ b/src/view/frontend/templates/ff/recommendation.phtml
@@ -1,5 +1,6 @@
 <?php
 /** @var Magento\Framework\View\Element\Template $block */
+/** @var ?Omikron\Factfinder\ViewModel\ProductBasedComponent $viewModel */
 $viewModel = $block->getViewModel();
 ?>
 <ff-recommendation record-id="<?= $block->escapeHtmlAttr($viewModel ? $viewModel->getProduct()->getSku() : implode(',', (array) $block->getData('record_id'))) ?>" unresolved>


### PR DESCRIPTION
- Description: Magento performs no sorting when fetching parent categories from the category resource model. A manual sorting by level is added to render a correct path.
- Tested with Magento editions/versions: CE 2.3.2
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
