### PR TITLE
FFWEB-2062: If the value of a product for the attribute is NULL then …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+### Fixed
+- Fixed behaviour of Attribute export for products - if value is nullable, return an empty string instead of throwing exception
+
 ## [v2.0.1] - 2021.05.14
 ### Fixed
  - Fixed "Area code is not set" during installation on Magento 2.4.2

--- a/src/Model/Export/Catalog/AttributeValuesExtractor.php
+++ b/src/Model/Export/Catalog/AttributeValuesExtractor.php
@@ -49,8 +49,14 @@ class AttributeValuesExtractor
                 break;
             default:
                 if (!is_scalar($value)) {
-                    $msg = "Attribute '{$code}' could not be exported. Please consider writing your own field model";
-                    throw new UnexpectedValueException($msg);
+                    switch (true) {
+                        case $value === null:
+                            $value = '';
+                            break;
+                        default:
+                            $msg = "Attribute '{$code}' could not be exported. Please consider writing your own field model";
+                            throw new UnexpectedValueException($msg);
+                    }
                 }
                 $values[] = (string) $value;
                 break;

--- a/src/Test/Unit/Model/Export/Catalog/AttributeValuesExtractorTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/AttributeValuesExtractorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Omikron\Factfinder\Model\Export\Catalog;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Email\Model\Template\Filter;
+use Omikron\Factfinder\Api\Filter\FilterInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ResourceModel\Eav\Attribute;
+use Omikron\Factfinder\Model\Formatter\NumberFormatter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class AttributeValuesExtractorTest extends TestCase
+{
+    private $filterMock;
+    private $numberFormatter;
+    private $attributeExtractor;
+
+    public function test_it_return_empty_string_on_null_value()
+    {
+        $productMock = $this->createMock(Product::class, ['getSku' => 'sku-1']);
+        $attributeMock = $this->createMock(Attribute::class, []);
+        $attributeValues = $this->attributeExtractor->getAttributeValues($productMock, $attributeMock);
+        $this->assertEquals([], $attributeValues);
+    }
+
+    protected function setUp(): void
+    {
+        $this->filterMock = $this->createMock(FilterInterface::class, []);
+        $this->numberFormatter = $this->createMock(NumberFormatter::class, []);
+        $this->attributeExtractor = new AttributeValuesExtractor($this->filterMock, $this->numberFormatter);
+    }
+}


### PR DESCRIPTION
…change it to an empty string

- Solves issue: 
- Description: 
- Tested with Magento editions/versions: 
- Tested with PHP versions: 

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
