### PR TITLE
FFWEB-2283: Move NumericalAttributes column to the end of the columns in feed export file version 3.x

### DIFF
--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -46,8 +46,8 @@
                 <item name="ImageURL" xsi:type="string">ImageURL</item>
                 <item name="CategoryPath" xsi:type="string">CategoryPath</item>
                 <item name="FilterAttributes" xsi:type="string">FilterAttributes</item>
-                <item name="NumericalAttributes" xsi:type="string">NumericalAttributes</item>
                 <item name="HasVariants" xsi:type="string">HasVariants</item>
+                <item name="NumericalAttributes" xsi:type="string">NumericalAttributes</item>
             </argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
Description:
Magento2 module changes the order of the field by adding a new one

Tested with Magento editions/versions:
2.4.2

Tested with PHP versions:
7.4.20
