### PR TITLE
FFWEB-1899: CMS export fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Fixed
 - Fix redirect URL in `controller_action_predispatch_*` observer
 - Exclude category filter from URL on category pages
+- Fix CMS export does not export pages assigned to all stores when exporting from specific store scope
+- Fix CMS export does not export any page if nothing is selected in the export blacklist
 
 ## [v1.6.4] - 2020.10.15
 ### Changed

--- a/src/Model/Export/Cms/Pages.php
+++ b/src/Model/Export/Cms/Pages.php
@@ -8,6 +8,7 @@ use Magento\Cms\Api\Data\PageInterface;
 use Magento\Cms\Api\PageRepositoryInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use Omikron\Factfinder\Model\Config\CmsConfig;
 
@@ -49,8 +50,10 @@ class Pages implements \IteratorAggregate
 
     protected function getQuery(): SearchCriteriaBuilder
     {
-        return $this->searchCriteriaBuilder
-            ->addFilter('identifier', $this->cmsConfig->getCmsBlacklist(), 'nin')
-            ->addFilter('store_id', $this->storeManager->getStore()->getId());
+        $blacklist = $this->cmsConfig->getCmsBlacklist();
+        if (!empty($blacklist)) {
+          $this->searchCriteriaBuilder->addFilter('identifier', $blacklist, 'nin');
+        }
+        return $this->searchCriteriaBuilder->addFilter('store_id', [Store::DEFAULT_STORE_ID, (int) $this->storeManager->getStore()->getId()], 'in');
     }
 }

--- a/src/Model/Export/Cms/Pages.php
+++ b/src/Model/Export/Cms/Pages.php
@@ -51,9 +51,11 @@ class Pages implements \IteratorAggregate
     protected function getQuery(): SearchCriteriaBuilder
     {
         $blacklist = $this->cmsConfig->getCmsBlacklist();
-        if (!empty($blacklist)) {
-          $this->searchCriteriaBuilder->addFilter('identifier', $blacklist, 'nin');
+        if ($blacklist) {
+            $this->searchCriteriaBuilder->addFilter('identifier', $blacklist, 'nin');
         }
-        return $this->searchCriteriaBuilder->addFilter('store_id', [Store::DEFAULT_STORE_ID, (int) $this->storeManager->getStore()->getId()], 'in');
+
+        $inStores  = [Store::DEFAULT_STORE_ID, (int) $this->storeManager->getStore()->getId()];
+        return $this->searchCriteriaBuilder->addFilter('store_id', $inStores, 'in');
     }
 }


### PR DESCRIPTION
- Closes: #289
- Description: 
Fixes filtering CMS pages when nothing is selected in blacklis
Ensures that pages assigned to all stores will be always include in export
- Tested with Magento editions/versions: 
2.3
- Tested with PHP versions: 
7.2

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
