### PR TITLE
FFWEB-2412: fix wrong scope in save/get configuration Release/3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 ## Unreleased
 ### Fix
-- Fix error while push import feed using CLI after generate it for API version 7.x
-- Fix content of informational modal window after feed export for API version 7.x
-
-
+ - Import 
+  - fix error while push import feed using CLI after generate it for API version 7.x
+  - fix content of informational modal window after feed export for API version 7.x
+ - Configuration
+  - fix Update FieldRoles uses wrong scope name while saving to database 
+  - fix PushImport data types are fetched with wrong scope
+  
 ## [v3.2.2] - 2022.02.02
 ### Fix
  - Export

--- a/src/Model/Config/ExportConfig.php
+++ b/src/Model/Config/ExportConfig.php
@@ -52,7 +52,7 @@ class ExportConfig
     public function getPushImportDataTypes(int $scopeId = null): array
     {
         $configPath = 'factfinder/data_transfer/ff_push_import_type';
-        $dataTypes  = (string) $this->scopeConfig->getValue($configPath, ScopeInterface::SCOPE_STORE, $scopeId);
+        $dataTypes  = (string) $this->scopeConfig->getValue($configPath, ScopeInterface::SCOPE_STORES, $scopeId);
         $isNg       = $this->communicationConfig->getVersion() === Version::NG;
 
         return explode(',', $isNg ? $dataTypes : str_replace('search', 'data', $dataTypes));

--- a/src/Model/FieldRoles.php
+++ b/src/Model/FieldRoles.php
@@ -45,8 +45,7 @@ class FieldRoles
     public function getFieldRoles(int $scopeId = null): array
     {
         try {
-            $scope  = $scopeId ? Scope::SCOPE_STORE : ScopeConfigInterface::SCOPE_TYPE_DEFAULT;
-            $config = $this->scopeConfig->getValue(self::PATH_PRODUCT_FIELD_ROLE, $scope, $scopeId);
+            $config = $this->scopeConfig->getValue(self::PATH_PRODUCT_FIELD_ROLE, Scope::SCOPE_STORES, $scopeId);
             return (array) $this->serializer->unserialize($config);
         } catch (\InvalidArgumentException $e) {
             return [];
@@ -62,8 +61,7 @@ class FieldRoles
     {
         try {
             $roles = (string) $this->serializer->serialize($fieldRoles);
-            $scope = $scopeId ? Scope::SCOPE_STORE : ScopeConfigInterface::SCOPE_TYPE_DEFAULT;
-            $this->configResource->saveConfig(self::PATH_PRODUCT_FIELD_ROLE, $roles, $scope, $scopeId);
+            $this->configResource->saveConfig(self::PATH_PRODUCT_FIELD_ROLE, $roles, Scope::SCOPE_STORES, $scopeId);
             return true;
         } catch (\InvalidArgumentException $e) {
             return false;

--- a/src/Test/Unit/Model/Config/ExportConfigTest.php
+++ b/src/Test/Unit/Model/Config/ExportConfigTest.php
@@ -6,6 +6,7 @@ namespace Omikron\Factfinder\Model\Config;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Store\Model\ScopeInterface as Scope;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -58,8 +59,8 @@ class ExportConfigTest extends TestCase
     {
         $scopeConfig  = $this->createMock(ScopeConfigInterface::class);
         $scopeConfig->method('getValue')->willReturnMap([
-            ['factfinder/data_transfer/ff_push_import_type', 'store', 1, 'search,suggest'],
-            ['factfinder/export/attributes', 'stores', 42,'{"_1":{"code":"color","multi":"0","numerical":"0"},"_2":{"code":"climate","multi":"1","numerical":"0"},"_3":{"code":"gender","multi":"0","numerical":"0"},"_4":{"code":"size","multi":"1","numerical":"1"}}']
+            ['factfinder/data_transfer/ff_push_import_type', Scope::SCOPE_STORES, 1, 'search,suggest'],
+            ['factfinder/export/attributes', Scope::SCOPE_STORES, 42,'{"_1":{"code":"color","multi":"0","numerical":"0"},"_2":{"code":"climate","multi":"1","numerical":"0"},"_3":{"code":"gender","multi":"0","numerical":"0"},"_4":{"code":"size","multi":"1","numerical":"1"}}']
         ]);
         $communicationConfig = $this->createMock(CommunicationConfig::class);
         $communicationConfig->method('getVersion')->willReturnOnConsecutiveCalls('7.3', 'ng');

--- a/src/Test/Unit/Model/FieldRolesTest.php
+++ b/src/Test/Unit/Model/FieldRolesTest.php
@@ -8,6 +8,7 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Config\Model\ResourceModel\Config as ConfigResource;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Serialize\Serializer\Json as JsonSerializer;
+use Magento\Store\Model\ScopeInterface as Scope;
 use Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProvider;
 use Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProviderFactory;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -48,14 +49,14 @@ class FieldRolesTest extends TestCase
         $valueToSave = ['description' => 'Description', 'masterArticleNumber' => 'Master'];
         $this->configResourceMock->expects($this->once())
             ->method('saveConfig')
-            ->with('factfinder/general/tracking_product_number_field_role', $this->serializer->serialize($valueToSave));
+            ->with('factfinder/general/tracking_product_number_field_role', $this->serializer->serialize($valueToSave), Scope::SCOPE_STORES);
         $this->assertTrue($this->fieldRoles->saveFieldRoles($valueToSave, 1));
     }
 
     public function test_field_role_to_attribute_returns_correct_array_value()
     {
         $productMock = $this->createConfiguredMock(ProductInterface::class, ['getSku' => 'sku-1']);
-        $this->scopeConfigMock->method('getValue')->with('factfinder/general/tracking_product_number_field_role')->willReturn($this->roles);
+        $this->scopeConfigMock->method('getValue')->with('factfinder/general/tracking_product_number_field_role', Scope::SCOPE_STORES)->willReturn($this->roles);
         $this->dataProvider->expects($this->once())->method('toArray')->willReturn([
             'ProductNumber' => 'sku-1',
             'Master'        => 'sku-1',


### PR DESCRIPTION
- Solves issue: 
- Fix saving and getting field roles and getting push import data types
- Tested with Magento editions/versions: 
2.4
- Tested with PHP versions:
7.4
