### PR TITLE
Attribute Export

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ depending on our requirements. Suppose you want to create a `Miscellanous` field
 </section>
 ```
 
-Now select the desired attributes in Magento backend. Now, configure your field via `di.xml`:
+Now select the desired attributes in Magento backend. Finally, configure your field via `di.xml`:
 
 ```xml
 <virtualType name="MyCompany\MyModule\ProductField\MiscAttributes" type="Omikron\Factfinder\Model\Export\Catalog\ProductField\Attributes">

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ customise them.
     - [Adding new column](#adding-new-column)
     - [Adding custom communication parameter](#adding-custom-communication-parameter)
     - [Adding custom product data provider](#adding-custom-product-data-provider)
+    - [Adding an additional multi-attribute field](#adding-an-additional-multi-attribute-field)
 - [Troubleshooting](#troubleshooting)
     - [Removing `/pub` from exported URLs](#removing-pub-from-exported-urls)
 - [Contribute](#contribute)
@@ -519,10 +520,52 @@ class CustomDataProvider implements DataProviderInterface
 }
 ```
 
-It's a minimum configuration. `$product` constructor will be passed automatically and in method `getEntities` You should extract all required data
+It's a minimum configuration. `$product` constructor will be passed automatically and in method `getEntities` You should extract all required data.
+
+### Adding an additional multi-attribute field
+Our multi-attribute model can be reused to add custom fields depending on our requirements. Suppose you want to create
+a `Miscellanous` field. First, add configuration for it to the `system.xml`:
+
+```xml
+<section id="my_section">
+    <group id="my_group">
+        <field id="misc_attributes" type="multiselect">
+            <label>Miscellanous Attributes</label>
+            <source_model>Omikron\Factfinder\Model\Config\Source\Attribute</source_model>
+            <can_be_empty>1</can_be_empty>
+        </field>
+    </group>
+</section>
+```
+
+Now select the desired attributes in Magento backend. Now, configure your field via `di.xml`:
+
+```xml
+<virtualType name="MyCompany\MyModule\ProductField\MiscAttributes" type="Omikron\Factfinder\Model\Export\Catalog\ProductField\Attributes">
+    <arguments>
+        <argument name="configPath" xsi:type="string">my_section/my_group/misc_attributes</argument>
+    </arguments>
+</virtualType>
+<type name="Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProvider">
+    <arguments>
+        <argument name="productFields" xsi:type="array">
+            <item name="Miscellaous" xsi:type="object">MyCompany\MyModule\ProductField\MiscAttributes</item>
+        </argument>
+    </arguments>
+</type>
+<virtualType name="Omikron\Factfinder\Model\Export\CatalogFeed">
+    <arguments>
+        <argument name="columns" xsi:type="array">
+            <item name="Miscellaous" xsi:type="string">Miscellaous</item>
+        </argument>
+    </arguments>
+</virtualType>
+```
+
+As you can see, the configured path reflects the system config path we defined previously. The new virtual type is then
+added to the available feed columns.
 
 ## Troubleshooting
-
 ### Removing `/pub` from exported URLs
 If the exported feed file contains URLs with `pub/` added, most probably your document root is set to the `/pub` folder. In order to skip this part in URL, please add following entry to your project's `env.php` file:
 ```php

--- a/README.md
+++ b/README.md
@@ -523,8 +523,9 @@ class CustomDataProvider implements DataProviderInterface
 It's a minimum configuration. `$product` constructor will be passed automatically and in method `getEntities` You should extract all required data.
 
 ### Adding an additional multi-attribute field
-Our multi-attribute model can be reused to add custom fields depending on our requirements. Suppose you want to create
-a `Miscellanous` field. First, add configuration for it to the `system.xml`:
+Our [multi-attribute model](src/Model/Export/Catalog/ProductField/Attributes.php) can be reused to add custom fields
+depending on our requirements. Suppose you want to create a `Miscellanous` field. First, add configuration for it to the
+`system.xml`:
 
 ```xml
 <section id="my_section">

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ class CustomDataProvider implements DataProviderInterface
 It's a minimum configuration. `$product` constructor will be passed automatically and in method `getEntities` You should extract all required data.
 
 ### Adding an additional multi-attribute field
-Our [multi-attribute model](src/Model/Export/Catalog/ProductField/Attributes.php) can be reused to add custom fields
+Our [multi-attribute field model](src/Model/Export/Catalog/ProductField/Attributes.php) can be reused to add custom fields
 depending on our requirements. Suppose you want to create a `Miscellanous` field. First, add configuration for it to the
 `system.xml`:
 

--- a/src/Model/Export/Catalog/ProductField/Attributes.php
+++ b/src/Model/Export/Catalog/ProductField/Attributes.php
@@ -12,6 +12,7 @@ use Magento\Store\Model\ScopeInterface as Scope;
 use Omikron\Factfinder\Api\Export\Catalog\ProductFieldInterface;
 use Omikron\Factfinder\Api\Filter\FilterInterface;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
+use UnexpectedValueException;
 
 class Attributes implements ProductFieldInterface
 {
@@ -59,7 +60,8 @@ class Attributes implements ProductFieldInterface
 
     private function getAttributeValues(Product $product, Attribute $attribute): array
     {
-        $value  = $product->getDataUsingMethod($attribute->getAttributeCode());
+        $code   = $attribute->getAttributeCode();
+        $value  = $product->getDataUsingMethod($code);
         $values = [];
 
         switch ($attribute->getFrontendInput()) {
@@ -70,12 +72,16 @@ class Attributes implements ProductFieldInterface
                 $values[] = $this->numberFormatter->format((float) $value);
                 break;
             case 'select':
-                $values[] = (string) $product->getAttributeText($attribute->getAttributeCode());
+                $values[] = (string) $product->getAttributeText($code);
                 break;
             case 'multiselect':
-                $values = (array) $product->getAttributeText($attribute->getAttributeCode());
+                $values = (array) $product->getAttributeText($code);
                 break;
             default:
+                if (!is_scalar($value)) {
+                    $msg = "Attribute '{$code}' could not be exported. Please consider writing your own field model";
+                    throw new UnexpectedValueException($msg);
+                }
                 $values[] = (string) $value;
                 break;
         }

--- a/src/Model/Export/Catalog/ProductField/Attributes.php
+++ b/src/Model/Export/Catalog/ProductField/Attributes.php
@@ -15,10 +15,11 @@ use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 
 class Attributes implements ProductFieldInterface
 {
-    private const CONFIG_PATH = 'factfinder/data_transfer/ff_additional_attributes';
-
     /** @var ScopeConfigInterface */
     private $scopeConfig;
+
+    /** @var string */
+    private $configPath;
 
     /** @var ProductResource */
     private $productResource;
@@ -33,12 +34,14 @@ class Attributes implements ProductFieldInterface
         ScopeConfigInterface $scopeConfig,
         ProductResource $productResource,
         FilterInterface $filter,
-        NumberFormatter $numberFormatter
+        NumberFormatter $numberFormatter,
+        string $configPath
     ) {
         $this->scopeConfig     = $scopeConfig;
         $this->productResource = $productResource;
         $this->filter          = $filter;
         $this->numberFormatter = $numberFormatter;
+        $this->configPath      = $configPath;
     }
 
     public function getValue(Product $product): string
@@ -87,7 +90,7 @@ class Attributes implements ProductFieldInterface
      */
     private function getAttributes(int $storeId): array
     {
-        $attributes = (string) $this->scopeConfig->getValue(self::CONFIG_PATH, Scope::SCOPE_STORES, $storeId);
+        $attributes = (string) $this->scopeConfig->getValue($this->configPath, Scope::SCOPE_STORES, $storeId);
         return array_filter(array_map([$this->productResource, 'getAttribute'], explode(',', $attributes)));
     }
 }

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -53,9 +53,9 @@ class ConfigurableDataProvider extends SimpleDataProvider
     {
         $data = ['HasVariants' => 1] + parent::toArray();
 
-        $options = array_merge([], ...array_values($this->getOptions($this->product)));
+        $options = array_unique(array_merge([], ...array_values($this->getOptions($this->product))));
         if ($options) {
-            $data = ['Attributes' => ($data['Attributes'] ?? '|') . implode('|', $options) . '|'] + $data;
+            $data['FilterAttributes'] .= rtrim($data['FilterAttributes'], '|') . '|' . implode('|', $options) . '|';
         }
 
         return $data;
@@ -67,10 +67,11 @@ class ConfigurableDataProvider extends SimpleDataProvider
         $data    = parent::toArray();
 
         return function (Product $variation) use ($options, $product, $data): ExportEntityInterface {
+            $filterValues = implode('|', $options[$variation->getSku()] ?? []);
             return $this->variationFactory->create([
-                'product' => $variation,
+                'product'      => $variation,
                 'configurable' => $product,
-                'data'    => ['Attributes' => '|' . implode('|', $options[$variation->getSku()] ?? []) . '|'] + $data,
+                'data'         => ['FilterAttributes' => "|{$filterValues}|"] + $data,
             ]);
         };
     }

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -55,7 +55,7 @@ class ConfigurableDataProvider extends SimpleDataProvider
 
         $options = array_unique(array_merge([], ...array_values($this->getOptions($this->product))));
         if ($options) {
-            $data['FilterAttributes'] .= rtrim($data['FilterAttributes'], '|') . '|' . implode('|', $options) . '|';
+            $data['FilterAttributes'] = rtrim($data['FilterAttributes'], '|') . '|' . implode('|', $options) . '|';
         }
 
         return $data;

--- a/src/Test/Unit/Model/Export/Catalog/ProductField/AttributesTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/ProductField/AttributesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Model\Export\Catalog\ProductField;
+
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ResourceModel\Eav\Attribute;
+use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Omikron\Factfinder\Model\Filter\TextFilter;
+use Omikron\Factfinder\Model\Formatter\NumberFormatter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class AttributesTest extends TestCase
+{
+    /** @var MockObject|ScopeConfigInterface */
+    private $config;
+
+    /** @var MockObject|ProductResource */
+    private $resource;
+
+    /** @var Attributes */
+    private $testee;
+
+    public function test_exception_is_thrown_if_the_attribute_is_not_exportable()
+    {
+        $this->expectException(\UnexpectedValueException::class);
+
+        $product   = $this->createConfiguredMock(Product::class, ['getDataUsingMethod' => [1, 2, 3]]);
+        $attribute = $this->createConfiguredMock(Attribute::class, [
+            'getAttributeCode' => 'foobar',
+            'getStoreLabel'    => 'Foobar',
+        ]);
+
+        $this->config->method('getValue')->willReturn('foobar');
+        $this->resource->method('getAttribute')->with('foobar')->willReturn($attribute);
+
+        $this->testee->getValue($product);
+    }
+
+    protected function setUp()
+    {
+        $this->config   = $this->createMock(ScopeConfigInterface::class);
+        $this->resource = $this->createMock(ProductResource::class);
+
+        $this->testee = new Attributes(
+            $this->config,
+            $this->resource,
+            new TextFilter(),
+            new NumberFormatter(),
+            'foo/bar/baz'
+        );
+    }
+}

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -9,6 +9,7 @@
             <include path="Omikron_Factfinder::system/general.xml" />
             <include path="Omikron_Factfinder::system/advanced.xml" />
             <include path="Omikron_Factfinder::system/components.xml" />
+            <include path="Omikron_Factfinder::system/feed.xml" />
             <include path="Omikron_Factfinder::system/data_transfer.xml" />
             <include path="Omikron_Factfinder::system/cms.xml" />
             <include path="Omikron_Factfinder::system/cron.xml" />

--- a/src/etc/adminhtml/system/data_transfer.xml
+++ b/src/etc/adminhtml/system/data_transfer.xml
@@ -25,12 +25,6 @@
             <label>Test FTP Connection</label>
             <frontend_model>Omikron\Factfinder\Block\Adminhtml\System\Config\Button\TestFtpConnection</frontend_model>
         </field>
-        <field id="ff_additional_attributes" translate="label comment" type="multiselect" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Select Additional Attributes</label>
-            <source_model>Omikron\Factfinder\Model\Config\Source\Attribute</source_model>
-            <comment>Select all attributes which should be exported to the product feed.</comment>
-            <can_be_empty>1</can_be_empty>
-        </field>
         <field id="ff_createfeed" translate="label comment" type="button" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Generate Export File</label>
             <frontend_model>Omikron\Factfinder\Block\Adminhtml\System\Config\Button\Feed</frontend_model>

--- a/src/etc/adminhtml/system/feed.xml
+++ b/src/etc/adminhtml/system/feed.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="feed" translate="label comment" sortOrder="45" showInDefault="1" showInWebsite="1" showInStore="1">
+        <label>Feed Settings</label>
+        <comment><![CDATA[<div class="message message-notice notice"><div data-ui-id="messages-message-success">Please always save the config in the upper right corner after making changes, especially before using the export button.</div></div>]]></comment>
+        <field id="filter_attributes" translate="label comment" type="multiselect" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Filter Attributes</label>
+            <source_model>Omikron\Factfinder\Model\Config\Source\Attribute</source_model>
+            <can_be_empty>1</can_be_empty>
+        </field>
+        <field id="search_attributes" translate="label comment" type="multiselect" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Search Attributes</label>
+            <source_model>Omikron\Factfinder\Model\Config\Source\Attribute</source_model>
+            <can_be_empty>1</can_be_empty>
+        </field>
+    </group>
+</include>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -31,8 +31,9 @@
                 <item name="MagentoId" xsi:type="string">MagentoId</item>
                 <item name="ImageURL" xsi:type="string">ImageURL</item>
                 <item name="CategoryPath" xsi:type="string">CategoryPath</item>
-                <item name="Attributes" xsi:type="string">Attributes</item>
                 <item name="HasVariants" xsi:type="string">HasVariants</item>
+                <item name="FilterAttributes" xsi:type="string">FilterAttributes</item>
+                <item name="SearchAttributes" xsi:type="string">SearchAttributes</item>
             </argument>
         </arguments>
     </virtualType>
@@ -69,8 +70,9 @@
                 <item name="MagentoId" xsi:type="string">MagentoId</item>
                 <item name="ImageURL" xsi:type="string">ImageURL</item>
                 <item name="CategoryPath" xsi:type="string">CategoryPath</item>
-                <item name="Attributes" xsi:type="string">Attributes</item>
                 <item name="HasVariants" xsi:type="string">HasVariants</item>
+                <item name="FilterAttributes" xsi:type="string">FilterAttributes</item>
+                <item name="SearchAttributes" xsi:type="string">SearchAttributes</item>
                 <item name="PageId" xsi:type="string">PageId</item>
                 <item name="PageIdentifier" xsi:type="string">PageIdentifier</item>
                 <item name="PageTitle" xsi:type="string">PageTitle</item>
@@ -99,6 +101,16 @@
     <virtualType name="Omikron\Factfinder\Model\TrackingEventClient" type="Omikron\Factfinder\Model\Client">
         <arguments>
             <argument name="serializer" xsi:type="object">Omikron\Factfinder\Model\Serializer\PlainTextSerializer</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Omikron\Factfinder\Model\Export\Catalog\ProductField\FilterAttributes" type="Omikron\Factfinder\Model\Export\Catalog\ProductField\Attributes">
+        <arguments>
+            <argument name="configPath" xsi:type="string">factfinder/feed/filter_attributes</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Omikron\Factfinder\Model\Export\Catalog\ProductField\SearchAttributes" type="Omikron\Factfinder\Model\Export\Catalog\ProductField\Attributes">
+        <arguments>
+            <argument name="configPath" xsi:type="string">factfinder/feed/search_attributes</argument>
         </arguments>
     </virtualType>
 
@@ -141,7 +153,8 @@
             <argument name="productFields" xsi:type="array">
                 <item name="ImageURL" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage</item>
                 <item name="CategoryPath" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\CategoryPath</item>
-                <item name="Attributes" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\Attributes</item>
+                <item name="FilterAttributes" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\FilterAttributes</item>
+                <item name="SearchAttributes" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\SearchAttributes</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
- Solves issue: 
- Description: Currently we are exporting all additional attributes in a single field called Attributes. In order to improve and simplify the data configuration on FF, as suggested in the Optimized Feed guide, we should separate the Attributes in Filter- and SearchAttributes. **Important**: This could be a huge breaking change, we should consider a major version bump for it.
- Tested with Magento editions/versions: CE 2.3.3
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
