### PR TITLE
Do no move searchbar to content

### DIFF
--- a/src/view/frontend/layout/factfinder_result_index.xml
+++ b/src/view/frontend/layout/factfinder_result_index.xml
@@ -20,6 +20,5 @@
 
         <move element="factfinder.feedbacktext" destination="factfinder.campaigns" />
         <move element="factfinder.campaigns" destination="content" before="factfinder.breadcrumb" />
-        <move element="top.search" destination="content" before="factfinder.breadcrumb" />
     </body>
 </page>

--- a/src/view/frontend/web/css/source/ff/_breadcrumb.less
+++ b/src/view/frontend/web/css/source/ff/_breadcrumb.less
@@ -10,7 +10,7 @@ ff-breadcrumb-trail {
 .ff-breadcrumb-trail {
   font-weight: @heading__font-weight__base;
   font-size: 3rem;
-  margin: 3rem 0 2rem;
+  margin: 0 0 2rem;
 
   ff-template span {
     font-weight: @font-weight__regular;


### PR DESCRIPTION
- Closes #278 
- Description: Moving the searchbox to the content area makes project implementation more complicated, because often you might want the bar to stay in the header. Remove this feature from the module, like we do in other SDKs.
- Tested with Magento editions/versions: CE 2.4
- Tested with PHP versions: 7.3
