### PR TITLE
FFCSPV2-2157: Pass store id while fetching channel name from store config

### DIFF
--- a/src/Console/Command/ExportProducts.php
+++ b/src/Console/Command/ExportProducts.php
@@ -112,7 +112,7 @@ class ExportProducts extends \Symfony\Component\Console\Command\Command
                 (int) $storeId,
                 function () use ($storeId, $input, $output) {
                     if ($this->communicationConfig->isChannelEnabled((int) $storeId)) {
-                        $filename = "export.{$this->communicationConfig->getChannel()}.csv";
+                        $filename = "export.{$this->communicationConfig->getChannel((int) $storeId)}.csv";
                         $stream = $this->csvFactory->create(['filename' => "factfinder/{$filename}"]);
                         $this->feedGeneratorFactory->create('product')->generate($stream);
                         $path = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR)

--- a/src/Cron/Feed.php
+++ b/src/Cron/Feed.php
@@ -75,7 +75,7 @@ class Feed
         foreach ($this->storeManager->getStores() as $store) {
             $this->storeEmulation->runInStore((int) $store->getId(), function () use ($store) {
                 if ($this->channelProvider->isChannelEnabled((int) $store->getId())) {
-                    $filename = "export.{$this->channelProvider->getChannel()}.csv";
+                    $filename = "export.{$this->channelProvider->getChannel((int) $store->getId())}.csv";
                     $stream   = $this->csvFactory->create(['filename' => "factfinder/{$filename}"]);
                     $this->feedGeneratorFactory->create($this->feedType)->generate($stream);
                     $this->ftpUploader->upload($filename, $stream);


### PR DESCRIPTION
- Description
Exporting feeds for multiple stores using store emulations cause default values will be fetched from config if no storeId argument will be passed
- Tested with Magento editions/versions: 
2.3.2
- Tested with PHP versions: 
7.2
