### PR TITLE
Remove UTF-8 whitespace with TextFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ The constructor for this class requires only an attribute code to be exported.
 ```xml
 <virtualType name="Omikron\Factfinder\Model\Export\Catalog\ProductField\Brand" type="Omikron\Factfinder\Model\Export\Catalog\ProductField\GenericField">
     <arguments>
-        <argument name="attributeName" xsi:type="string">manufacturer</argument>
+        <argument name="attributeCode" xsi:type="string">manufacturer</argument>
     </arguments>
 </virtualType>
 ``` 

--- a/src/Model/Filter/TextFilter.php
+++ b/src/Model/Filter/TextFilter.php
@@ -16,7 +16,7 @@ class TextFilter implements FilterInterface
         $value = strip_tags($value);
         $value = mb_convert_encoding($value, 'HTML-ENTITIES', 'UTF-8');
         $value = mb_convert_encoding($value, 'UTF-8', 'HTML-ENTITIES');
-        $value = preg_replace('#\s+#', ' ', $value);
+        $value = preg_replace('#\s+#u', ' ', $value);
         $value = preg_replace('#[[:^print:]]#u', '', $value);
         return trim($value);
     }

--- a/src/Test/Unit/Model/Filter/TextFilterTest.php
+++ b/src/Test/Unit/Model/Filter/TextFilterTest.php
@@ -45,6 +45,7 @@ class TextFilterTest extends TestCase
             'strip HTML, keep blocks #1' => ['<h1>FACT-Finder</h1><p>Omikron GmbH</p>', 'FACT-Finder Omikron GmbH'],
             'strip HTML, keep blocks #2' => ['FACT-Finder<br>Omikron GmbH', 'FACT-Finder Omikron GmbH'],
             'non printable chars'        => ['Schulfüller Pelikano Junior P68L türkis', 'Schulfüller Pelikano Junior P68L türkis'],
+            'non-breaking space'         => ['chevaux contre', 'chevaux contre'],
         ];
     }
 


### PR DESCRIPTION
- Description: Currently, UFT-8 whitespace characters are not removed by the TextFilter
- Tested with Magento editions/versions: CE 2.3.5
- Tested with PHP versions: PHP 7.2

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
