### PR TITLE
Fix type for adding new columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ which is relevant for your project and not part of a default Magento 2 installat
 into the DataProvider definition:
  
  ```xml
-<type name="Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProvider">
+<type name="Omikron\Factfinder\Model\Export\Catalog\FieldProvider">
      <arguments>
          <argument name="productFields" xsi:type="array">
              <item name="ImageURL" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage</item>


### PR DESCRIPTION
The current README contains an error regarding how to add more columns to the export. The type is correct for version 1.x (starting with 1.5 or so?) - however in version 2.2  the type needs to be `Omikron\Factfinder\Model\Export\Catalog\FieldProvider`.