### PR TITLE
Improve extendability of product export

### DIFF
--- a/src/Model/Export/Catalog/Entity/ProductVariation.php
+++ b/src/Model/Export/Catalog/Entity/ProductVariation.php
@@ -11,17 +11,21 @@ use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 class ProductVariation implements ExportEntityInterface
 {
     /** @var Product */
-    private $product;
+    protected $product;
+
+    /** @var Product */
+    protected $configurable;
 
     /** @var NumberFormatter */
-    private $numberFormatter;
+    protected $numberFormatter;
 
     /** @var array */
     private $data;
 
-    public function __construct(Product $product, NumberFormatter $numberFormatter, array $data = [])
+    public function __construct(Product $product, Product $configurable, NumberFormatter $numberFormatter, array $data = [])
     {
         $this->product         = $product;
+        $this->configurable    = $configurable;
         $this->numberFormatter = $numberFormatter;
         $this->data            = $data;
     }
@@ -40,5 +44,19 @@ class ProductVariation implements ExportEntityInterface
             'HasVariants'   => 1,
             'MagentoId'     => $this->getId(),
         ]);
+    }
+
+    /**
+     * @return Product
+     */
+    public function getProduct() {
+        return $this->product;
+    }
+
+    /**
+     * @return Product
+     */
+    public function getConfigurable() {
+        return $this->configurable;
     }
 }

--- a/src/Model/Export/Catalog/Entity/ProductVariation.php
+++ b/src/Model/Export/Catalog/Entity/ProductVariation.php
@@ -11,13 +11,13 @@ use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 class ProductVariation implements ExportEntityInterface
 {
     /** @var Product */
-    protected $product;
+    private $product;
 
     /** @var Product */
-    protected $configurable;
+    private $configurable;
 
     /** @var NumberFormatter */
-    protected $numberFormatter;
+    private $numberFormatter;
 
     /** @var array */
     private $data;
@@ -46,17 +46,13 @@ class ProductVariation implements ExportEntityInterface
         ]);
     }
 
-    /**
-     * @return Product
-     */
-    public function getProduct() {
+    public function getProduct(): Product
+    {
         return $this->product;
     }
 
-    /**
-     * @return Product
-     */
-    public function getConfigurable() {
+    public function getConfigurable(): Product
+    {
         return $this->configurable;
     }
 }

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -66,9 +66,10 @@ class ConfigurableDataProvider extends SimpleDataProvider
         $options = $this->getOptions($product);
         $data    = parent::toArray();
 
-        return function (Product $variation) use ($options, $data): ExportEntityInterface {
+        return function (Product $variation) use ($options, $product, $data): ExportEntityInterface {
             return $this->variationFactory->create([
                 'product' => $variation,
+                'configurable' => $product,
                 'data'    => ['Attributes' => '|' . implode('|', $options[$variation->getSku()] ?? []) . '|'] + $data,
             ]);
         };

--- a/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
@@ -67,4 +67,11 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
             return $field->getValue($this->product);
         }, $this->productFields));
     }
+
+    /**
+     * @return Product
+     */
+    public function getProduct() {
+        return $this->product;
+    }
 }

--- a/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
@@ -68,10 +68,8 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
         }, $this->productFields));
     }
 
-    /**
-     * @return Product
-     */
-    public function getProduct() {
+    public function getProduct(): Product
+    {
         return $this->product;
     }
 }


### PR DESCRIPTION
- Solves issue: 
Current implementation makes it hard for other modules to apply changes to the export. 

- Description: 
Depending on the project, data structures in magento might not match data structures for factfinder export. In many cases changing the export models is often the most cost-effective approach.

This PR improves the situation by introducing getters for product data and also making the parent configurable product data available to its simple contexts.

Eg. we had a use case where product images were only assigned to the configurable products.
With the upstream in this PR, it will be much more simple to do and changes in the shop less complex.

- Tested with Magento editions/versions: 
Magento Commerce 2.3.4

- Tested with PHP versions: 
PHP 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
