### PR TITLE
Prevent merging and bundling of Web Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 - Follow-up fixup to encoding parameter names to make them parsed correctly by `http_build_query`
 - Enforce correct category path order in ViewModel
+- Prevent merging and bundling of Web Components
 
 ## [v1.4.1] - 2020.01.28
 ### Fixed

--- a/src/etc/view.xml
+++ b/src/etc/view.xml
@@ -9,6 +9,7 @@
         </images>
     </media>
     <exclude>
-        <item type="file">Omikron_Factfinder::ff-web-components/vendor/webcomponents-loader.js</item>
+        <item type="directory">Omikron_Factfinder::ff-web-components</item>
+        <item type="directory">Omikron_Factfinder::js/polyfill</item>
     </exclude>
 </view>


### PR DESCRIPTION
- Solves issue: FFWEB-1552
- Description: Prevent merging and/or bundling of all Web Components related files. Ideally we should add this to 1.4.2!
- Tested with Magento editions/versions: CE 2.3.2
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
