### PR TITLE
FFWEB-2278: Add enable/disable optional custom elements configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Add
+ - Configuration
+    - Add Enable/Disable optional custom elements in module config page
+ 
 ## v3.0.1 - 2021.11.04
 ### Add
  - Upload

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ customise them.
         - [FACT-Finder version](#fact-finder-version)
         - [Server Side Rendering](#server-side-rendering)
     - [Advanced Settings](#advanced-settings)
-    - [Activated Web Components](#activated-web-components)
+        - [Currency and Country Settings](#currency-and-country-settings)
+    - [Optional Custom Elements](#optional-custom-elements)
     - [Export Settings](#export-settings)
     - [CMS Export Settings](#cms-export-settings)
     - [Data Transfer Settings](#data-transfer-settings)
@@ -129,6 +130,13 @@ You don't need to set currency nor country only for module purposes. It will use
 component as respectively `currency-code` and `country-code` parameters. You can find these settings under Magento General settings
 - [How to configure currency?](https://docs.magento.com/m2/ce/user_guide/stores/currency-configuration.html)
 - [How to configure country?](https://docs.magento.com/m2/ce/user_guide/stores/country-options.html)
+
+### Optional Custom Elements
+![Optional Custom Elements](docs/assets/optional-custom-elements.png "Optional Custom Elements")
+Some of the custom elements we offer works only when specific additional FACT-Finder modules has been purchased.
+Here you can disabled them, if you do not use utilize this part of FACT-Finder functionality
+
+**Note:** Paging has been added cause with infinite scrolling enabled in ff-record list, this custom element is redundant  
 
 ### Export Settings
 ![Product Data Export](docs/assets/export-settings.png "Product Data Export")

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -8,6 +8,7 @@
             <resource>Omikron_Factfinder::config</resource>
             <include path="Omikron_Factfinder::system/general.xml" />
             <include path="Omikron_Factfinder::system/advanced.xml" />
+            <include path="Omikron_Factfinder::system/components.xml" />
             <include path="Omikron_Factfinder::system/export.xml" />
             <include path="Omikron_Factfinder::system/cms.xml" />
             <include path="Omikron_Factfinder::system/data_transfer.xml" />

--- a/src/etc/adminhtml/system/components.xml
+++ b/src/etc/adminhtml/system/components.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="components" translate="label comment" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+        <label>Optional Custom Elements</label>
+        <field id="campaign_advisor" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Advisor Campaigns</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+        </field>
+
+        <field id="campaign_redirect" translate="label" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Redirect Campaigns</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+        </field>
+
+        <field id="campaign_feedbacktext" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Feedback Campaigns</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+        </field>
+
+        <field id="product_campaigns" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Product Campaigns</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+        </field>
+
+        <field id="shopping_cart_campaigns" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Shopping Cart Campaigns</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+        </field>
+
+        <field id="recommendation" translate="label" type="select" sortOrder="7" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Recommendations</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+        </field>
+
+        <field id="similar_products" translate="label" type="select" sortOrder="8" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Similar products</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+        </field>
+
+        <field id="paging" translate="label" type="select" sortOrder="9" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Paging</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+        </field>
+    </group>
+</include>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -16,6 +16,16 @@
                 <use_url_parameter>1</use_url_parameter>
                 <only_search_params>1</only_search_params>
             </advanced>
+            <components>
+                <campaign_advisor>1</campaign_advisor>
+                <campaign_redirect>1</campaign_redirect>
+                <campaign_feedbacktext>1</campaign_feedbacktext>
+                <product_campaigns>1</product_campaigns>
+                <shopping_cart_campaigns>1</shopping_cart_campaigns>
+                <recommendation>1</recommendation>
+                <similar_products>1</similar_products>
+                <paging>1</paging>
+            </components>
             <data_transfer>
                 <ff_upload_password backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
                 <ff_upload_key_passphrase backend_model="Magento\Config\Model\Config\Backend\Encrypted" />

--- a/src/view/frontend/layout/catalog_product_view.xml
+++ b/src/view/frontend/layout/catalog_product_view.xml
@@ -2,17 +2,17 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.product" ifconfig="factfinder/general/is_enabled" template="Omikron_Factfinder::ff/campaign-product.phtml">
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.product" ifconfig="factfinder/components/product_campaigns" template="Omikron_Factfinder::ff/campaign-product.phtml">
                 <arguments>
                     <argument name="view_model" xsi:type="object">Omikron\Factfinder\ViewModel\ProductBasedComponent</argument>
                 </arguments>
             </block>
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.recommendation" ifconfig="factfinder/general/is_enabled" template="Omikron_Factfinder::ff/recommendation.phtml">
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.recommendation" ifconfig="factfinder/components/recommendation" template="Omikron_Factfinder::ff/recommendation.phtml">
                 <arguments>
                     <argument name="view_model" xsi:type="object">Omikron\Factfinder\ViewModel\ProductBasedComponent</argument>
                 </arguments>
             </block>
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.similar" ifconfig="factfinder/general/is_enabled" template="Omikron_Factfinder::ff/similar.phtml">
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.similar" ifconfig="factfinder/components/similar_products" template="Omikron_Factfinder::ff/similar.phtml">
                 <arguments>
                     <argument name="view_model" xsi:type="object">Omikron\Factfinder\ViewModel\ProductBasedComponent</argument>
                 </arguments>

--- a/src/view/frontend/layout/checkout_cart_index.xml
+++ b/src/view/frontend/layout/checkout_cart_index.xml
@@ -2,17 +2,17 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.shopping.cart" ifconfig="factfinder/general/is_enabled" template="Omikron_Factfinder::ff/campaign-shopping-cart.phtml">
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.shopping.cart" ifconfig="factfinder/components/shopping_cart_campaigns" template="Omikron_Factfinder::ff/campaign-shopping-cart.phtml">
                 <arguments>
                     <argument name="record_id" xsi:type="helper" helper="Omikron\Factfinder\ViewModel\Cart::getItemIds" />
                 </arguments>
             </block>
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.pushed.products.cart" ifconfig="factfinder/general/is_enabled" template="Omikron_Factfinder::ff/campaign-pushed-products.phtml">
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.pushed.products.cart" template="Omikron_Factfinder::ff/campaign-pushed-products.phtml">
                 <arguments>
                     <argument name="flag" xsi:type="string">is-shopping-cart-campaign</argument>
                 </arguments>
             </block>
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.recommendation.cart" ifconfig="factfinder/general/is_enabled" template="Omikron_Factfinder::ff/recommendation.phtml">
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.recommendation.cart" ifconfig="factfinder/components/ff_recommendation" template="Omikron_Factfinder::ff/recommendation.phtml">
                 <arguments>
                     <argument name="record_id" xsi:type="helper" helper="Omikron\Factfinder\ViewModel\Cart::getItemIds" />
                 </arguments>

--- a/src/view/frontend/layout/default.xml
+++ b/src/view/frontend/layout/default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Framework\View\Element\Template" name="factfinder.feedbacktext" ifconfig="factfinder/general/is_enabled" template="Omikron_Factfinder::ff/campaign-feedbacktext.phtml" />
+        <block class="Magento\Framework\View\Element\Template" name="factfinder.feedbacktext" ifconfig="factfinder/components/campaign_feedbacktext" template="Omikron_Factfinder::ff/campaign-feedbacktext.phtml" />
         <block class="Magento\Framework\View\Element\Template" name="factfinder.recordlist" template="Omikron_Factfinder::ff/record-list.phtml">
             <arguments>
                 <argument name="subscribe" xsi:type="boolean">true</argument>

--- a/src/view/frontend/layout/factfinder_product_list.xml
+++ b/src/view/frontend/layout/factfinder_product_list.xml
@@ -26,7 +26,7 @@
             </container>
 
             <container name="factfinder.toolbar.bottom" htmlTag="div" htmlClass="toolbar toolbar-products toolbar-factfinder">
-                <block class="Magento\Framework\View\Element\Template" name="factfinder.paging.bottom" template="Omikron_Factfinder::ff/paging.phtml" />
+                <block class="Magento\Framework\View\Element\Template" name="factfinder.paging.bottom" ifconfig="factfinder/components/paging" template="Omikron_Factfinder::ff/paging.phtml" />
                 <block class="Magento\Framework\View\Element\Template" name="factfinder.ppp" template="Omikron_Factfinder::ff/products-per-page.phtml" />
             </container>
         </referenceContainer>

--- a/src/view/frontend/layout/factfinder_result_index.xml
+++ b/src/view/frontend/layout/factfinder_result_index.xml
@@ -13,8 +13,8 @@
         </referenceContainer>
 
         <container name="factfinder.campaigns">
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.advisor" template="Omikron_Factfinder::ff/campaign-advisor.phtml" />
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.redirect" template="Omikron_Factfinder::ff/campaign-redirect.phtml" />
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.advisor" ifconfig="factfinder/components/campaign_advisor" template="Omikron_Factfinder::ff/campaign-advisor.phtml" />
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.redirect" ifconfig="factfinder/components/campaign_redirect" template="Omikron_Factfinder::ff/campaign-redirect.phtml" />
             <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.pushedproducts" template="Omikron_Factfinder::ff/campaign-pushed-products.phtml" />
         </container>
 


### PR DESCRIPTION
- Description: 
Add new configuration section "Optional Custom Elements" which allows user to disable/enable some of the custom-elements (especially these which requires additionally paid FACT-Finder modules)
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4
