### PR TITLE
FFWEB-1606: added RECOMMENDATION to available push import types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-# Unreleased
+# Changelog
+## Unreleased
 ### Added
 - Added RECOMMENDATION to available import type to be pushed after feed is uploaded.
 
-# Changelog
 ## [v1.5.0] - 2020.03.06
 ### Changed
-- Improve extendability of product export
+- Improve extendability of product export (by @aptudock)
 
 ### Fixed
 - Fixed cron feed export is now working correctly with multistore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+### Added
+- Added RECOMMENDATION to available import type to be pushed after feed is uploaded.
+
 # Changelog
 ## [v1.5.0] - 2020.03.06
 ### Changed

--- a/src/etc/adminhtml/system/data_transfer.xml
+++ b/src/etc/adminhtml/system/data_transfer.xml
@@ -39,6 +39,7 @@
             <options>
                 <option label="Data">data</option>
                 <option label="Suggest">suggest</option>
+                <option label="Recommendation">recommendation</option>
             </options>
             <depends>
                 <field id="ff_push_import_enabled">1</field>


### PR DESCRIPTION
 - Description: 
Added RECOMMENDATION push import type 
- Tested with Magento editions/versions: 
2.3.2
- Tested with PHP versions: 
7.2