### PR TITLE
FFWEB-2170: SSR use URL string parameters from request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 ## Unreleased
+### BREAKING
+- SSR
+    Due to FACT-Finder filters format in GET request (multiple parameters with the same name `filter`) we were in need to change the implementation of:  
+    `src/Model/Ssr/SearchAdapter.php` - changed function definition 
+    `public function search(string $query = '*', array $params = []): array` to `public function search(string $paramString): array`
+    
 ### Added
-  - SSR
+ - Export:
+    - Add possibility to select field to be exported as numerical in module configuration. Numerical fields will be exported in new multi-attribute column `NumericalAttributes`
+ - SSR
     - Added Single Hit Redirection feature when SSR is enabled
-  - Export
-    - Add possibility to select field to be exported as numerical in module configuration. Numerical fields will be exported in new multi-attribute column `NumericalAttributes`   
+    - Now remembers the user selected search parameters (filters, sorting, etc.)   
 
 ### Fix
  - SSR

--- a/src/Block/Ssr/RecordList.php
+++ b/src/Block/Ssr/RecordList.php
@@ -6,6 +6,7 @@ namespace Omikron\Factfinder\Block\Ssr;
 
 use Magento\Framework\App\Response\Http as Response;
 use Magento\Framework\App\Response\RedirectInterface;
+use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\View\Element\Template;
 use Omikron\Factfinder\Model\FieldRoles;
@@ -59,7 +60,7 @@ class RecordList extends Template
             return "<ff-record-list ssr {$attributes}>";
         }, $html);
 
-        $result = $this->searchResult($this->getRequest()->getParam('query', '*'), $this->getSearchParams());
+        $result = $this->searchResult($this->getRequest(), $this->getSearchParams());
         if ($this->shouldRedirect($result)) {
             $this->redirectToProductPage($result);
         }
@@ -75,9 +76,11 @@ class RecordList extends Template
         return str_replace('{FF_SEARCH_RESULT}', $this->jsonSerializer->serialize($result), $html);
     }
 
-    protected function searchResult(string $query, array $params): array
+    protected function searchResult(RequestInterface $request, array $searchParams): array
     {
-        return $this->searchAdapter->search($query, $params);
+        $paramsString = implode('&', [parse_url($request->getUriString() ,PHP_URL_QUERY), http_build_query($searchParams)]);
+
+        return $this->searchAdapter->search($paramsString);
     }
 
     protected function recordRenderer(string $template): callable

--- a/src/Model/Ssr/PriceFormatter.php
+++ b/src/Model/Ssr/PriceFormatter.php
@@ -37,7 +37,7 @@ class PriceFormatter
         $records     = $isNG ? $searchResult['hits'] : $searchResult['searchResult']['records'];
         $recordField = $isNG ? 'masterValues' : 'record';
 
-        return array_map($this->price($priceField, $recordField), $records);
+        return ['records' => array_map($this->price($priceField, $recordField), $records)] + $searchResult;
     }
 
     protected function price(string $priceField, string $recordField): callable

--- a/src/Model/Ssr/SearchAdapter.php
+++ b/src/Model/Ssr/SearchAdapter.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\Model\Ssr;
 
-use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
+use Omikron\FactFinder\Communication\Client\ClientException;
 use Omikron\FactFinder\Communication\Resource\AdapterFactory;
+use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Model\Api\CredentialsFactory;
+use Omikron\Factfinder\Model\Config\CommunicationConfig;
+use Psr\Http\Message\ResponseInterface;
 
 class SearchAdapter
 {
@@ -35,16 +38,36 @@ class SearchAdapter
         $this->priceFormatter      = $priceFormatter;
     }
 
-    public function search(string $query = '*', array $params = []): array
+    public function search(string $paramString): array
     {
         $client = $this->clientBuilder
             ->withServerUrl($this->communicationConfig->getAddress())
-            ->withCredentials($this->credentialsFactory->create());
+            ->withCredentials($this->credentialsFactory->create())
+            ->withVersion($this->communicationConfig->getVersion())
+            ->build();
 
-        $searchAdapter           = (new AdapterFactory($client, $this->communicationConfig->getVersion()))->getSearchAdapter();
-        $searchResult            = $searchAdapter->search($this->communicationConfig->getChannel(), $query, $params);
-        $searchResult['records'] = $this->priceFormatter->format($searchResult);
+        $endpoint = $this->createEndpoint($paramString);
+        $response = $client->request('GET', $endpoint);
 
-        return $searchResult;
+        if (!$response) {
+            throw new ClientException('The response was empty');
+        }
+
+        return $this->priceFormatter->format($this->searchResult($response));
+    }
+
+    private function searchResult(ResponseInterface $response): array
+    {
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    private function createEndpoint(string $paramString)
+    {
+        $channel  = $this->communicationConfig->getChannel();
+        $endpoint = (bool) preg_match('/navigation=true/', $paramString) ? 'navigation' : 'search';
+
+        return $this->communicationConfig->getVersion() == Version::NG
+            ? "rest/v4/{$endpoint}/{$channel}?{$paramString}"
+            : "Search.ff?channel={$channel}&{$paramString}&format=json";
     }
 }

--- a/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
@@ -11,6 +11,9 @@ use Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers ProductVariation
+ */
 class ProductVariationTest extends TestCase
 {
     public function test_variant_data_will_override_the_parent()


### PR DESCRIPTION
 - Description: 
 SSR remembers user selection (filters, sorting etc) after reloading
Also for category pages it uses navigation instead of search
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4