### PR TITLE
FFWEN-2163: SSR Record list does not render after first search returns no records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   - Export
     - Add possibility to select field to be exported as numerical in module configuration. Numerical fields will be exported in new multi-attribute column `NumericalAttributes`   
 
+### Fix
+ - Fix SSR after first search with 0 result, next will render no products even if FACT-Finder returns some
+
 ## [v2.1.0] - 2021.07.15
 ### Added
  - Add possibility to export fields from variant level. Previously export took only configurable attributes from variants and rest was copied from parent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
     - Add possibility to select field to be exported as numerical in module configuration. Numerical fields will be exported in new multi-attribute column `NumericalAttributes`   
 
 ### Fix
- - Fix SSR after first search with 0 result, next will render no products even if FACT-Finder returns some
+ - SSR
+    - after first search with 0 result, next will render no products even if FACT-Finder returns them
 
 ## [v2.1.0] - 2021.07.15
 ### Added

--- a/src/Block/Ssr/RecordList.php
+++ b/src/Block/Ssr/RecordList.php
@@ -66,7 +66,9 @@ class RecordList extends Template
 
         // Add pre-rendered records
         $html = preg_replace_callback(self::RECORD_PATTERN, function (array $match) use ($result): string {
-            $template = '<template data-role="record">' . $match[0] . '</template>';
+            // $match[0] is added twice due to SSR bug in Web Components. ff-record template need to be added one time
+            // as a template and one time as regular ff-record element
+            $template = '<template data-role="record">' . $match[0] .'</template>' . $match[0];
             return array_reduce($result['records'] ?? [], $this->recordRenderer($match[0]), $template);
         }, $html);
 


### PR DESCRIPTION
 - Description: 
 If you search for the first time with a query which gives you no result, the next search, no matter it returns records or not, will not make record list to render it. It's because there is only <template data-role="record"> and apparently standalone version of the ff-record is also necessary
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4

