### PR TITLE
FFWEB-2170: Params handling in SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,22 @@
 # Changelog
-## [v2.3.0]
-### Added
-- Category Page
-    - for NG version implement `category-page` attribute
+## Unreleased
+### BREAKING
+- SSR
+    Due to FACT-Finder filters format in GET request (multiple parameters with the same name `filter`) we were in need to change the implementation of:  
+    `src/Model/Ssr/SearchAdapter.php` - changed function definition 
+    `public function search(string $query = '*', array $params = []): array` to `public function search(string $paramString): array`
+### Add
+ - SSR
+   - Now remembers the user selected search parameters (filters, sorting, etc.)
  - Upload
-    - Implement SFTP upload with public key authentication method
+   - Implement SFTP upload with public key authentication method     
 
 ### Fix
  - Tracking
     - Add to cart tracking throws an error on versions less than 2.4
-  
+ - Suggest
+   - Category suggestion are redirected to search result page with query *
+   
 ## [v2.2.0] - 2021.10.01
 ### Added
   - SSR

--- a/src/Block/Ssr/RecordList.php
+++ b/src/Block/Ssr/RecordList.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\Block\Ssr;
 
+use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\Response\Http as Response;
 use Magento\Framework\App\Response\RedirectInterface;
 use Magento\Framework\Serialize\SerializerInterface;
@@ -13,7 +14,8 @@ use Omikron\Factfinder\Model\Ssr\SearchAdapter;
 
 class RecordList extends Template
 {
-    private const RECORD_PATTERN = '#<ff-record[\s>].*?</ff-record>#s';
+    private const RECORD_PATTERN         = '#<ff-record[\s>].*?</ff-record>#s';
+    private const OPENING_RECORD_PATTERN = '#<ff-record#';
 
     /** @var SearchAdapter */
     protected $searchAdapter;
@@ -59,25 +61,32 @@ class RecordList extends Template
             return "<ff-record-list ssr {$attributes}>";
         }, $html);
 
-        $result = $this->searchResult($this->getRequest()->getParam('query', '*'), $this->getSearchParams());
+        $result = $this->searchResult($this->getRequest(), $this->getSearchParams());
         if ($this->shouldRedirect($result)) {
             $this->redirectToProductPage($result);
         }
 
         // Add pre-rendered records
         $html = preg_replace_callback(self::RECORD_PATTERN, function (array $match) use ($result): string {
-            // $match[0] is added twice due to SSR bug in Web Components. ff-record template need to be added one time
-            // as a template and one time as regular ff-record element
-            $template = '<template data-role="record">' . $match[0] .'</template>' . $match[0];
+            $template = '<template data-role="record">' . $match[0] .'</template>';
+            // walkaround for FFWEB-2182
+            if (!count($result['records'])) {
+                return $template . preg_replace(self::OPENING_RECORD_PATTERN, '<ff-record unresolved', $match[0]);
+            }
             return array_reduce($result['records'] ?? [], $this->recordRenderer($match[0]), $template);
         }, $html);
 
         return str_replace('{FF_SEARCH_RESULT}', $this->jsonSerializer->serialize($result), $html);
     }
 
-    protected function searchResult(string $query, array $params): array
+    protected function searchResult(RequestInterface $request, array $searchParams): array
     {
-        return $this->searchAdapter->search($query, $params);
+        $paramsString = implode('&', array_filter([
+                parse_url($request->getUriString(), PHP_URL_QUERY),
+                http_build_query($searchParams)
+            ]));
+
+        return $this->searchAdapter->search($paramsString, $this->getRequest()->getFullActionName() === 'catalog_category_view');
     }
 
     protected function recordRenderer(string $template): callable

--- a/src/Controller/Adminhtml/FieldRoles/Update.php
+++ b/src/Controller/Adminhtml/FieldRoles/Update.php
@@ -10,6 +10,8 @@ use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Resource\AdapterFactory;
+use Omikron\FactFinder\Communication\Version;
+use Omikron\Factfinder\Exception\ResponseException;
 use Omikron\Factfinder\Model\Api\CredentialsFactory;
 use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Omikron\Factfinder\Model\FieldRoles;
@@ -65,9 +67,13 @@ class Update extends Action
 
             $searchAdapter = (new AdapterFactory($client, $this->communicationConfig->getVersion()))->getSearchAdapter();
             $response      = $searchAdapter->search($this->communicationConfig->getChannel($storeId), 'Search.ff');
-
-            $this->fieldRoles->saveFieldRoles($response['fieldRoles'], $storeId);
-            $result->setData(['message' => __('Field roles updated successfully')]);
+            $searchResult  = $this->communicationConfig->getVersion() === Version::NG ? $response : $response['searchResult'];
+            if (!isset($searchResult['fieldRoles'])) {
+                $result->setData(['message' => __('Search result does not contain field roles')]);
+            } else {
+                $this->fieldRoles->saveFieldRoles($searchResult['fieldRoles'], $storeId);
+                $result->setData(['message' => __('Field roles updated successfully')]);
+            }
         } catch (ClientExceptionInterface $e) {
             $result->setData(['message' => $e->getMessage()]);
         }

