### PR TITLE
FFWEB-2405: Fix error with exporting and show information to modal after export feed operation for api versions 7.x (api 2.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Fix 
+ - Fix error while push import feed using CLI after generate it for API version 7.x
+ - Fix content of informational modal window after feed export for API version 7.x
+
 ## [v2.4.2] - 2022.02.02
 ### Fix
  - Export

--- a/src/Model/Api/PushImport.php
+++ b/src/Model/Api/PushImport.php
@@ -81,21 +81,43 @@ class PushImport
 
     private function prepareListFromPushImportResponses(array $responses): string
     {
-        $table = '<ul>';
+        return strtolower($this->communicationConfig->getVersion()) === 'ng' ? $this->ngResponse($responses) : $this->standardResponse($responses);
+    }
+
+    private function ngResponse(array $responses): string
+    {
+        $list = '<ul>%s</ul>';
+        $listContent = '';
 
         foreach ($responses as $response) {
             $importType = sprintf('<li><b>%s push import type</b></li>', $response['importType']);
 
-            $statusMessagesList = sprintf('<ul>%s</ul>', implode('', array_map(function ($message)
-            {return sprintf('<li>%s</li>', $message);}, $response['statusMessages'])));
+            $statusMessagesList = sprintf('<ul>%s</ul>', implode('', array_map(function ($message) {
+                return sprintf('<li>%s</li>', $message);
+            }, $response['statusMessages'])));
             $statusMessages = sprintf('<li><i>Status messages</i></li><li>%s</li>', $statusMessagesList);
 
             $importType .= $statusMessages;
-            $table .= $importType;
+            $listContent .= $importType;
         }
 
-        $table .= '</ul>';
+        return sprintf($list, $listContent);
+    }
 
-        return $table;
+    private function standardResponse(array $responses): string
+    {
+        $list = '<ul>%s</ul>';
+        $listContent = '';
+
+        if (!empty($responses['status'])) {
+            $statusMessagesList = sprintf('<ul>%s</ul>', implode('', array_map(function ($message) {
+                return sprintf('<li>%s</li>', $message);
+            }, $responses['status'])));
+
+            $statusMessages = sprintf('<li><i>Status messages</i></li><li>%s</li>', $statusMessagesList);
+            $listContent .= $statusMessages;
+        }
+
+        return sprintf($list, $listContent);
     }
 }


### PR DESCRIPTION
- Solves issue: 
https://jira.omikron.net/browse/FFWEB-2405

- Description: 
Fix error for API v 7.x - Error while generate export file: Undefined index: importType

- Tested with Magento editions/versions: 
2.4.2

- Tested with PHP versions: 
7.4.20
