### PR TITLE
FFWEB-1855: Exclude category filter from URL on category pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Fixed
 - Fix redirect URL in `controller_action_predispatch_*` observer
+- Exclude category filter from URL on category pages
 
 ## [v1.6.4] - 2020.10.15
 ### Changed

--- a/src/view/frontend/layout/factfinder_category_view.xml
+++ b/src/view/frontend/layout/factfinder_category_view.xml
@@ -6,6 +6,9 @@
         <referenceBlock name="category.products" remove="true" />
         <referenceBlock name="catalog.leftnav" remove="true" />
 
+        <referenceBlock name="after.body.start">
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.history.cb" template="Omikron_Factfinder::category/history_callback.phtml" after="factfinder.communication" />
+        </referenceBlock>
         <referenceBlock name="factfinder.communication">
             <arguments>
                 <argument name="communication_parameters" xsi:type="array">

--- a/src/view/frontend/templates/category/history_callback.phtml
+++ b/src/view/frontend/templates/category/history_callback.phtml
@@ -1,0 +1,9 @@
+<script>
+    document.addEventListener('ffReady', function (ff) {
+        ff.eventAggregator.addBeforeHistoryPushCallback(function (res, event, url) {
+            url = url.replace(/filter=CategoryPath[^&]+&?/, '').replace(/filterCategoryPathROOT[^&]+&?/g, '');
+            ff.factfinder.communication.Util.pushParameterToHistory(res, url, event);
+            return false;
+        });
+    });
+</script>


### PR DESCRIPTION
- Solves issue: FFWEB-1855
- Description: Exclude category filter from URL on category pages
- Tested with Magento editions/versions: CE 2.4
- Tested with PHP versions: 7.3
