### PR TITLE
FFWEB-1579: Prevent slider filter requests from being redirected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
-## [v1.4.3] - UNRELEASED
+## [v1.5.0] - 2020.03.06
+### Changed
+- Improve extendability of product export
+
 ### Fixed
 - Fixed cron feed export is now working correctly with multistore
+- Prevent slider filter requests from being redirected to search result page
 
 ## [v1.4.2] - 2020.02.06
 ### Changed
@@ -203,6 +207,7 @@
 ### Added
 - Feed Export: Export feed file is now available via separate link
 
+[v1.5.0]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v1.5.0
 [v1.4.2]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v1.4.2
 [v1.4.1]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v1.4.1
 [v1.4.0]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v1.4.0

--- a/src/Model/Export/Catalog/Entity/ProductVariation.php
+++ b/src/Model/Export/Catalog/Entity/ProductVariation.php
@@ -22,8 +22,12 @@ class ProductVariation implements ExportEntityInterface
     /** @var array */
     private $data;
 
-    public function __construct(Product $product, Product $configurable, NumberFormatter $numberFormatter, array $data = [])
-    {
+    public function __construct(
+        Product $product,
+        Product $configurable,
+        NumberFormatter $numberFormatter,
+        array $data = []
+    ) {
         $this->product         = $product;
         $this->configurable    = $configurable;
         $this->numberFormatter = $numberFormatter;

--- a/src/view/frontend/web/js/search-navigation.js
+++ b/src/view/frontend/web/js/search-navigation.js
@@ -2,7 +2,7 @@ define(['factfinder', 'mage/url'], function (factfinder, url) {
     var redirectPath = 'FACT-Finder/result';
 
     factfinder.communication.EventAggregator.addBeforeDispatchingCallback(function (event) {
-        if (event.type === 'search' && !isSearchResultPage() && !event.__immediate) {
+        if (event.type === 'search' && !isSearchResultPage() && !event.__immediate && event.navigation !== 'true') {
             delete event.type;
             var params = factfinder.common.dictToParameterString(event);
             if (!url.build('')) url.setBaseUrl(BASE_URL || '');


### PR DESCRIPTION
- Solves issue: FFWEB-1579
- Description: Prevent slider filter requests from being redirected to search result page
- Tested with Magento editions/versions: CE 2.3.3
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
