### PR TITLE
FFWEB-2215 add utility for redirection to search result page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 ## Unreleased
 ### Added
   - SSR
-    - Added Single Hit Redirection feature when SSR is enabled
+    - Add Single Hit Redirection feature when SSR is enabled
   - Export
-    - Add possibility to select field to be exported as numerical in module configuration. Numerical fields will be exported in new multi-attribute column `NumericalAttributes`   
+    - Add possibility to select field to be exported as numerical in module configuration. Numerical fields will be exported in new multi-attribute column `NumericalAttributes`
+  - Navigation
+    - Add `ffRedirectToSearchResultPage` function which could be used to manually redirect to search result page.
+    
+### Changed    
+  Navigation     
   - Remove category filter from ff-asn block on Category page
 
 ### Fix

--- a/src/view/frontend/web/js/search-redirect.js
+++ b/src/view/frontend/web/js/search-redirect.js
@@ -10,5 +10,18 @@ define(['factfinder'], function (factfinder) {
                 window.location = options.targetUrl + factfinder.common.dictToParameterString(factfinder.common.encodeDict(event.detail));
             }
         });
+
+        if (!window.hasOwnProperty('ffRedirectToSearchResultPage')) {
+            window.ffRedirectToSearchResultPage = function (query, addlParams) {
+                const detail = Object.assign({type: 'search', query: query}, addlParams);
+                const event = new CustomEvent('before-search', {
+                    detail: detail,
+                    bubbles: true,
+                    cancelable: true,
+                    composed: true
+                });
+                element.dispatchEvent(event);
+            }
+        }
     }
 });

--- a/src/view/frontend/web/js/view/ffcommunication.js
+++ b/src/view/frontend/web/js/view/ffcommunication.js
@@ -1,11 +1,11 @@
-define(['Magento_Customer/js/customer-data', 'factfinder'], function (customerData, factfinder) {
+define(['Magento_Customer/js/customer-data', 'factfinder','underscore',], function (customerData, factfinder, _) {
     'use strict';
 
     return function (config, element) {
         var sessionData = customerData.get('ffcommunication');
         sessionData.subscribe(function (data) {
             if (!data.uid) {
-                const uidKey = Object.keys(localStorage).find(function (key) {
+                const uidKey = _.find(Object.keys(localStorage), function (key) {
                     return key.indexOf(factfinder.common.localStorage.getItem('ff_sid')) === 0
                 });
                 if (uidKey) factfinder.common.localStorage.setItem(uidKey, null);


### PR DESCRIPTION
- Solves:
- #342 
- Description: 
add `ffRedirectToSearchResultPage`  and assign it to window object to be globally available
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4

