### PR TITLE
FFWEB-2312: Unify feed export file name 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Add
+- Unify filename creation for feed export file
+
 ## v2.3.2 - 2021.11.15
 ### Add
  - Configuration

--- a/src/Console/Command/Export.php
+++ b/src/Console/Command/Export.php
@@ -14,6 +14,7 @@ use Omikron\Factfinder\Model\Export\FeedFactory as FeedGeneratorFactory;
 use Omikron\Factfinder\Model\FtpUploader;
 use Omikron\Factfinder\Model\StoreEmulation;
 use Omikron\Factfinder\Model\Stream\CsvFactory;
+use Omikron\Factfinder\Service\FeedFileService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -96,10 +97,11 @@ class Export extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->state->setAreaCode('frontend');
+
         foreach ($this->getStoreIds((int) $input->getOption('store')) as $storeId) {
             $this->storeEmulation->runInStore($storeId, function () use ($storeId, $input, $output) {
                 $type     = $input->getArgument('type');
-                $filename = "export.{$type}.{$this->communicationConfig->getChannel($storeId)}.csv";
+                $filename = (new FeedFileService())->getFeedExportFilename($type, $this->communicationConfig->getChannel($storeId));
                 $stream   = $this->csvFactory->create(['filename' => "factfinder/{$filename}"]);
 
                 $this->feedGeneratorFactory->create($type)->generate($stream);

--- a/src/Controller/Adminhtml/Export/Feed.php
+++ b/src/Controller/Adminhtml/Export/Feed.php
@@ -15,6 +15,7 @@ use Omikron\Factfinder\Model\Export\FeedFactory as FeedGeneratorFactory;
 use Omikron\Factfinder\Model\FtpUploader;
 use Omikron\Factfinder\Model\StoreEmulation;
 use Omikron\Factfinder\Model\Stream\CsvFactory;
+use Omikron\Factfinder\Service\FeedFileService;
 
 class Feed extends Action
 {
@@ -75,7 +76,7 @@ class Feed extends Action
             preg_match('@/store/([0-9]+)/@', (string) $this->_redirect->getRefererUrl(), $match);
             $storeId = (int) ($match[1] ?? $this->storeManager->getDefaultStoreView()->getId());
             $this->storeEmulation->runInStore($storeId, function () use ($storeId) {
-                $filename = "export.{$this->communicationConfig->getChannel()}.csv";
+                $filename = (new FeedFileService())->getFeedExportFilename($this->feedType, $this->communicationConfig->getChannel());
                 $stream   = $this->csvFactory->create(['filename' => "factfinder/{$filename}"]);
                 $this->feedGeneratorFactory->create($this->feedType)->generate($stream);
                 $this->ftpUploader->upload($filename, $stream);

--- a/src/Controller/Export/Product.php
+++ b/src/Controller/Export/Product.php
@@ -12,6 +12,7 @@ use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Omikron\Factfinder\Model\Export\FeedFactory as FeedGeneratorFactory;
 use Omikron\Factfinder\Model\StoreEmulation;
 use Omikron\Factfinder\Model\Stream\CsvFactory;
+use Omikron\Factfinder\Service\FeedFileService;
 
 class Product extends Action
 {
@@ -58,7 +59,7 @@ class Product extends Action
     {
         $storeId = (int) $this->getRequest()->getParam('store', $this->storeManager->getDefaultStoreView()->getId());
         $this->storeEmulation->runInStore($storeId, function () {
-            $filename = "export.{$this->communicationConfig->getChannel()}.csv";
+            $filename = (new FeedFileService())->getFeedExportFilename($this->feedType, $this->communicationConfig->getChannel());
             $stream   = $this->csvFactory->create(['filename' => "factfinder/{$filename}"]);
             $this->feedGeneratorFactory->create($this->feedType)->generate($stream);
             $this->fileFactory->create($filename, $stream->getContent());

--- a/src/Cron/Feed.php
+++ b/src/Cron/Feed.php
@@ -13,6 +13,7 @@ use Omikron\Factfinder\Model\Export\FeedFactory as FeedGeneratorFactory;
 use Omikron\Factfinder\Model\FtpUploader;
 use Omikron\Factfinder\Model\StoreEmulation;
 use Omikron\Factfinder\Model\Stream\CsvFactory;
+use Omikron\Factfinder\Service\FeedFileService;
 
 class Feed
 {
@@ -77,7 +78,7 @@ class Feed
             $this->storeEmulation->runInStore((int) $store->getId(), function () use ($store) {
                 $storeId = (int) $store->getId();
                 if ($this->communicationConfig->isChannelEnabled($storeId)) {
-                    $filename = "export.{$this->communicationConfig->getChannel($storeId)}.csv";
+                    $filename = (new FeedFileService())->getFeedExportFilename($this->feedType, $this->communicationConfig->getChannel());
                     $stream   = $this->csvFactory->create(['filename' => "factfinder/{$filename}"]);
                     $this->feedGeneratorFactory->create($this->feedType)->generate($stream);
                     $this->ftpUploader->upload($filename, $stream);

--- a/src/Service/FeedFileService.php
+++ b/src/Service/FeedFileService.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Service;
+
+use Exception;
+
+class FeedFileService
+{
+    private const FEED_FILENAME_PATTERN = 'export.%type%.%channel%.csv';
+
+    /**
+     * @param string $exportType
+     * @param string $channel
+     * @return string
+     * @throws Exception
+     */
+    public function getFeedExportFilename(string $exportType, string $channel): string
+    {
+        if (empty($exportType)) {
+            throw new Exception('Export type should not be empty');
+        }
+
+        if (empty($channel)) {
+            throw new Exception('Channel should not be empty');
+        }
+
+        return str_replace(['%type%', '%channel%'], [$exportType, $channel], self::FEED_FILENAME_PATTERN);
+    }
+}

--- a/src/Test/Unit/Service/FeedFileServiceTest.php
+++ b/src/Test/Unit/Service/FeedFileServiceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace Omikron\Factfinder\Service;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers FeedFileService
+ */
+class FeedFileServiceTest extends TestCase
+{
+    /** @var FeedFileService */
+    private $feedFileService;
+
+    /**
+     * @dataProvider validDataProvider
+     * @throws \Exception
+     */
+    public function test_will_return_filename(string $exportType, string $channel, string $expected)
+    {
+        $result = $this->feedFileService->getFeedExportFilename($exportType, $channel);
+        $this->assertSame($expected, $result);
+    }
+
+    public function test_will_throw_exception_on_empty_export_type()
+    {
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('Export type should not be empty');
+        $this->assertSame('export.test_type.test_channel.csv', $this->feedFileService->getFeedExportFilename('', 'test_channel'));
+    }
+
+    public function test_will_throw_exception_on_empty_export_channel()
+    {
+        $this->expectException('Exception');
+        $this->expectExceptionMessage('Channel should not be empty');
+        $this->assertSame('export.test_type.test_channel.csv', $this->feedFileService->getFeedExportFilename('test_type', ''));
+    }
+
+    public static function validDataProvider(): array
+    {
+        return [
+            [
+                'test_type', 'test_channel', 'export.test_type.test_channel.csv'
+            ]
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        $this->feedFileService = new FeedFileService();
+
+    }
+}

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -32,6 +32,7 @@
                 <ff_cron_enabled>0</ff_cron_enabled>
                 <ff_push_import_enabled>1</ff_push_import_enabled>
                 <ff_push_import_type>data,suggest</ff_push_import_type>
+                <ff_upload_dir>/</ff_upload_dir>
                 <ff_upload_port>21</ff_upload_port>
             </data_transfer>
             <basic_auth_data_transfer>


### PR DESCRIPTION
- Solves issue: 
https://jira.omikron.net/browse/FFWEB-2312

- Description: 
unify all feed file names

- Tested with Magento editions/versions: 
2.4.2

- Tested with PHP versions: 
7.4.20
