### PR TITLE
FFWEB-2197: Add variable casting to string to prevent fatal error on export

### DIFF
--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -87,7 +87,7 @@ class ConfigurableDataProvider extends SimpleDataProvider
     {
         return array_reduce($this->productType->getConfigurableOptions($product), function (array $res, array $option) {
             foreach ($option as ['sku' => $sku, 'super_attribute_label' => $label, 'option_title' => $value]) {
-                $res[$this->checkOptionValue($sku)][] = "{$this->filter->filterValue($this->checkOptionValue($label))}={$this->filter->filterValue($this->checkOptionValue($value))}";
+                $res[$this->getValueOrEmptyString($sku)][] = "{$this->filter->filterValue($this->getValueOrEmptyString($label))}={$this->filter->filterValue($this->getValueOrEmptyString($value))}";
             }
             return $res;
         }, []);
@@ -106,7 +106,7 @@ class ConfigurableDataProvider extends SimpleDataProvider
             ->getItems();
     }
 
-    private function checkOptionValue(string $value = null): string
+    private function getValueOrEmptyString(string $value = null): string
     {
         return $value ?? '';
     }

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -87,6 +87,9 @@ class ConfigurableDataProvider extends SimpleDataProvider
     {
         return array_reduce($this->productType->getConfigurableOptions($product), function (array $res, array $option) {
             foreach ($option as ['sku' => $sku, 'super_attribute_label' => $label, 'option_title' => $value]) {
+                $sku = $sku ?? '';
+                $label = $label ?? '';
+                $value = $value ?? '';
                 $res[$sku][] = "{$this->filter->filterValue($label)}={$this->filter->filterValue($value)}";
             }
             return $res;

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -87,10 +87,7 @@ class ConfigurableDataProvider extends SimpleDataProvider
     {
         return array_reduce($this->productType->getConfigurableOptions($product), function (array $res, array $option) {
             foreach ($option as ['sku' => $sku, 'super_attribute_label' => $label, 'option_title' => $value]) {
-                $sku = $sku ?? '';
-                $label = $label ?? '';
-                $value = $value ?? '';
-                $res[$sku][] = "{$this->filter->filterValue($label)}={$this->filter->filterValue($value)}";
+                $res[$this->checkOptionValue($sku)][] = "{$this->filter->filterValue($this->checkOptionValue($label))}={$this->filter->filterValue($this->checkOptionValue($value))}";
             }
             return $res;
         }, []);
@@ -107,5 +104,10 @@ class ConfigurableDataProvider extends SimpleDataProvider
             ->getList($this->builder->addFilter('entity_id', $this->productType->getChildrenIds($this->product->getId()), 'in')
             ->create())
             ->getItems();
+    }
+
+    private function checkOptionValue(string $value = null): string
+    {
+        return $value ?? '';
     }
 }


### PR DESCRIPTION
- Solves issue: 
FFWEB-2197

- Description: 
Resolve fatal error issue on export 

- Tested with Magento editions/versions: 
2.4.2

- Tested with PHP versions: 
7.4.20