### PR TITLE
Use 3 curly braces for filter search result

### DIFF
--- a/src/view/frontend/templates/ff/asn-group.phtml
+++ b/src/view/frontend/templates/ff/asn-group.phtml
@@ -2,8 +2,8 @@
 
 <div slot="groupCaption" class="groupCaption">{{group.name}}</div>
 <ff-asn-group-element>
-    <div slot="selected"><span class="filterName">{{element.name}}</span></div>
-    <div slot="unselected"><span class="filterName">{{element.name}}</span></div>
+    <div slot="selected"><span class="filterName">{{{element.name}}}</span></div>
+    <div slot="unselected"><span class="filterName">{{{element.name}}}</span></div>
 </ff-asn-group-element>
 
 <div data-container="detailedLinks"><div data-content="detailedLinks"></div></div>


### PR DESCRIPTION
As dicussed in Omikron ticket __C-21004427__ the `element.name` variable needs to be put in curly braces, otherwise features like `searchable-from` will not work correctly, as they will display the HTML to highlight the search term, instead of the HTML being rendered by the browser:

![image](https://user-images.githubusercontent.com/4970961/138672556-ce3e7f2b-c849-4634-b066-14f852ccf51f.png)
