### PR TITLE
FFWEB-2205: Dont check if import is running on 7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Fix
  - SSR
     - after first search with 0 result, next will render no products even if FACT-Finder returns them
+ - Import
+    - PushImport triggers not implemented `running` method in Communication SDK for 7.3 version
 
 ## [v2.1.0] - 2021.07.15
 ### Added

--- a/src/Model/Api/PushImport.php
+++ b/src/Model/Api/PushImport.php
@@ -7,6 +7,7 @@ namespace Omikron\Factfinder\Model\Api;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Client\ClientException;
 use Omikron\FactFinder\Communication\Resource\AdapterFactory;
+use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Omikron\Factfinder\Model\Config\ExportConfig;
 use Psr\Log\LoggerInterface;
@@ -56,7 +57,7 @@ class PushImport
             return false;
         }
 
-        if ($importAdapter->running($channel)) {
+        if ($this->communicationConfig->getVersion() === Version::NG && $importAdapter->running($channel)) {
             throw new ClientException("Can't start a new import process. Another one is still going");
         }
 


### PR DESCRIPTION
- Description: 
Do not check if import is running as the communication API doesn not support it for version 7.3
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4

