### PR TITLE
FFWEB-2066: add additional attributes to variant products from parent configurable product

### DIFF
--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -65,7 +65,7 @@ class ConfigurableDataProvider extends SimpleDataProvider
             return $this->variationFactory->create([
                 'product'      => $variation,
                 'configurable' => $product,
-                'data'         => ['FilterAttributes' => '|' . implode('|', $options[$sku] ?? []) . '|'] + $data,
+                'data'         => ['FilterAttributes' => (empty($data['FilterAttributes']) ? '|' : $data['FilterAttributes']) . implode('|', $options[$sku] ?? []) . '|'] + $data,
             ]);
         };
     }


### PR DESCRIPTION
- Solves issue: 
  FFWEB-2066

- Description: 
  This PR solves an issue with adding additional attributes for variant products in feed

- Tested with Magento editions/versions: 
  2.4

- Tested with PHP versions: 
  7.4
