### PR TITLE
FFWEB-20017: Encode event data before converting it to query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+#Changelog
 ## [v1.6.6] - 2021.04.29
+### Changed
+- Upgrade Web Components to version 4.0.2
+
 ### Fixed
 - Prevent array to string conversion when exporting products select attribute option
+- Event data coming from searchbox element is not URLencoded before redirecting to search result page
 
 ## [v1.6.5] - 2020.12.16
 ### Changed

--- a/src/view/frontend/web/js/search-redirect.js
+++ b/src/view/frontend/web/js/search-redirect.js
@@ -7,7 +7,7 @@ define(['factfinder'], function (factfinder) {
         element.addEventListener('before-search', function (event) {
             if (['productDetail', 'getRecords'].lastIndexOf(event.detail.type) === -1) {
                 event.preventDefault();
-                window.location = options.targetUrl + factfinder.common.dictToParameterString(event.detail);
+                window.location = options.targetUrl + factfinder.common.dictToParameterString(factfinder.common.encodeDict(event.detail));
             }
         });
     }


### PR DESCRIPTION
- Solves issue: 
If user search for phrase containing special characters they will be not correctly formed during sending a request to FACT-Finder. This applies especially to shops using FACT-Finder 7.x version where `/` is used as a separator in category paths.
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
