### PR TITLE
FFWEB-2066: Add variant based field export V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Changelog
+## Unreleased
+### Added
+- Add possibility to export fields from variant level. Previously export took only configurable attributes from variants and rest was copied from parent
+
 ## [v2.0.2] - 2021.06.15
 ### Changed
 - Upgrade Web Components to version 4.0.3

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ customise them.
         - [GenericField usage](#genericfield-usage)
     - [Adding custom communication parameter](#adding-custom-communication-parameter)
     - [Adding custom product data provider](#adding-custom-product-data-provider)
+    - [Configure field to be exported from variant](#configure-field-to-be-exported-from-variant)
 - [Troubleshooting](#troubleshooting)
     - [Removing `/pub` from exported URLs](#removing-pub-from-exported-urls)
 - [Contribute](#contribute)
@@ -507,6 +508,29 @@ class CustomDataProvider implements DataProviderInterface
 ```
 
 It's a minimum configuration. `$product` constructor will be passed automatically and in method `getEntities` You should extract all required data
+
+### Configure field to be exported from variant
+By default, module exports data from configurable product. Its variants override only few of fields which you can see in class:
+
+    src/Model/Export/Catalog/Entity/ProductVariation.php
+
+This is done to provide the best performance but if you variants differs in some attributes other than configurable attributes (color, size etc.) You can configure which fields should be exported from variants.
+Use `variantFields` argument for that. 
+Here is the example from module, where we want to export `ImageURL` from variants because some configurable attribute could have an impact on the how product looks (color is a good example).
+```xml
+<type name="Omikron\Factfinder\Model\Export\Catalog\FieldProvider">
+    <arguments>
+        <argument name="productFields" xsi:type="array">
+            <item name="CategoryPath" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\CategoryPath</item>
+            <item name="Brand" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\Brand</item>
+            <item name="FilterAttributes" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\FilterAttributes</item>
+        </argument>
+        <argument name="variantFields" xsi:type="array">
+            <item name="ImageURL" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage</item>
+        </argument>
+    </arguments>
+</type>
+```
 
 ## Troubleshooting
 

--- a/src/Api/Export/FieldProviderInterface.php
+++ b/src/Api/Export/FieldProviderInterface.php
@@ -10,14 +10,20 @@ namespace Omikron\Factfinder\Api\Export;
 interface FieldProviderInterface
 {
     /**
-     * Method should return an array where
-     * a keys represents the field names and the values
-     * are a FieldInterface implementation responsible
-     * for retrieving corresponding product value
+     * Method should return an array of fields which should be taken from configurable product
      *
      * @see FieldInterface
      *
      * @return array
      */
     public function getFields(): array;
+
+    /**
+     * Method should return an array of fields which should be taken from variants
+     *
+     * @see FieldInterface
+     *
+     * @return array
+     */
+    public function getVariantFields(): array;
 }

--- a/src/Model/Export/FeedFactory.php
+++ b/src/Model/Export/FeedFactory.php
@@ -30,9 +30,12 @@ class FeedFactory
             throw new InvalidArgumentException(sprintf('There is no feed configuration for the given type: %s', $type));
         }
 
-        $fields = is_array($this->feedPool[$type]['fieldProvider'])
-            ? $this->feedPool[$type]['fieldProvider']
-            : $this->objectManager->create($this->feedPool[$type]['fieldProvider'])->getFields();
+        $fieldProvider = $this->feedPool[$type]['fieldProvider'];
+        $fields = is_array($fieldProvider)
+            ? $fieldProvider
+            : call_user_func(function(FieldProviderInterface $fieldProvider) {
+                return $fieldProvider->getFields() + $fieldProvider->getVariantFields();
+            }, $this->objectManager->create($fieldProvider));
 
         $dataProvider = $this->objectManager->create($this->feedPool[$type]['dataProvider'], ['fields' => $fields]);
 

--- a/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Model\Export\Catalog\Entity;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product;
+use Omikron\Factfinder\Model\Export\Catalog\FieldProvider;
+use Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage;
+use Omikron\Factfinder\Model\Formatter\NumberFormatter;
+use PHPUnit\Framework\TestCase;
+
+class ProductVariationTest extends TestCase
+{
+    public function test_variant_data_will_override_the_parent()
+    {
+        $configurableProductData = [
+            'ProductNumber' => 'sku-configurable',
+            'Price'         => '8.99',
+            'HasVariants'   => 1,
+            'MagentoId'     => 1,
+            'ImageUrl'      => 'http://random-variant-image.png'
+        ];
+
+        $variantMock = $this->createConfiguredMock(
+            Product::class,
+            [
+                'getSku'        => 'sku-variant',
+                'getFinalPrice' => '9.99',
+                'isAvailable'   => true,
+                'getId'         => 2
+            ]
+        );
+
+        $fieldProviderMock = $this->createConfiguredMock(
+            FieldProvider::class,
+            [
+                'getVariantFields' => [
+                    'image_url' => $this->createConfiguredMock(
+                        ProductImage::class,
+                        [
+                            'getName'  => 'ImageUrl',
+                            'getValue' => 'http://specific-variant-image.png'
+                        ]
+                    )
+                ]
+            ]
+        );
+
+        $productVariation = new ProductVariation(
+            $variantMock,
+            $this->createMock(Product::class),
+            new NumberFormatter(),
+            $fieldProviderMock,
+            $configurableProductData
+        );
+
+        $this->assertEquals(
+            [
+                'ProductNumber' => 'sku-variant',
+                'Price'         => '9.99',
+                'Availability'  => 1,
+                'HasVariants'   => 0,
+                'MagentoId'     => 2,
+                'ImageUrl'      => 'http://specific-variant-image.png'
+            ], $productVariation->toArray()
+        );
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -81,10 +81,12 @@
     <type name="Omikron\Factfinder\Model\Export\Catalog\FieldProvider">
         <arguments>
             <argument name="productFields" xsi:type="array">
-                <item name="ImageURL" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage</item>
                 <item name="CategoryPath" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\CategoryPath</item>
                 <item name="Brand" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\Brand</item>
                 <item name="FilterAttributes" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\FilterAttributes</item>
+            </argument>
+            <argument name="variantFields" xsi:type="array">
+                <item name="ImageURL" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
- Description: 
Adds possibility to export fields stored on variants instead of copy values from configurable product
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4