### PR TITLE
FIX variant values are missing in export Release/2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [v2.4.2] - 2022.02.02
+### Fix
+ - Export
+  - fix variant base values are not exported if FilterAttributes are not configured to be exported from variant level 
+
 ## [v2.4.1] - 2022.01.28
 ### Fix
  - Category Page
@@ -397,6 +402,7 @@
 ### Added
 - Feed Export: Export feed file is now available via separate link
 
+[v2.4.2]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v2.4.2
 [v2.4.1]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v2.4.1
 [v2.4.0]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v2.4.0
 [v2.3.3]:       https://github.com/FACT-Finder-Web-Components/magento2-module/releases/tag/v2.3.3

--- a/src/Model/Export/Catalog/Entity/ProductVariation.php
+++ b/src/Model/Export/Catalog/Entity/ProductVariation.php
@@ -57,12 +57,14 @@ class ProductVariation implements ExportEntityInterface
             ] + $this->configurableData;
 
         list($filterAttributes, $restFields) = $this->extractFilterAttributes($this->fieldprovider->getVariantFields());
-        $splicedFilterAttributes = str_replace('||', '|', ($this->configurableData['FilterAttributes'] ?? '') . ($filterAttributes ? $filterAttributes->getValue($this->product) : ''));
+        $parentAttributes        = $this->configurableData['FilterAttributes'] ?? '';
+        $variantAttributes       = $filterAttributes ? $filterAttributes->getValue($this->product) : '';
+        $splicedFilterAttributes = str_replace('||', '|', $parentAttributes . $variantAttributes);
 
-        return $splicedFilterAttributes ? ['FilterAttributes' => $splicedFilterAttributes] : [] + array_reduce($restFields,
-                function (array $result, FieldInterface $field): array {
-                    return [$field->getName() => $field->getValue($this->product)] + $result;
-                }, $baseData);
+        return ($splicedFilterAttributes ? ['FilterAttributes' => $splicedFilterAttributes] : [])
+            + array_reduce($restFields, function (array $result, FieldInterface $field): array {
+                return [$field->getName() => $field->getValue($this->product)] + $result;
+            }, $baseData);
     }
 
     public function getProduct(): Product


### PR DESCRIPTION
- Solves issue: 
if FilterAttributes are not configured to be exported from variant level then base variant data is not exported.
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions: 
7.4