--- a/src/Controller/Adminhtml/FieldRoles/Update.php
+++ b/src/Controller/Adminhtml/FieldRoles/Update.php
@@ -68,12 +68,13 @@ class Update extends Action
             $searchAdapter = (new AdapterFactory($client, $this->communicationConfig->getVersion()))->getSearchAdapter();
             $response      = $searchAdapter->search($this->communicationConfig->getChannel($storeId), 'Search.ff');
             $searchResult  = $this->communicationConfig->getVersion() === Version::NG ? $response : $response['searchResult'];
-            if (!isset($searchResult['fieldRoles'])) {
-                $result->setData(['message' => __('Search result does not contain field roles')]);
-            } else {
+            $result->setData(['message' => __('Search result does not contain field roles')]);
+
+            if (isset($searchResult['fieldRoles'])) {
                 $this->fieldRoles->saveFieldRoles($searchResult['fieldRoles'], $storeId);
                 $result->setData(['message' => __('Field roles updated successfully')]);
             }
+
         } catch (ClientExceptionInterface $e) {
             $result->setData(['message' => $e->getMessage()]);
         }

--- a/src/Model/Ssr/PriceFormatter.php
+++ b/src/Model/Ssr/PriceFormatter.php
@@ -37,16 +37,17 @@ class PriceFormatter
         $records     = $isNG ? $searchResult['hits'] : $searchResult['searchResult']['records'];
         $recordField = $isNG ? 'masterValues' : 'record';
 
-        return array_map($this->price($priceField, $recordField), $records);
+        return ['records' => array_map($this->price($priceField, $recordField), $records)] + $searchResult;
     }
 
     protected function price(string $priceField, string $recordField): callable
     {
         return function (array $record) use ($priceField, $recordField): array {
-            $record['record'] = array_merge($record[$recordField], [
-                '__ORIG_PRICE__' => $record[$recordField][$priceField],
-                $priceField      => $this->priceCurrency->format($record[$recordField][$priceField], false)
-            ]);
+            $record['record'] = [
+                    '__ORIG_PRICE__' => $record[$recordField][$priceField],
+                    $priceField      => $this->priceCurrency->format($record[$recordField][$priceField], false)
+                ] + $record[$recordField];
+
             return $record;
         };
     }

--- a/src/Model/Ssr/SearchAdapter.php
+++ b/src/Model/Ssr/SearchAdapter.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\Model\Ssr;
 
-use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
+use Omikron\FactFinder\Communication\Client\ClientException;
 use Omikron\FactFinder\Communication\Resource\AdapterFactory;
+use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Model\Api\CredentialsFactory;
+use Omikron\Factfinder\Model\Config\CommunicationConfig;
+use Psr\Http\Message\ResponseInterface;
 
 class SearchAdapter
 {
@@ -35,16 +38,36 @@ class SearchAdapter
         $this->priceFormatter      = $priceFormatter;
     }
 
-    public function search(string $query = '*', array $params = []): array
+    public function search(string $paramString, bool $navigationRequest): array
     {
         $client = $this->clientBuilder
             ->withServerUrl($this->communicationConfig->getAddress())
-            ->withCredentials($this->credentialsFactory->create());
+            ->withCredentials($this->credentialsFactory->create())
+            ->withVersion($this->communicationConfig->getVersion())
+            ->build();
 
-        $searchAdapter           = (new AdapterFactory($client, $this->communicationConfig->getVersion()))->getSearchAdapter();
-        $searchResult            = $searchAdapter->search($this->communicationConfig->getChannel(), $query, $params);
-        $searchResult['records'] = $this->priceFormatter->format($searchResult);
+        $endpoint = $this->createEndpoint($paramString, $navigationRequest);
+        $response = $client->request('GET', $endpoint);
 
-        return $searchResult;
+        if (!$response) {
+            throw new ClientException('The response was empty');
+        }
+
+        return $this->priceFormatter->format($this->searchResult($response));
+    }
+
+    private function searchResult(ResponseInterface $response): array
+    {
+        return json_decode((string) $response->getBody(), true);
+    }
+
+    private function createEndpoint(string $paramString, bool $navigationRequest)
+    {
+        $channel  = $this->communicationConfig->getChannel();
+        $endpoint = $navigationRequest ? 'navigation' : 'search';
+
+        return $this->communicationConfig->getVersion() == Version::NG
+            ? "rest/v4/{$endpoint}/{$channel}?{$paramString}"
+            : "Search.ff?channel={$channel}&{$paramString}&format=json";
     }
 }

--- a/src/view/frontend/templates/ff/record-list.phtml
+++ b/src/view/frontend/templates/ff/record-list.phtml
@@ -9,7 +9,7 @@ $viewModel = $block->getViewModel();
             <div class="product-item-info" data-container="product-grid">
                 <a class="product-image-container" data-redirect="{{record.Deeplink}}" data-anchor="{{record.Deeplink}}" data-redirect-target="_self">
                     <span class="product-image-wrapper">
-                        <img class="product-image-photo" data-image alt="{{record.Name}}"/>
+                        <img class="product-image-photo" data-image="{{record.ImageUrl}}" alt="{{record.Name}}"/>
                     </span>
                 </a>
 


### PR DESCRIPTION
 - Description: 
 - Right now SSR support only predefined parameters from search-params and query from fetched request. After reloading page all filters, sorting etc are gone. This PR changes that. In addition it support redirection from suggest with different type than productName. For instance clicking on category suggestion should redirect user to search result page with selected corresponding category filter
 - Fix problem with non loading images in pre-rendered result
 - Fix problem with redundant ff-record element. It should be only passed when request returns 0 records.
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
