### PR TITLE
FFWEB-2383: Sort ng categoryPath by categories nesting level RELEASE/3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [Unreleased]
+### Fix
+ - Category Page
+  - Fix category path is not correctly sorted if the parent category has id with greater number than its childs
+  
 ## [v3.2.0] - 2022.01.26
 ### Add
   - Product Page
@@ -410,6 +415,7 @@
 ### Added
 - Feed Export: Export feed file is now available via separate link
 
+[v3.2.1]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v3.2.1
 [v3.2.0]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v3.2.0
 [v3.1.0]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v3.1.0
 [v3.0.2]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v3.0.2

--- a/src/Test/Unit/ViewModel/CategoryPathTest.php
+++ b/src/Test/Unit/ViewModel/CategoryPathTest.php
@@ -33,7 +33,7 @@ class CategoryPathTest extends TestCase
         $categoryPath    = $this->newCategoryPath($this->communicationConfig);
 
         $this->currentCategory->method('getParentCategories')
-            ->willReturn([$this->category('Men', 1), $this->category('Tops', 2), $this->category('Jackets', 3)]);
+            ->willReturn([$this->category('Tops', 2), $this->category('Jackets', 3), $this->category('Men', 1)]);
 
         $value = 'filter=CategoryPath%3AMen%2FTops%2FJackets';
         $this->assertSame($value, (string) $categoryPath->getCategoryPath());

--- a/src/ViewModel/CategoryPath.php
+++ b/src/ViewModel/CategoryPath.php
@@ -75,16 +75,11 @@ class CategoryPath implements ArgumentInterface
 
     private function ngPath(?Category $category): array
     {
-        $path = implode('/', $this->createPathFromCategory($category));
-        return [sprintf('filter=%s', urlencode($this->param . ':' . $path))];
-    }
-
-    private function createPathFromCategory(?Category $category): array
-    {
-        return array_map(function (Category $item): string {
+        $path = array_map(function (Category $item): string {
             return (string) $item->getName();
-        }, $category ? $category->getParentCategories() : []
-        );
+        }, $category ? $this->getParentCategories($category) : []);
+
+        return [sprintf('filter=%s', urlencode($this->param . ':' . implode('/', $path)))];
     }
 
     /**


### PR DESCRIPTION
- Solves issue: 
CategoryPath using NG could be incorrectly sorted if parent category has bigger id than its childs
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4
