### PR TITLE
FFWEB-2251: Fix extracting added product id from the event data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Fix
+ - Tracking
+    - Add to cart tracking throws an error on versions less than 2.4
+
 ## [v2.2.0] - 2021.10.01
 ### Added
   - SSR

--- a/src/view/frontend/web/js/catalog-add-to-cart-mixin.js
+++ b/src/view/frontend/web/js/catalog-add-to-cart-mixin.js
@@ -8,7 +8,7 @@ define([
 
     $(document).on('ajax:addToCart', function (event, eventData) {
         const cart = customerData.get('cart');
-        const productId = _.first(eventData.productInfo, null, {id: 0}).id;
+        const productId = _.first(eventData.productIds);
         let subscription;
 
         if (productId && (!subscription || subscription.isDisposed)) {


### PR DESCRIPTION
- Solves issue: 
#346 
- Tested with Magento editions/versions:
2.3.4, 2.3.5, 2.4.0
- Tested with PHP versions: 
7.4
