### PR TITLE
FFWEB-2034: Fix "area code is not set" during installation on Magento2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
-
 ## Unreleased
 ### Fixed
-- Login tracking events were sent with each page reload after user was logged in.
+ - Fix "Area code is not set" during installation on Magento 2.4.2
+ - Login tracking events were sent with each page reload after user was logged in.
 
 ## [v2.0.0] - 2021.04.30
 ### BREAKING

--- a/src/Model/Export/Cms/Field/Image.php
+++ b/src/Model/Export/Cms/Field/Image.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Export\Cms\Field;
 
 use Magento\Cms\Api\Data\PageInterface;
-use Magento\Email\Model\Template\Filter as TemplateFilter;
+use Magento\Email\Model\Template\Filter;
 use Omikron\Factfinder\Api\Export\FieldInterface;
 use Magento\Framework\Model\AbstractModel;
 
 class Image implements FieldInterface
 {
-    /** @var TemplateFilter */
+    /** @var Filter */
     private $filter;
 
-    public function __construct(TemplateFilter $filter)
+    public function __construct(Filter $filter)
     {
         $this->filter = $filter;
     }
@@ -30,7 +30,7 @@ class Image implements FieldInterface
      */
     public function getValue(AbstractModel $page): string
     {
-        $pattern = '#https?://[^/\s]+/\S+\.(jpe?g|png|gif)#';
+        $pattern = '#https?://[^/\s]+/\S+\.(jpe?g|png|gif)#i';
         preg_match($pattern, $this->filter->filter((string) $page->getContent()), $result);
         return $result[0] ?? '';
     }

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -108,6 +108,16 @@
             </argument>
         </arguments>
     </type>
+    <type name="Omikron\Factfinder\Model\Export\Cms\Field\Content">
+        <arguments>
+            <argument name="filter" xsi:type="object">Magento\Email\Model\Template\Filter\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Omikron\Factfinder\Model\Export\Cms\Field\Image">
+        <arguments>
+            <argument name="filter" xsi:type="object">Magento\Email\Model\Template\Filter\Proxy</argument>
+        </arguments>
+    </type>
     <type name="Omikron\Factfinder\Model\Export\Catalog\ProductField\Attributes">
         <arguments>
             <argument name="filter" xsi:type="object">Omikron\Factfinder\Model\Filter\ExtendedTextFilter</argument>


### PR DESCRIPTION
- Solves issue: 
- #313 
- Tested with Magento editions/versions: 
2.4.2
- Tested with PHP versions: 
7.4
