### PR TITLE
Filter non-printable characters in export feed

### DIFF
--- a/src/Model/Filter/TextFilter.php
+++ b/src/Model/Filter/TextFilter.php
@@ -17,6 +17,7 @@ class TextFilter implements FilterInterface
         $value = mb_convert_encoding($value, 'HTML-ENTITIES', 'UTF-8');
         $value = mb_convert_encoding($value, 'UTF-8', 'HTML-ENTITIES');
         $value = preg_replace('#\s+#', ' ', $value);
+        $value = preg_replace('#[[:^print:]]#u', '', $value);
         return trim($value);
     }
 }

--- a/src/Test/Unit/Model/Filter/TextFilterTest.php
+++ b/src/Test/Unit/Model/Filter/TextFilterTest.php
@@ -44,6 +44,7 @@ class TextFilterTest extends TestCase
             'strip HTML #2'              => ['FACT-<span>Finder</span>', 'FACT-Finder'],
             'strip HTML, keep blocks #1' => ['<h1>FACT-Finder</h1><p>Omikron GmbH</p>', 'FACT-Finder Omikron GmbH'],
             'strip HTML, keep blocks #2' => ['FACT-Finder<br>Omikron GmbH', 'FACT-Finder Omikron GmbH'],
+            'non printable chars'        => ['Schulfüller Pelikano Junior P68L türkis', 'Schulfüller Pelikano Junior P68L türkis'],
         ];
     }
 


### PR DESCRIPTION
- Description: Improve export text filter by removing ALL non-printable characters
- Tested with Magento editions/versions: CE 2.3.4
- Tested with PHP versions: 7.2

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
