### PR TITLE
FFWEB-2265:  ASN Group template fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+ - Category Page & Search Result Page
+  - fix asn-group template has not been loaded correctly
+
 ## v3.0.0 - 2021.10.25
 ### BREAKING
 - SSR

--- a/src/view/frontend/layout/factfinder_product_list.xml
+++ b/src/view/frontend/layout/factfinder_product_list.xml
@@ -15,7 +15,7 @@
                     <argument name="category_path_field_name" xsi:type="helper" helper="Omikron\Factfinder\ViewModel\CategoryPath::getCategoryPathFieldName"/>
                     <argument name="is_category_page" xsi:type="boolean">false</argument>
                 </arguments>
-                <block class="Magento\Framework\View\Element\Template" name="factfinder.asn_group" as="asn_group" template="Omikron_Factfinder::ff/asn-group.phtml" />
+                <block class="Magento\Framework\View\Element\Template" name="factfinder.asn_group" template="Omikron_Factfinder::ff/asn-group.phtml" />
             </block>
         </referenceContainer>
 


### PR DESCRIPTION
 - Description: 
asn-group.phtml currently is not loaded as the redunant alias has been defined in layoyt file. This change removes it
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions:
7.4