### PR TITLE
FFWEB-2003: Prevent forbidden array to string conversion

### DIFF
--- a/src/Model/Export/Catalog/AttributeValuesExtractor.php
+++ b/src/Model/Export/Catalog/AttributeValuesExtractor.php
@@ -38,7 +38,11 @@ class AttributeValuesExtractor
                 $values[] = $this->numberFormatter->format((float) $value);
                 break;
             case 'select':
-                $values[] = (string) $product->getAttributeText($code);
+                $value = $product->getAttributeText($code);
+                if (is_array($value)) {
+                    $value = reset($value);
+                }
+                $values[] = (string) $value;
                 break;
             case 'multiselect':
                 $values = (array) $product->getAttributeText($code);


### PR DESCRIPTION
- Solves issue: 
If there's no option selected for products select attribute, then `$product->getAttributeText($attributeCode)` returns empty array instead of empty string or `null`. Since we cast returned value to string, we are running into forbidden array to string conversion.

- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4
