### PR TITLE
FFWEB-2320: Add scroll to top after product page change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased 
+### Add
+   - Category Page & Search Result Page
+      - add Scroll to top callback after products page change
+      
 ## v3.0.2 - 2021.11.15
 ### Add
  - Configuration

--- a/src/view/frontend/requirejs-config.js
+++ b/src/view/frontend/requirejs-config.js
@@ -1,7 +1,8 @@
 var config = {
     map: {
         '*': {
-            factfinder: 'Omikron_Factfinder/ff-web-components/bundle'
+            factfinder: 'Omikron_Factfinder/ff-web-components/bundle',
+            ffCallbacks: 'Omikron_Factfinder/js/callbacks',
         }
     },
     config: {

--- a/src/view/frontend/templates/ff/record-list.phtml
+++ b/src/view/frontend/templates/ff/record-list.phtml
@@ -46,14 +46,27 @@ $viewModel = $block->getViewModel();
     </ff-record-list>
 </div>
 <script>
+    require(['ffCallbacks'], function (ffCallbacks) {
+        document.addEventListener('ffReady', function (ff) {
+            factfinder.communication.EventAggregator.addBeforeDispatchingCallback(function (event) {
+                if (event.type === 'search' || event.type === 'paging') {
+                    const scrollToTopCallback = ffCallbacks.scrollToCallback();
+                    event.success = factfinder.common.concatFunctions(event.success, scrollToTopCallback);
+                }
+            });
+        });
+    });
+
     require(['jquery', 'catalogAddToCart'], function ($) {
-        document.addEventListener('WebComponentsReady', function (ff) {
+        document.addEventListener('WebComponentsReady', function () {
             document.querySelectorAll('ff-record-list').forEach(function (recordList) {
                 recordList.addEventListener('dom-updated', function () {
                     const addToCartForm = $('.product_addtocart_form');
-                    if (addToCartForm) addToCartForm.catalogAddToCart();
+                    if (addToCartForm && addToCartForm.hasOwnProperty('catalogAddToCart') && typeof addToCartForm.catalogAddToCart === 'function') {
+                        addToCartForm.catalogAddToCart();
+                    }
                 });
             })
-        });
+        })
     });
 </script>

--- a/src/view/frontend/web/js/callbacks.js
+++ b/src/view/frontend/web/js/callbacks.js
@@ -1,0 +1,21 @@
+define(function () {
+    return {
+        scrollToCallback: function (selector, config) {
+            return function () {
+                const defaultConfig = {
+                    behavior: 'smooth',
+                    top: 0,
+                    left: 0
+                };
+                const mergedConfig = Object.assign({}, defaultConfig, config);
+
+                if (selector) {
+                    const element = document.querySelector(selector);
+                    !element ? console.error('Invalid selector', selector) : element.scrollIntoView(mergedConfig);
+                } else {
+                    window.scrollTo(mergedConfig);
+                }
+            }
+        }
+    }
+});


### PR DESCRIPTION
- Description: 
Added configurable `scrollTo` callback
Added sample usage of scrolling to top when product page is changed
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4