### PR TITLE
FFWEB-2375: Join FilterAttributes with variant configurable attributes RELEASE/3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+## [Unreleased]
+
+### Improved
+- Export
+  - improved diagnostic messages printed during running feed export in admin panel
+  - throw Exception while running export for disabled channel
+  - add support for DateTime type
+    
+### Fixed 
+ - Export
+  - fix false value coming from getConfigurableOptions breaks export 
+  - fix configurable attributes are not merged with FilterAttributes field if FilterAttributes is configured to be exported from variants 
+
 ## [v3.1.0] - 2021.12.03
 ### Add
  - Category Page & Search Result Page


### PR DESCRIPTION
- Description: 
Fix configurable attributes are not merged with FilterAttributes field if FilterAttributes is configured to be exported from variants 
- Tested with Magento editions/versions: 
2.4.2
- Tested with PHP versions: 
7.4

