### PR TITLE
Make category optional in CategoryPath view model

### DIFF
--- a/src/ViewModel/CategoryPath.php
+++ b/src/ViewModel/CategoryPath.php
@@ -41,20 +41,20 @@ class CategoryPath implements ArgumentInterface
     }
 
     /**
-     * @param Category $category
+     * @param Category|null $category
      *
      * @return Category[]
      */
-    private function getParentCategories(Category $category): array
+    private function getParentCategories(?Category $category): array
     {
-        $categories = $category->getParentCategories();
+        $categories = $category ? $category->getParentCategories() : [];
         usort($categories, function (Category $a, Category $b): int {
             return $a->getLevel() - $b->getLevel();
         });
         return $categories;
     }
 
-    private function getCurrentCategory(): Category
+    private function getCurrentCategory(): ?Category
     {
         return $this->registry->registry('current_category');
     }


### PR DESCRIPTION
- Fixes #277 
- Description: When Varnish cache is active, a call including our `factfinder_categoy_view` handle is performed against the ESI controller on category pages, e.g. for the topnav. Since the category is not loaded, a call to the CategoryPath view model would fail. This whole part might be refactored in 2.x, so for the moment we can simply make the category optional.
- Tested with Magento editions/versions: CE 2.4
- Tested with PHP versions: 7.2
