### PR TITLE
FFWEB-2062: Attribute export for products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+### Fixed
+ - Fixed behaviour of Attribute export for products - if value is nullable, return an empty string instead of throwing exception
+
+
 ## [v1.6.7] - 2021.05.14
 ### Fixed
  - Fixed "Area code is not set" during installation on Magento 2.4.2

--- a/src/Model/Export/Catalog/AttributeValuesExtractor.php
+++ b/src/Model/Export/Catalog/AttributeValuesExtractor.php
@@ -49,8 +49,14 @@ class AttributeValuesExtractor
                 break;
             default:
                 if (!is_scalar($value)) {
-                    $msg = "Attribute '{$code}' could not be exported. Please consider writing your own field model";
-                    throw new UnexpectedValueException($msg);
+                    switch (true) {
+                        case $value === null:
+                            $value = '';
+                            break;
+                        default:
+                            $msg = "Attribute '{$code}' could not be exported. Please consider writing your own field model";
+                            throw new UnexpectedValueException($msg);
+                    }
                 }
                 $values[] = (string) $value;
                 break;

--- a/src/Test/Unit/Model/Export/Catalog/AttributeValuesExtractorTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/AttributeValuesExtractorTest.php
@@ -2,8 +2,6 @@
 
 namespace Omikron\Factfinder\Model\Export\Catalog;
 
-use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Email\Model\Template\Filter;
 use Omikron\Factfinder\Api\Filter\FilterInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Eav\Attribute;

--- a/src/Test/Unit/Model/Export/Catalog/AttributeValuesExtractorTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/AttributeValuesExtractorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Omikron\Factfinder\Model\Export\Catalog;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Email\Model\Template\Filter;
+use Omikron\Factfinder\Api\Filter\FilterInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ResourceModel\Eav\Attribute;
+use Omikron\Factfinder\Model\Formatter\NumberFormatter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class AttributeValuesExtractorTest extends TestCase
+{
+    private $filterMock;
+    private $numberFormatter;
+    private $attributeExtractor;
+
+    public function test_it_return_empty_string_on_null_value()
+    {
+        $productMock = $this->createMock(Product::class, ['getSku' => 'sku-1']);
+        $attributeMock = $this->createMock(Attribute::class, []);
+        $attributeValues = $this->attributeExtractor->getAttributeValues($productMock, $attributeMock);
+        $this->assertEquals([], $attributeValues);
+    }
+
+    protected function setUp(): void
+    {
+        $this->filterMock = $this->createMock(FilterInterface::class, []);
+        $this->numberFormatter = $this->createMock(NumberFormatter::class, []);
+        $this->attributeExtractor = new AttributeValuesExtractor($this->filterMock, $this->numberFormatter);
+    }
+}

--- a/src/Test/Unit/Model/Export/Catalog/AttributeValuesExtractorTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/AttributeValuesExtractorTest.php
@@ -7,20 +7,42 @@ use Magento\Email\Model\Template\Filter;
 use Omikron\Factfinder\Api\Filter\FilterInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Eav\Attribute;
+use Omikron\Factfinder\Model\Filter\TextFilter;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AttributeValuesExtractorTest extends TestCase
 {
-    private $filterMock;
+    /** @var NumberFormatter|MockObject  */
     private $numberFormatter;
+
+    /** @var AttributeValuesExtractor  */
     private $attributeExtractor;
 
-    public function test_it_return_empty_string_on_null_value()
+    public function test_it_returns_scalar_value()
     {
-        $productMock = $this->createMock(Product::class, ['getSku' => 'sku-1']);
-        $attributeMock = $this->createMock(Attribute::class, []);
+        $attributeValue  = 'Value';
+        $productMock = $this->createConfiguredMock(Product::class, [
+            'getDataUsingMethod' => $attributeValue
+        ]);
+        $attributeMock = $this->createConfiguredMock(Attribute::class, [
+            'getAttributeCode' => 'test-atttribute',
+            'getFrontendInput' => 'varchar'
+        ]);
+        $attributeValues = $this->attributeExtractor->getAttributeValues($productMock, $attributeMock);
+        $this->assertEquals([$attributeValue], $attributeValues);
+    }
+
+    public function test_it_returns_empty_string_on_null_value()
+    {
+        $productMock = $this->createConfiguredMock(Product::class, [
+            'getDataUsingMethod' => null
+        ]);
+        $attributeMock   = $this->createConfiguredMock(Attribute::class, [
+            'getAttributeCode' => 'test-atttribute',
+            'getFrontendInput' => 'varchar'
+        ]);
         $attributeValues = $this->attributeExtractor->getAttributeValues($productMock, $attributeMock);
         $this->assertEquals([], $attributeValues);
     }
@@ -29,6 +51,6 @@ class AttributeValuesExtractorTest extends TestCase
     {
         $this->filterMock = $this->createMock(FilterInterface::class, []);
         $this->numberFormatter = $this->createMock(NumberFormatter::class, []);
-        $this->attributeExtractor = new AttributeValuesExtractor($this->filterMock, $this->numberFormatter);
+        $this->attributeExtractor = new AttributeValuesExtractor(new TextFilter(), $this->numberFormatter);
     }
 }


### PR DESCRIPTION
- Solves issue: 
   Return and emtpy string if value is NULL while exporting attributes
- Description:
  When AttributeValuesExtractor is exporting attributes, it should return an empty string instead of throwing errors when value is nullable
- Tested with Magento editions/versions: 2
- Tested with PHP versions:  7.4
