### PR TITLE
FFWEB-2003 prevent forbidden array to string conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+---
+name: build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['7.2', '7.4']
+        deps: ['lowest', 'stable']
+        exclude:
+          - php: '7.4'
+            deps: lowest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Load Composer cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.deps }}-composer
+
+      - name: Install dependencies
+        run: |
+          composer config --global --auth http-basic.repo.magento.com "${{ secrets.MAGENTO_USERNAME }}" "${{ secrets.MAGENTO_PASSWORD }}"
+          composer config --global repositories.magento composer https://repo.magento.com/
+          composer update --no-ansi --no-interaction --prefer-${{ matrix.deps }}
+
+      - name: Run tests
+        run: |
+          vendor/bin/phpunit
+          vendor/bin/phpcs -nq .
+          vendor/bin/phpmd src text phpmd.xml.dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Changelog
+## [v1.6.6] - 2021.04.29
+### Fixed
+- Prevent array to string conversion when exporting products select attribute option
+
 ## [v1.6.5] - 2020.12.16
 ### Changed
 - Upgrade Web Components to version 3.15.10

--- a/src/Model/Export/Catalog/AttributeValuesExtractor.php
+++ b/src/Model/Export/Catalog/AttributeValuesExtractor.php
@@ -8,6 +8,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Eav\Attribute;
 use Omikron\Factfinder\Api\Filter\FilterInterface;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
+use UnexpectedValueException;
 
 class AttributeValuesExtractor
 {
@@ -25,7 +26,8 @@ class AttributeValuesExtractor
 
     public function getAttributeValues(Product $product, Attribute $attribute): array
     {
-        $value  = $product->getDataUsingMethod($attribute->getAttributeCode());
+        $code   = $attribute->getAttributeCode();
+        $value  = $product->getDataUsingMethod($code);
         $values = [];
 
         switch ($attribute->getFrontendInput()) {
@@ -36,12 +38,20 @@ class AttributeValuesExtractor
                 $values[] = $this->numberFormatter->format((float) $value);
                 break;
             case 'select':
-                $values[] = (string) $product->getAttributeText($attribute->getAttributeCode());
+                $value = $product->getAttributeText($code);
+                if (is_array($value)) {
+                    $value = reset($value);
+                }
+                $values[] = (string) $value;
                 break;
             case 'multiselect':
-                $values = (array) $product->getAttributeText($attribute->getAttributeCode());
+                $values = (array) $product->getAttributeText($code);
                 break;
             default:
+                if (!is_scalar($value)) {
+                    $msg = "Attribute '{$code}' could not be exported. Please consider writing your own field model";
+                    throw new UnexpectedValueException($msg);
+                }
                 $values[] = (string) $value;
                 break;
         }


### PR DESCRIPTION
Solves issue:
If there's no option selected for products select attribute, then $product->getAttributeText($attributeCode) returns empty array instead of empty string or null. Since we cast returned value to string, we are running into forbidden array to string conversion.

Tested with Magento editions/versions:
2.4

Tested with PHP versions:
7.4