### PR TITLE
Magento CSP Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.4
 env:
   - COMPOSER_FLAGS="--prefer-lowest"
   - COMPOSER_FLAGS="--prefer-stable"
+jobs:
+  exclude:
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
 cache:
   directories:

--- a/src/etc/csp_whitelist.xml
+++ b/src/etc/csp_whitelist.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="connect-src">
+            <values>
+                <value id="factfinder_de" type="host">*.fact-finder.de</value>
+                <value id="factfinder_com" type="host">*.fact-finder.com</value>
+                <value id="factfinder_uk" type="host">*.fact-finder.co.uk</value>
+                <value id="factfinder_fr" type="host">*.fact-finder.fr</value>
+                <value id="factfinder_pl" type="host">*.fact-finder.pl</value>
+                <value id="factfinder_it" type="host">*.fact-finder.it</value>
+                <value id="factfinder_at" type="host">*.fact-finder.at</value>
+                <value id="factfinder_ch" type="host">*.fact-finder.ch</value>
+                <value id="factfinder_cloud" type="host">*.fact-finder.cloud</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
- Closes #272  
- Description: Ensures compatibility with Magento 2.3.5, which introduced the CSP module
- Tested with Magento editions/versions: CE 2.3.5
- Tested with PHP versions: 7.2.25
