### PR TITLE
FFWEB-1892: Prevent sending redundant login tracking requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
+
+## Unreleased
+### Fixed
+- Login tracking events were sent with each page reload after user was logged in.
+
 ## [v2.0.0] - 2021.04.30
-## BREAKING
+### BREAKING
 - Removed config models interfaces which appeared to be unnecessary. Their only responsibility is to fetch stored config and it is unlikely to need a different implementation.  
     - `CommunicationConfigInterface`
     - `AuthConfigInterface`

--- a/src/view/frontend/web/js/view/ffcommunication.js
+++ b/src/view/frontend/web/js/view/ffcommunication.js
@@ -1,10 +1,21 @@
-define(['Magento_Customer/js/customer-data'], function (customerData) {
+define(['Magento_Customer/js/customer-data', 'factfinder'], function (customerData, factfinder) {
     'use strict';
 
     return function (config, element) {
         var sessionData = customerData.get('ffcommunication');
         sessionData.subscribe(function (data) {
-            if (data.uid && data.uid !== element.userId) element.userId = data.uid;
+            if (!data.uid) {
+                const uidKey = Object.keys(localStorage).find(function (key) {
+                    return key.indexOf(factfinder.common.localStorage.getItem('ff_sid')) === 0
+                });
+                factfinder.common.localStorage.setItem(uidKey, null);
+            }
+
+            const storedUserId = factfinder.common.localStorage.getItem(factfinder.common.localStorage.getItem('ff_sid') + ':' + data.uid);
+            if (data.uid && data.uid !== element.userId && (!storedUserId || storedUserId !== data.uid.toString())) {
+                element.userId = data.uid;
+            }
+
             if (data.internal) element.addParams = (element.addParams ? element.addParams + ',' : '') + 'log=internal';
         });
         sessionData.valueHasMutated();

--- a/src/view/frontend/web/js/view/ffcommunication.js
+++ b/src/view/frontend/web/js/view/ffcommunication.js
@@ -8,7 +8,7 @@ define(['Magento_Customer/js/customer-data', 'factfinder'], function (customerDa
                 const uidKey = Object.keys(localStorage).find(function (key) {
                     return key.indexOf(factfinder.common.localStorage.getItem('ff_sid')) === 0
                 });
-                factfinder.common.localStorage.setItem(uidKey, null);
+                if (uidKey) factfinder.common.localStorage.setItem(uidKey, null);
             }
 
             const storedUserId = factfinder.common.localStorage.getItem(factfinder.common.localStorage.getItem('ff_sid') + ':' + data.uid);


### PR DESCRIPTION
- Solves issue: 
After user is logged in, reach page reloads causes Web Components to send a new login tracking request. This fix is preventing that.
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4

