### PR TITLE
FFWEB-2040: Use catalogAddToCart widget on `ff-record` element V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Changelog
 ## Unreleased
 ### Added
-- Add possibility to export fields from variant level. Previously export took only configurable attributes from variants and rest was copied from parent
+ - Add possibility to export fields from variant level. Previously export took only configurable attributes from variants and rest was copied from parent
+ - Use catalogAddToCart widget on `ff-record` elements 
 
 ## [v2.0.2] - 2021.06.15
 ### Changed
-- Upgrade Web Components to version 4.0.3
+ - Upgrade Web Components to version 4.0.3
 
 ### Fixed
-- Fixed behaviour of Attribute export for products - if value is nullable, return an empty string instead of throwing exception
+ - Fixed behaviour of Attribute export for products - if value is nullable, return an empty string instead of throwing exception
 
 ## [v2.0.1] - 2021.05.14
 ### Fixed

--- a/src/view/frontend/templates/ff/record-list.phtml
+++ b/src/view/frontend/templates/ff/record-list.phtml
@@ -45,3 +45,15 @@ $viewModel = $block->getViewModel();
         </ff-record>
     </ff-record-list>
 </div>
+<script>
+    require(['jquery', 'catalogAddToCart'], function ($) {
+        document.addEventListener('WebComponentsReady', function (ff) {
+            document.querySelectorAll('ff-record-list').forEach(function (recordList) {
+                recordList.addEventListener('dom-updated', function () {
+                    const addToCartForm = $('.product_addtocart_form');
+                    if (addToCartForm) addToCartForm.catalogAddToCart();
+                });
+            })
+        });
+    });
+</script>


### PR DESCRIPTION
- Description: 
Use Magento2 [`catalogAddToCart` ](https://github.com/pepe1518/magento2/blob/master/vendor/magento/module-catalog/view/frontend/web/js/catalog-add-to-cart.js) widget on `ff-record` element. This allows to perform ajax addToCart action and hook with custom scripts after product is added to the cart
- Tested with Magento editions/versions: 
2.4.0
- Tested with PHP versions: 
7.4