### PR TITLE
Fix redirect URL in controller_action_predispatch_* observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fixed
+- Fix redirect URL in `controller_action_predispatch_*` observer
+
 ## [v1.6.4] - 2020.10.15
 ### Changed
 - Upgrade Web Components to version 3.15.8

--- a/src/Observer/RedirectSearch.php
+++ b/src/Observer/RedirectSearch.php
@@ -42,6 +42,6 @@ class RedirectSearch implements ObserverInterface
     private function redirectRequest(RequestInterface $request): void
     {
         $query = $request->getParam('q', '*');
-        $this->redirect->redirect($this->response, 'FACT-Finder/result', ['_query' => ['query' => $query]]);
+        $this->redirect->redirect($this->response, 'factfinder/result', ['_query' => ['query' => $query]]);
     }
 }

--- a/src/Test/Unit/Observer/RedirectSearchTest.php
+++ b/src/Test/Unit/Observer/RedirectSearchTest.php
@@ -55,7 +55,7 @@ class RedirectSearchTest extends TestCase
         // Test search query forwarding
         $this->redirect->expects($this->once())
             ->method('redirect')
-            ->with($this->response, 'FACT-Finder/result', ['_query' => ['query' => 'Foobar']]);
+            ->with($this->response, 'factfinder/result', ['_query' => ['query' => 'Foobar']]);
 
         // Run!
         $this->observer->execute(new Observer(['request' => $request]));


### PR DESCRIPTION
- Fixes #281
- Description: We are still referring to the legacy URL structure in the redirect observer, which is now deprecated.
- Tested with Magento editions/versions: CE 2.4
- Tested with PHP versions: 7.4.9

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
