### PR TITLE
FFWEB-2066: Add variant based field export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Added
+- Add possibility to export fields from variant level. Previously export took only configurable attributes from variants and rest was copied from parent
+
 ## [v1.6.8] - 2021.06.15
 ### Changed
 - Upgrade Web Components to version 4.0.3

--- a/README.md
+++ b/README.md
@@ -531,6 +531,32 @@ class CustomDataProvider implements DataProviderInterface
 }
 ```
 
+### Configure field to be exported from variant
+By default, module exports data from configurable product. Its variants override only few of fields which you can see in class:
+
+    src/Model/Export/Catalog/Entity/ProductVariation.php
+
+This is done to provide the best performance but if you variants differs in some attributes other than configurable attributes (color, size etc.) You can configure which fields should be exported from variants.
+Use `variantFields` argument for that.
+Here is the example from module, where we want to export `ImageURL` from variants because some configurable attribute could have an impact on the how product looks (color is a good example).
+```xml
+<type name="Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProvider">
+    <arguments>
+        <argument name="productFields" xsi:type="array">
+            <item name="ImageURL" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage</item>
+            <item name="CategoryPath" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\CategoryPath</item>
+            <item name="Brand" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\Brand</item>
+            <item name="Attributes" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\Attributes</item>
+        </argument>
+        <argument name="variantFields" xsi:type="array">
+            <item name="ImageURL" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage</item>
+            <item name="Attributes" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\Attributes</item>
+        </argument>
+    </arguments>
+</type>
+```
+**Note:** We advise to left the field you want to be exported from variant in `productFields` argument. This will prevent exporter from exporting `null` values for configurable products.
+
 It's a minimum configuration. `$product` constructor will be passed automatically and in method `getEntities` You should extract all required data
 
 ## Troubleshooting

--- a/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Model\Export\Catalog\Entity;
+
+use Magento\Catalog\Model\Product;
+use Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage;
+use Omikron\Factfinder\Model\Formatter\NumberFormatter;
+use PHPUnit\Framework\TestCase;
+
+class ProductVariationTest extends TestCase
+{
+
+    public function test_variant_data_will_override_the_parent()
+    {
+        $configurableProductData = [
+            'ProductNumber' => 'sku-configurable',
+            'Price'         => '8.99',
+            'HasVariants'   => 1,
+            'MagentoId'     => 1,
+            'ImageUrl'      => 'http://random-variant-image.png'
+        ];
+
+        $variantMock = $this->createConfiguredMock(Product::class, [
+            'getSku'        => 'sku-variant',
+            'getFinalPrice' => '9.99',
+            'isAvailable'   => true,
+            'getId'         => 2
+        ]);
+
+        $fieldsMock = [
+            'ImageUrl' => $this->createConfiguredMock(
+                ProductImage::class,
+                [
+                    'getValue' => 'http://specific-variant-image.png'
+                ])
+        ];
+
+        $productVariation = new ProductVariation(
+            $variantMock,
+            $this->createMock(Product::class),
+            new NumberFormatter(),
+            $configurableProductData,
+            $fieldsMock
+        );
+
+        $this->assertEquals([
+            'ProductNumber' => 'sku-variant',
+            'Price'         => '9.99',
+            'Availability'  => 1,
+            'HasVariants'   => 0,
+            'MagentoId'     => 2,
+            'ImageUrl'      => 'http://specific-variant-image.png'
+        ], $productVariation->toArray());
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -149,6 +149,10 @@
                 <item name="Brand" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\Brand</item>
                 <item name="Attributes" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\Attributes</item>
             </argument>
+            <argument name="variantFields" xsi:type="array">
+                <item name="ImageURL" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage</item>
+                <item name="Attributes" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\Attributes</item>
+            </argument>
         </arguments>
     </type>
     <type name="Omikron\Factfinder\Model\Export\Cms\Field\Content">


### PR DESCRIPTION
- Solves issue: 
#321 
- Description:
Adds possibility to export fields stored on variants instead of copy values from configurable product
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions:
7.4

