### PR TITLE
trim category name when building category path

### DIFF
--- a/src/ViewModel/CategoryPath.php
+++ b/src/ViewModel/CategoryPath.php
@@ -34,8 +34,8 @@ class CategoryPath implements ArgumentInterface
         $path  = 'ROOT';
         $value = $this->initial;
         foreach ($this->getParentCategories($this->getCurrentCategory()) as $item) {
-            $value[] = sprintf("filter{$this->param}%s=%s", $path, urlencode($item->getName()));
-            $path    .= urlencode('/' . $item->getName());
+            $value[] = sprintf("filter{$this->param}%s=%s", $path, urlencode(trim($item->getName())));
+            $path    .= urlencode('/' . trim($item->getName()));
         }
         return implode(',', $value);
     }


### PR DESCRIPTION
- Solves issue: 
currently, when a category is saved with a trailing whitespace, it is trimmed during export but not when the categorypath is build for the frontend components. This leads to no records being found when a category has a trailing whitespace in the name

- Description: 
this pr just trims the category name that is used for the category path in f-communication


- Tested with Magento editions/versions: 
2.3.3
- Tested with PHP versions: 
7.2

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
