### PR TITLE
PHP 7.4 support, new static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.4']
         deps: ['lowest', 'stable']
         exclude:
           - php: '7.4'
@@ -39,8 +39,12 @@ jobs:
           composer config --global repositories.magento composer https://repo.magento.com/
           composer update --no-ansi --no-interaction --prefer-${{ matrix.deps }}
 
+      - name: Run Static analysis
+        run: |
+            vendor/bin/phpcs -nq .
+            vendor/bin/phpmd src text phpmd.xml.dist
+
       - name: Run tests
         run: |
           vendor/bin/phpunit
-          vendor/bin/phpcs -nq .
-          vendor/bin/phpmd src text phpmd.xml.dist
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
 
       - name: Run Static analysis
         run: |
-            vendor/bin/phpcs -nq .
+            vendor/bin/phpcs --config-set installed_paths vendor/magento/magento-coding-standard,vendor/phpcompatibility/php-compatibility
+            vendor/bin/phpcs --standard=phpcs.xml.dist --extensions=php,phtml src
             vendor/bin/phpmd src text phpmd.xml.dist
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [v4.0.0]
+### BREAKING
+ - drop PHP 7.3 support
+
 ## [v3.3.0] - 2022.03.04
 ### Fix
  - Import 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ customise them.
 This module supports:
 
 - Magento 2 version 2.3 and higher
-- PHP version 7.2 and higher  
+- PHP version 7.4 and higher  
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -10,20 +10,15 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.4",
     "omikron/factfinder-communication-sdk": "^0.9",
-    "magento/framework": ">=102.0.0",
-    "magento/module-catalog": ">=103.0.0",
-    "magento/module-configurable-product": ">=100.3.0",
-    "magento/module-directory": ">=100.3.0",
-    "magento/module-store": ">=101.0.0",
     "mustache/mustache": "^2.13"
   },
   "require-dev": {
-    "magento/magento-coding-standard": "^6.0",
     "pdepend/pdepend": "^2.8",
     "phpmd/phpmd": "^2.9",
-    "phpunit/phpunit": ">=6.5 <10.0"
+    "phpunit/phpunit": "~9.5.0",
+    "magento/magento-coding-standard": "*"
   },
   "autoload": {
     "files": [

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,11 @@
   "require": {
     "php": "^7.4",
     "omikron/factfinder-communication-sdk": "^0.9",
+    "magento/framework": ">=102.0.0",
+    "magento/module-catalog": ">=103.0.0",
+    "magento/module-configurable-product": ">=100.3.0",
+    "magento/module-directory": ">=100.3.0",
+    "magento/module-store": ">=101.0.0",
     "mustache/mustache": "^2.13"
   },
   "require-dev": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,11 +4,15 @@
 
     <arg value="psw" />
     <arg name="extensions" value="php,phtml" />
-    <arg name="ignore" value="*/vendor/*" />
+    <arg name="ignore" value="*/vendor/*,src/Test/Integration/_files/*" />
 
     <config name="ignore_warnings_on_exit" value="1" />
 
-    <rule ref="vendor/magento/magento-coding-standard/Magento2" />
+    <rule ref="vendor/magento/magento-coding-standard/Magento2">
+        <exclude name="Magento2.Commenting" />
+        <exclude name="Magento2.Annotation" />
+    </rule>
+
     <rule ref="Generic.CodeAnalysis.EmptyStatement" />
     <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">
         <exclude-pattern>*/Observer/*</exclude-pattern>
@@ -24,11 +28,14 @@
         <exclude-pattern>*.phtml</exclude-pattern>
         <exclude-pattern>*Test.php</exclude-pattern>
         <properties>
-            <property name="lineLimit" value="120" />
+            <property name="lineLimit" value="140" />
             <property name="absoluteLineLimit" value="0" />
         </properties>
     </rule>
     <rule ref="Generic.Formatting.SpaceAfterCast" />
+    <rule ref="Generic.Files.LineEndings">
+        <exclude name="Generic.Files.LineEndings.InvalidEOLChar"/>
+    </rule>
     <rule ref="Generic.Metrics.CyclomaticComplexity">
         <exclude-pattern>*/Setup/*</exclude-pattern>
     </rule>

--- a/src/Block/Adminhtml/System/Config/Field/ExportFields.php
+++ b/src/Block/Adminhtml/System/Config/Field/ExportFields.php
@@ -16,17 +16,10 @@ use Omikron\Factfinder\Model\Adminhtml\System\Config\Source\Attribute as Attribu
  */
 class ExportFields extends AbstractFieldArray
 {
-    /** @var Select */
-    private $attributeRenderer;
-
-    /** @var Select */
-    private $typeRenderer;
-
-    /** @var AttributeSource */
-    private $attributeSource;
-
-    /** @var Yesno */
-    private $boolSource;
+    private Select $attributeRenderer;
+    private Select $typeRenderer;
+    private AttributeSource $attributeSource;
+    private Yesno $boolSource;
 
     public function __construct(
         Context $context,

--- a/src/Block/Ssr/RecordList.php
+++ b/src/Block/Ssr/RecordList.php
@@ -54,7 +54,7 @@ class RecordList extends Template
         $result = $this->searchResult($this->getRequest(), $this->getSearchParams());
         if ($this->shouldRedirect($result)) {
             $this->redirectToProductPage($result);
-            return;
+            return '';
         }
 
         // Add pre-rendered records
@@ -73,7 +73,7 @@ class RecordList extends Template
     protected function searchResult(RequestInterface $request, array $searchParams): array
     {
         $paramsString = implode('&', array_filter([
-                parse_url($request->getRequestString(), PHP_URL_QUERY),
+                parse_url($request->getRequestString(), PHP_URL_QUERY), //@phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
                 http_build_query($searchParams)
             ]));
 

--- a/src/Block/Ssr/RecordList.php
+++ b/src/Block/Ssr/RecordList.php
@@ -17,20 +17,11 @@ class RecordList extends Template
     private const RECORD_PATTERN         = '#<ff-record[\s>].*?</ff-record>#s';
     private const OPENING_RECORD_PATTERN = '#<ff-record#';
 
-    /** @var SearchAdapter */
-    protected $searchAdapter;
-
-    /** @var SerializerInterface */
-    protected $jsonSerializer;
-
-    /** @var Response */
-    private $response;
-
-    /** @var RedirectInterface */
-    private $redirect;
-
-    /** @var FieldRoles */
-    private $fieldRoles;
+    protected SearchAdapter $searchAdapter;
+    protected SerializerInterface $jsonSerializer;
+    private Response $response;
+    private RedirectInterface $redirect;
+    private FieldRoles $fieldRoles;
 
     public function __construct(
         Template\Context    $context,
@@ -50,10 +41,9 @@ class RecordList extends Template
     }
 
     /**
-     * @return string
      * @SuppressWarnings(PHPMD.CamelCaseMethodName)
      */
-    protected function _afterToHtml($html)
+    protected function _afterToHtml($html): string
     {
         // Resolve record list
         $html = preg_replace_callback('#<ff-record-list([^>]*?)>#s', function (array $match) {

--- a/src/Console/Command/Export.php
+++ b/src/Console/Command/Export.php
@@ -26,32 +26,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Export extends Command
 {
-    /** @var StoreEmulation */
-    private $storeEmulation;
-
-    /** @var FeedGeneratorFactory */
-    private $feedGeneratorFactory;
-
-    /** @var StoreManagerInterface */
-    private $storeManager;
-
-    /** @var CommunicationConfig */
-    private $communicationConfig;
-
-    /** @var CsvFactory */
-    private $csvFactory;
-
-    /** @var FtpUploader */
-    private $ftpUploader;
-
-    /** @var PushImport */
-    private $pushImport;
-
-    /** @var State */
-    private $state;
-
-    /** @var Filesystem */
-    private $filesystem;
+    private StoreEmulation $storeEmulation;
+    private FeedGeneratorFactory $feedGeneratorFactory;
+    private StoreManagerInterface $storeManager;
+    private CommunicationConfig $communicationConfig;
+    private CsvFactory $csvFactory;
+    private FtpUploader $ftpUploader;
+    private PushImport $pushImport;
+    private State $state;
+    private Filesystem $filesystem;
 
     public function __construct(
         StoreManagerInterface $storeManager,
@@ -79,7 +62,7 @@ class Export extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('factfinder:export')->setDescription('Export feed data as CSV file');
 
@@ -129,9 +112,7 @@ class Export extends Command
 
     private function getStoreIds(int $storeId): array
     {
-        $storeIds = array_map(function ($store) {
-            return (int) $store->getId();
-        }, $storeId ? [$this->storeManager->getStore($storeId)] : $this->storeManager->getStores());
+        $storeIds = array_map(fn ($store) => (int) $store->getId(), $storeId ? [$this->storeManager->getStore($storeId)] : $this->storeManager->getStores());
         return array_filter($storeIds, [$this->communicationConfig, 'isChannelEnabled']);
     }
 }

--- a/src/Console/Command/Export.php
+++ b/src/Console/Command/Export.php
@@ -83,7 +83,7 @@ class Export extends Command
         $storeIds = $this->getStoreIds((int) $input->getOption('store'));
 
         if (count($storeIds) === 0) {
-            $output->writeln(sprintf('Integration for the channel `%s` must be enabled to run %s export', $this->communicationConfig->getChannel(), $input->getArgument('type')));
+            $output->writeln(sprintf('Integration for the channel `%s` is not enabled', $this->communicationConfig->getChannel()));
             return 0;
         }
 
@@ -95,7 +95,10 @@ class Export extends Command
                 $stream   = $this->csvFactory->create(['filename' => "factfinder/{$filename}"]);
 
                 $this->feedGeneratorFactory->create($type)->generate($stream);
-                $path = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR)->getAbsolutePath('factfinder' . DIRECTORY_SEPARATOR . $filename);
+                $path = $this->filesystem
+                    ->getDirectoryWrite(DirectoryList::VAR_DIR)
+                    ->getAbsolutePath('factfinder' . DIRECTORY_SEPARATOR . $filename);
+
                 $output->writeln("Store {$storeId}: File {$path} has been generated.");
 
                 if ($input->getOption('upload')) {
@@ -112,7 +115,11 @@ class Export extends Command
 
     private function getStoreIds(int $storeId): array
     {
-        $storeIds = array_map(fn ($store) => (int) $store->getId(), $storeId ? [$this->storeManager->getStore($storeId)] : $this->storeManager->getStores());
+        $storeIds = array_map(
+            fn ($store) => (int) $store->getId(),
+            $storeId ? [$this->storeManager->getStore($storeId)] : $this->storeManager->getStores()
+        );
+
         return array_filter($storeIds, [$this->communicationConfig, 'isChannelEnabled']);
     }
 }

--- a/src/Controller/Adminhtml/Export/Feed.php
+++ b/src/Controller/Adminhtml/Export/Feed.php
@@ -19,32 +19,15 @@ use Omikron\Factfinder\Service\FeedFileService;
 
 class Feed extends Action
 {
-    /** @var JsonFactory */
-    private $jsonResultFactory;
-
-    /** @var CommunicationConfig */
-    private $communicationConfig;
-
-    /** @var StoreEmulation */
-    private $storeEmulation;
-
-    /** @var FeedGeneratorFactory */
-    private $feedGeneratorFactory;
-
-    /** @var CsvFactory */
-    private $csvFactory;
-
-    /** @var FtpUploader */
-    private $ftpUploader;
-
-    /** @var StoreManagerInterface */
-    private $storeManager;
-
-    /** @var PushImport */
-    private $pushImport;
-
-    /** @var string */
-    protected $feedType = 'product';
+    protected string $feedType = 'product';
+    private JsonFactory $jsonResultFactory;
+    private CommunicationConfig $communicationConfig;
+    private StoreEmulation $storeEmulation;
+    private FeedGeneratorFactory $feedGeneratorFactory;
+    private CsvFactory $csvFactory;
+    private FtpUploader $ftpUploader;
+    private StoreManagerInterface $storeManager;
+    private PushImport $pushImport;
 
     public function __construct(
         Context $context,

--- a/src/Controller/Adminhtml/FieldRoles/Update.php
+++ b/src/Controller/Adminhtml/FieldRoles/Update.php
@@ -48,6 +48,7 @@ class Update extends Action
     {
         $result = $this->jsonResultFactory->create();
         try {
+            //@phpcs:ignore Magento2.Legacy.ObsoleteResponse.RedirectResponseMethodFound
             preg_match('@/store/([0-9]+)/@', (string) $this->_redirect->getRefererUrl(), $match);
             $storeId = (int) ($match[1] ?? $this->storeManager->getDefaultStoreView()->getId());
             $client  = $this->clientBuilder

--- a/src/Controller/Adminhtml/FieldRoles/Update.php
+++ b/src/Controller/Adminhtml/FieldRoles/Update.php
@@ -19,23 +19,12 @@ use Psr\Http\Client\ClientExceptionInterface;
 
 class Update extends Action
 {
-    /** @var JsonFactory */
-    private $jsonResultFactory;
-
-    /** @var StoreManagerInterface */
-    private $storeManager;
-
-    /** @var CommunicationConfig */
-    private $communicationConfig;
-
-    /** @var CredentialsFactory */
-    private $credentialsFactory;
-
-    /** @var FieldRoles */
-    private $fieldRoles;
-
-    /** @var ClientBuilder */
-    private $clientBuilder;
+    private JsonFactory $jsonResultFactory;
+    private StoreManagerInterface $storeManager;
+    private CommunicationConfig $communicationConfig;
+    private CredentialsFactory $credentialsFactory;
+    private FieldRoles $fieldRoles;
+    private ClientBuilder $clientBuilder;
 
     public function __construct(
         Context $context,

--- a/src/Controller/Adminhtml/TestConnection/TestConnection.php
+++ b/src/Controller/Adminhtml/TestConnection/TestConnection.php
@@ -16,20 +16,11 @@ use Psr\Http\Client\ClientExceptionInterface;
 
 class TestConnection extends Action
 {
-    /** @var string */
-    private $obscuredValue = '******';
-
-    /** @var JsonFactory */
-    private $jsonResultFactory;
-
-    /** @var CredentialsFactory */
-    private $credentialsFactory;
-
-    /** @var AuthConfig */
-    private $authConfig;
-
-    /** @var ClientBuilder */
-    private $clientBuilder;
+    private string $obscuredValue = '******';
+    private JsonFactory $jsonResultFactory;
+    private CredentialsFactory $credentialsFactory;
+    private AuthConfig $authConfig;
+    private ClientBuilder $clientBuilder;
 
     public function __construct(
         Action\Context $context,

--- a/src/Controller/Adminhtml/TestConnection/TestFtpConnection.php
+++ b/src/Controller/Adminhtml/TestConnection/TestFtpConnection.php
@@ -12,17 +12,10 @@ use Omikron\Factfinder\Model\FtpUploader;
 
 class TestFtpConnection extends Action
 {
-    /** @var string */
-    private $obscuredValue = '******';
-
-    /** @var JsonFactory */
-    private $jsonResultFactory;
-
-    /** @var FtpUploader */
-    private $ftpUploader;
-
-    /** @var FtpConfig */
-    private $ftpConfig;
+    private string $obscuredValue = '******';
+    private JsonFactory $jsonResultFactory;
+    private FtpUploader $ftpUploader;
+    private FtpConfig $ftpConfig;
 
     public function __construct(
         Action\Context $context,
@@ -55,13 +48,9 @@ class TestFtpConnection extends Action
     {
         $prefix   = 'ff_upload_';
 
-        $filtered = array_filter($params, function (string $key) use ($prefix): bool {
-            return (bool) preg_match("#^{$prefix}#", $key);
-        }, ARRAY_FILTER_USE_KEY);
+        $filtered = array_filter($params, fn (string $key) => (bool) preg_match("#^{$prefix}#", $key), ARRAY_FILTER_USE_KEY);
 
-        return array_combine(array_map(function (string $key) use ($prefix): string {
-            return str_replace($prefix, '', $key);
-        }, array_keys($filtered)), array_values($filtered));
+        return array_combine(array_map(fn (string $key) => (string) str_replace($prefix, '', $key), array_keys($filtered)), array_values($filtered));
     }
 
     private function getRealValuesFromObscured(array $params): array

--- a/src/Controller/Adminhtml/TestConnection/TestFtpConnection.php
+++ b/src/Controller/Adminhtml/TestConnection/TestFtpConnection.php
@@ -50,7 +50,10 @@ class TestFtpConnection extends Action
 
         $filtered = array_filter($params, fn (string $key) => (bool) preg_match("#^{$prefix}#", $key), ARRAY_FILTER_USE_KEY);
 
-        return array_combine(array_map(fn (string $key) => (string) str_replace($prefix, '', $key), array_keys($filtered)), array_values($filtered));
+        return array_combine(
+            array_map(fn (string $key) => (string) str_replace($prefix, '', $key), array_keys($filtered)),
+            array_values($filtered)
+        );
     }
 
     private function getRealValuesFromObscured(array $params): array

--- a/src/Controller/Export/Cms.php
+++ b/src/Controller/Export/Cms.php
@@ -8,6 +8,5 @@ use Omikron\Factfinder\Controller\Export\Product;
 
 class Cms extends Product
 {
-    /** @var string */
-    protected $feedType = 'cms';
+    protected string $feedType = 'cms';
 }

--- a/src/Controller/Export/Product.php
+++ b/src/Controller/Export/Product.php
@@ -16,26 +16,13 @@ use Omikron\Factfinder\Service\FeedFileService;
 
 class Product extends Action
 {
-    /** @var CommunicationConfig */
-    private $communicationConfig;
-
-    /** @var StoreEmulation */
-    private $storeEmulation;
-
-    /** @var FeedGeneratorFactory */
-    private $feedGeneratorFactory;
-
-    /** @var FileFactory */
-    private $fileFactory;
-
-    /** @var CsvFactory */
-    private $csvFactory;
-
-    /** @var StoreManagerInterface */
-    private $storeManager;
-
-    /** @var string */
-    protected $feedType = 'product';
+    protected string $feedType = 'product';
+    private CommunicationConfig $communicationConfig;
+    private StoreEmulation $storeEmulation;
+    private FeedGeneratorFactory $feedGeneratorFactory;
+    private FileFactory $fileFactory;
+    private CsvFactory $csvFactory;
+    private StoreManagerInterface $storeManager;
 
     public function __construct(
         Context $context,

--- a/src/Controller/Proxy/Call.php
+++ b/src/Controller/Proxy/Call.php
@@ -22,20 +22,11 @@ class Call extends Action\Action implements Action\HttpGetActionInterface, Actio
 {
     use SkipCsrfValidation;
 
-    /** @var JsonResultFactory */
-    private $jsonResultFactory;
-
-    /** @var RawResultFactory */
-    private $rawResultFactory;
-
-    /** @var CommunicationConfig */
-    private $communicationConfig;
-
-    /** @var CredentialsFactory */
-    private $credentialsFactory;
-
-    /** @var ClientBuilder */
-    private $clientBuilder;
+    private JsonResultFactory $jsonResultFactory;
+    private RawResultFactory $rawResultFactory;
+    private CommunicationConfig $communicationConfig;
+    private CredentialsFactory $credentialsFactory;
+    private ClientBuilder $clientBuilder;
 
     public function __construct(
         Action\Context $context,

--- a/src/Controller/Result/Index.php
+++ b/src/Controller/Result/Index.php
@@ -10,8 +10,7 @@ use Magento\Framework\View\Result\PageFactory;
 
 class Index extends Action
 {
-    /** @var PageFactory */
-    private $resultPageFactory;
+    private PageFactory $resultPageFactory;
 
     public function __construct(Context $context, PageFactory $resultPageFactory)
     {

--- a/src/Controller/Router.php
+++ b/src/Controller/Router.php
@@ -13,8 +13,7 @@ class Router implements RouterInterface
 {
     public const FRONT_NAME = 'fact-finder';
 
-    /** @var ActionFactory */
-    private $actionFactory;
+    private ActionFactory $actionFactory;
 
     public function __construct(ActionFactory $actionFactory)
     {

--- a/src/Controller/SkipCsrfValidation.php
+++ b/src/Controller/SkipCsrfValidation.php
@@ -1,5 +1,5 @@
 <?php
-
+//@
 declare(strict_types=1);
 
 namespace Omikron\Factfinder\Controller;
@@ -11,6 +11,7 @@ use Magento\Framework\App\RequestInterface;
  * Implementation of CsrfAwareActionInterface.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ * @codingStandardsIgnoreFile
  */
 trait SkipCsrfValidation
 {

--- a/src/Cron/Feed.php
+++ b/src/Cron/Feed.php
@@ -19,32 +19,15 @@ class Feed
 {
     private const PATH_CONFIGURABLE_CRON_IS_ENABLED = 'factfinder/configurable_cron/ff_cron_enabled';
 
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
-
-    /** @var StoreEmulation */
-    private $storeEmulation;
-
-    /** @var FeedGeneratorFactory */
-    private $feedGeneratorFactory;
-
-    /** @var StoreManagerInterface */
-    private $storeManager;
-
-    /** @var CommunicationConfig */
-    private $communicationConfig;
-
-    /** @var CsvFactory */
-    private $csvFactory;
-
-    /** @var FtpUploader */
-    private $ftpUploader;
-
-    /** @var PushImport */
-    private $pushImport;
-
-    /** @var string */
-    private $feedType;
+    private ScopeConfigInterface $scopeConfig;
+    private StoreEmulation $storeEmulation;
+    private FeedGeneratorFactory $feedGeneratorFactory;
+    private StoreManagerInterface $storeManager;
+    private CommunicationConfig $communicationConfig;
+    private CsvFactory $csvFactory;
+    private FtpUploader $ftpUploader;
+    private PushImport $pushImport;
+    private string $feedType;
 
     public function __construct(
         ScopeConfigInterface $scopeConfig,

--- a/src/Model/Adminhtml/System/Config/Backend/Feed/Frequency.php
+++ b/src/Model/Adminhtml/System/Config/Backend/Feed/Frequency.php
@@ -20,8 +20,7 @@ class Frequency extends Value
     private const PATH_CRON_TIME   = 'ff_cron_time';
     private const CRON_STRING_PATH = 'crontab/default/jobs/factfinder_feed_export/schedule/cron_expr';
 
-    /** @var WriterInterface */
-    protected $configWriter;
+    protected WriterInterface $configWriter;
 
     public function __construct(
         Context $context,

--- a/src/Model/Adminhtml/System/Config/Source/Attribute.php
+++ b/src/Model/Adminhtml/System/Config/Source/Attribute.php
@@ -10,8 +10,7 @@ use Magento\Framework\Data\OptionSourceInterface;
 
 class Attribute implements OptionSourceInterface
 {
-    /** @var AttributeCollectionFactory */
-    private $collectionFactory;
+    private AttributeCollectionFactory $collectionFactory;
 
     public function __construct(AttributeCollectionFactory $collectionFactory)
     {
@@ -20,20 +19,11 @@ class Attribute implements OptionSourceInterface
 
     public function toOptionArray()
     {
-        $options = array_map(function (EavAttribute $attribute): array {
-            return [
-                'value' => (string) $attribute->getAttributeCode(),
-                'label' => (string) $attribute->getDefaultFrontendLabel(),
-            ];
-        }, $this->collectionFactory->create()->getItems());
+        $options = array_map(fn (EavAttribute $attribute) => ['value' => (string) $attribute->getAttributeCode(), 'label' => (string) $attribute->getDefaultFrontendLabel()], $this->collectionFactory->create()->getItems());
 
-        $options = array_filter($options, function (array $a): bool {
-            return !!$a['label'];
-        });
+        $options = array_filter($options, fn (array $a) => (bool) !!$a['label']);
 
-        usort($options, function (array $a, array $b): int {
-            return strtolower($a['label']) <=> strtolower($b['label']);
-        });
+        usort($options, fn (array $a, array $b) => strtolower($a['label']) <=> strtolower($b['label']));
 
         return $options;
     }

--- a/src/Model/Adminhtml/System/Config/Source/Attribute.php
+++ b/src/Model/Adminhtml/System/Config/Source/Attribute.php
@@ -19,7 +19,13 @@ class Attribute implements OptionSourceInterface
 
     public function toOptionArray()
     {
-        $options = array_map(fn (EavAttribute $attribute) => ['value' => (string) $attribute->getAttributeCode(), 'label' => (string) $attribute->getDefaultFrontendLabel()], $this->collectionFactory->create()->getItems());
+        $options = array_map(
+            fn(EavAttribute $attr) => [
+                'value' => (string) $attr->getAttributeCode(),
+                'label' => (string) $attr->getDefaultFrontendLabel()
+            ],
+            $this->collectionFactory->create()->getItems()
+        );
 
         $options = array_filter($options, fn (array $a) => (bool) !!$a['label']);
 

--- a/src/Model/Api/CredentialsFactory.php
+++ b/src/Model/Api/CredentialsFactory.php
@@ -10,11 +10,8 @@ use Omikron\Factfinder\Model\Config\AuthConfig;
 
 class CredentialsFactory
 {
-    /** @var AuthConfig */
-    private $authConfig;
-
-    /** @var ObjectManagerInterface */
-    private $objectManager;
+    private AuthConfig $authConfig;
+    private ObjectManagerInterface $objectManager;
 
     public function __construct(ObjectManagerInterface $objectManager, AuthConfig $authConfig)
     {

--- a/src/Model/Api/PushImport.php
+++ b/src/Model/Api/PushImport.php
@@ -14,23 +14,12 @@ use Psr\Log\LoggerInterface;
 
 class PushImport
 {
-    /** @var CommunicationConfig */
-    private $communicationConfig;
-
-    /** @var CredentialsFactory */
-    private $credentialsFactory;
-
-    /** @var ExportConfig */
-    private $exportConfig;
-
-    /** @var LoggerInterface */
-    private $logger;
-
-    /** @var ClientBuilder */
-    private $clientBuilder;
-
-    /** @var string */
-    private $pushImportResult;
+    private CommunicationConfig $communicationConfig;
+    private CredentialsFactory $credentialsFactory;
+    private ExportConfig $exportConfig;
+    private LoggerInterface $logger;
+    private ClientBuilder $clientBuilder;
+    private string $pushImportResult;
 
     public function __construct(
         ClientBuilder $clientBuilder,
@@ -66,7 +55,7 @@ class PushImport
 
         $responses = [];
         foreach ($dataTypes as $dataType) {
-            $responses = array_merge($responses, $importAdapter->import($channel, $dataType));
+            $responses = [...$responses, ...$importAdapter->import($channel, $dataType)];
         }
 
         $this->pushImportResult = $this->prepareListFromPushImportResponses($responses);
@@ -92,10 +81,9 @@ class PushImport
         foreach ($responses as $response) {
             $importType = sprintf('<li><b>%s push import type</b></li>', $response['importType']);
 
-            $statusMessagesList = sprintf('<ul>%s</ul>', implode('', array_map(function ($message) {
-                return sprintf('<li>%s</li>', $message);
-            }, $response['statusMessages'])));
-            $statusMessages = sprintf('<li><i>Status messages</i></li><li>%s</li>', $statusMessagesList);
+            $statusList = sprintf('<ul>%s</ul>', implode('', array_map(fn (string $message): string => sprintf('<li>%s</li>', $message), $response['statusMessages'])));
+
+            $statusMessages = sprintf('<li><i>Status messages</i></li><li>%s</li>', $statusList);
 
             $importType .= $statusMessages;
             $listContent .= $importType;
@@ -110,11 +98,9 @@ class PushImport
         $listContent = '';
 
         if (!empty($responses['status'])) {
-            $statusMessagesList = sprintf('<ul>%s</ul>', implode('', array_map(function ($message) {
-                return sprintf('<li>%s</li>', $message);
-            }, $responses['status'])));
+            $statusList = sprintf('<ul>%s</ul>', implode('', array_map(fn (string $message): string => sprintf('<li>%s</li>', $message), $responses['status'])));
 
-            $statusMessages = sprintf('<li><i>Status messages</i></li><li>%s</li>', $statusMessagesList);
+            $statusMessages = sprintf('<li><i>Status messages</i></li><li>%s</li>', $statusList);
             $listContent .= $statusMessages;
         }
 

--- a/src/Model/Api/PushImport.php
+++ b/src/Model/Api/PushImport.php
@@ -70,7 +70,9 @@ class PushImport
 
     private function prepareListFromPushImportResponses(array $responses): string
     {
-        return strtolower($this->communicationConfig->getVersion()) === 'ng' ? $this->ngResponse($responses) : $this->standardResponse($responses);
+        return strtolower($this->communicationConfig->getVersion()) === 'ng'
+            ? $this->ngResponse($responses)
+            : $this->standardResponse($responses);
     }
 
     private function ngResponse(array $responses): string
@@ -81,7 +83,10 @@ class PushImport
         foreach ($responses as $response) {
             $importType = sprintf('<li><b>%s push import type</b></li>', $response['importType']);
 
-            $statusList = sprintf('<ul>%s</ul>', implode('', array_map(fn (string $message): string => sprintf('<li>%s</li>', $message), $response['statusMessages'])));
+            $statusList = sprintf(
+                '<ul>%s</ul>',
+                implode('', array_map(fn (string $message): string => sprintf('<li>%s</li>', $message), $response['statusMessages']))
+            );
 
             $statusMessages = sprintf('<li><i>Status messages</i></li><li>%s</li>', $statusList);
 
@@ -98,7 +103,10 @@ class PushImport
         $listContent = '';
 
         if (!empty($responses['status'])) {
-            $statusList = sprintf('<ul>%s</ul>', implode('', array_map(fn (string $message): string => sprintf('<li>%s</li>', $message), $responses['status'])));
+            $statusList = sprintf(
+                '<ul>%s</ul>',
+                implode('', array_map(fn (string $message): string => sprintf('<li>%s</li>', $message), $responses['status']))
+            );
 
             $statusMessages = sprintf('<li><i>Status messages</i></li><li>%s</li>', $statusList);
             $listContent .= $statusMessages;

--- a/src/Model/Config/AuthConfig.php
+++ b/src/Model/Config/AuthConfig.php
@@ -14,8 +14,7 @@ class AuthConfig
     private const PATH_AUTH_PREFIX  = 'factfinder/general/prefix';
     private const PATH_AUTH_POSTFIX = 'factfinder/general/postfix';
 
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
+    private ScopeConfigInterface $scopeConfig;
 
     public function __construct(ScopeConfigInterface $scopeConfig)
     {

--- a/src/Model/Config/CmsConfig.php
+++ b/src/Model/Config/CmsConfig.php
@@ -10,8 +10,7 @@ class CmsConfig
 {
     private const PATH_DISABLE_CMS_PAGES = 'factfinder/cms_export/ff_cms_blacklist';
 
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
+    private ScopeConfigInterface $scopeConfig;
 
     public function __construct(ScopeConfigInterface $scopeConfig)
     {

--- a/src/Model/Config/Communication/BehaviourConfig.php
+++ b/src/Model/Config/Communication/BehaviourConfig.php
@@ -19,8 +19,7 @@ class BehaviourConfig implements ParametersSourceInterface
     private const PATH_PARAMETER_WHITELIST = 'factfinder/advanced/parameter_whitelist';
     private const PATH_VERSION              = 'factfinder/general/version';
 
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
+    private ScopeConfigInterface $scopeConfig;
 
     public function __construct(ScopeConfigInterface $scopeConfig)
     {

--- a/src/Model/Config/Communication/BehaviourConfig.php
+++ b/src/Model/Config/Communication/BehaviourConfig.php
@@ -37,7 +37,9 @@ class BehaviourConfig implements ParametersSourceInterface
             'parameter-whitelist'         => $this->getConfig(self::PATH_PARAMETER_WHITELIST),
         ];
 
-        if ($this->getVersion() === Version::NG) $parameters['category-page'] = '';
+        if ($this->getVersion() === Version::NG) {
+            $parameters['category-page'] = '';
+        }
 
         return $parameters;
     }

--- a/src/Model/Config/Communication/CurrencyConfig.php
+++ b/src/Model/Config/Communication/CurrencyConfig.php
@@ -12,11 +12,8 @@ use Omikron\Factfinder\Api\Config\ParametersSourceInterface;
 
 class CurrencyConfig implements ParametersSourceInterface
 {
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
-
-    /** @var ResolverInterface */
-    private $localeResolver;
+    private ScopeConfigInterface $scopeConfig;
+    private ResolverInterface $localeResolver;
 
     public function __construct(ScopeConfigInterface $scopeConfig, ResolverInterface $localeResolver)
     {

--- a/src/Model/Config/CommunicationConfig.php
+++ b/src/Model/Config/CommunicationConfig.php
@@ -21,11 +21,9 @@ class CommunicationConfig implements ParametersSourceInterface
     private const PATH_DATA_TRANSFER_IMPORT = 'factfinder/data_transfer/ff_push_import_enabled';
     private const PATH_IS_LOGGING_ENABLED   = 'factfinder/general/logging_enabled';
 
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
+    private ScopeConfigInterface $scopeConfig;
 
-    /** @var UrlInterface */
-    private $urlBuilder;
+    private UrlInterface $urlBuilder;
 
     public function __construct(ScopeConfigInterface $scopeConfig, UrlInterface $urlBuilder)
     {

--- a/src/Model/Config/CommunicationParametersProvider.php
+++ b/src/Model/Config/CommunicationParametersProvider.php
@@ -17,6 +17,10 @@ class CommunicationParametersProvider implements ParametersSourceInterface
 
     public function getParameters(): array
     {
-        return array_reduce($this->sources, fn (array $params, ParametersSourceInterface $source): array => array_merge($params, $source->getParameters()), []);
+        return array_reduce(
+            $this->sources,
+            fn (array $params, ParametersSourceInterface $source): array => array_merge($params, $source->getParameters()),
+            []
+        );
     }
 }

--- a/src/Model/Config/CommunicationParametersProvider.php
+++ b/src/Model/Config/CommunicationParametersProvider.php
@@ -8,8 +8,7 @@ use Omikron\Factfinder\Api\Config\ParametersSourceInterface;
 
 class CommunicationParametersProvider implements ParametersSourceInterface
 {
-    /** @var ParametersSourceInterface[] */
-    private $sources;
+    private array $sources;
 
     public function __construct(array $parametersSource = [])
     {
@@ -18,8 +17,6 @@ class CommunicationParametersProvider implements ParametersSourceInterface
 
     public function getParameters(): array
     {
-        return array_reduce($this->sources, function (array $params, ParametersSourceInterface $source): array {
-            return array_merge($params, $source->getParameters());
-        }, []);
+        return array_reduce($this->sources, fn (array $params, ParametersSourceInterface $source): array => array_merge($params, $source->getParameters()), []);
     }
 }

--- a/src/Model/Config/ExportConfig.php
+++ b/src/Model/Config/ExportConfig.php
@@ -13,14 +13,9 @@ class ExportConfig
 {
     private const CONFIG_PATH = 'factfinder/export/attributes';
 
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
-
-    /** @var SerializerInterface */
-    private $serializer;
-
-    /** @var CommunicationConfig */
-    private $communicationConfig;
+    private ScopeConfigInterface $scopeConfig;
+    private SerializerInterface $serializer;
+    private CommunicationConfig $communicationConfig;
 
     public function __construct(
         ScopeConfigInterface $scopeConfig,
@@ -37,16 +32,12 @@ class ExportConfig
      */
     public function getMultiAttributes(?int $storeId = null, bool $numerical = false): array
     {
-        return $this->getAttributeCodes($storeId, function (array $row) use ($numerical): bool {
-            return $row['multi'] && (bool) $row['numerical'] == $numerical;
-        });
+        return $this->getAttributeCodes($storeId, fn (array $row): bool => $row['multi'] && (bool) $row['numerical'] == $numerical);
     }
 
     public function getSingleFields(?int $storeId = null): array
     {
-        return $this->getAttributeCodes($storeId, function (array $row): bool {
-            return !$row['multi'];
-        });
+        return $this->getAttributeCodes($storeId, fn (array $row): bool => !$row['multi']);
     }
 
     public function getPushImportDataTypes(int $scopeId = null): array
@@ -67,8 +58,9 @@ class ExportConfig
     private function getConfigValue(?int $storeId): array
     {
         $value = $this->scopeConfig->getValue(self::CONFIG_PATH, ScopeInterface::SCOPE_STORES, $storeId);
-        return array_map(function (array $row): array {
-            return ['multi' => !!$row['multi']] + $row;
-        }, (array) $this->serializer->unserialize($value ?: '[]'));
+        return array_map(
+            fn (array $row): array => ['multi' => !!$row['multi']] + $row,
+            (array) $this->serializer->unserialize($value ?: '[]')
+        );
     }
 }

--- a/src/Model/Config/FeatureConfig.php
+++ b/src/Model/Config/FeatureConfig.php
@@ -11,11 +11,8 @@ class FeatureConfig
 {
     private const PATH_USE_FOR_CATEGORIES = 'factfinder/general/use_for_categories';
 
-    /** @var CommunicationConfig */
-    private $communicationConfig;
-
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
+    private CommunicationConfig $communicationConfig;
+    private ScopeConfigInterface $scopeConfig;
 
     public function __construct(ScopeConfigInterface $scopeConfig, CommunicationConfig $communicationConfig)
     {

--- a/src/Model/Config/FtpConfig.php
+++ b/src/Model/Config/FtpConfig.php
@@ -10,8 +10,7 @@ class FtpConfig
 {
     private const FPT_UPLOAD_CONFIG_PATH = 'factfinder/data_transfer/ff_upload_';
 
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
+    private ScopeConfigInterface $scopeConfig;
 
     public function __construct(ScopeConfigInterface $scopeConfig)
     {

--- a/src/Model/Export/BasicAuth.php
+++ b/src/Model/Export/BasicAuth.php
@@ -11,9 +11,7 @@ class BasicAuth
 {
     private const CONFIG_PATH_USERNAME = 'factfinder/basic_auth_data_transfer/ff_upload_url_user';
     private const CONFIG_PATH_PASSWORD = 'factfinder/basic_auth_data_transfer/ff_upload_url_password';
-
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
+    private ScopeConfigInterface $scopeConfig;
 
     public function __construct(ScopeConfigInterface $scopeConfig)
     {

--- a/src/Model/Export/Catalog/AttributeValuesExtractor.php
+++ b/src/Model/Export/Catalog/AttributeValuesExtractor.php
@@ -29,6 +29,7 @@ class AttributeValuesExtractor
      * @return array
      * @throws \Exception
      */
+    //phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
     public function getAttributeValues(Product $product, Attribute $attribute): array
     {
         $code   = $attribute->getAttributeCode();

--- a/src/Model/Export/Catalog/AttributeValuesExtractor.php
+++ b/src/Model/Export/Catalog/AttributeValuesExtractor.php
@@ -13,11 +13,8 @@ use DateTime;
 
 class AttributeValuesExtractor
 {
-    /** @var FilterInterface */
-    private $filter;
-
-    /** @var NumberFormatter */
-    private $numberFormatter;
+    private FilterInterface $filter;
+    private NumberFormatter $numberFormatter;
 
     public function __construct(FilterInterface $filter, NumberFormatter $numberFormatter)
     {

--- a/src/Model/Export/Catalog/DataProvider.php
+++ b/src/Model/Export/Catalog/DataProvider.php
@@ -13,17 +13,10 @@ use Omikron\Factfinder\Api\Export\FieldInterface;
 
 class DataProvider implements DataProviderInterface
 {
-    /** @var Products */
-    private $products;
-
-    /** @var ObjectManagerInterface */
-    private $objectManager;
-
-    /** @var string[] */
-    private $entityTypes;
-
-    /** @var FieldInterface[] */
-    private $productFields;
+    private Products $products;
+    private ObjectManagerInterface $objectManager;
+    private array $entityTypes;
+    private array $productFields;
 
     public function __construct(
         Products $products,

--- a/src/Model/Export/Catalog/Entity/ProductVariation.php
+++ b/src/Model/Export/Catalog/Entity/ProductVariation.php
@@ -56,7 +56,8 @@ class ProductVariation implements ExportEntityInterface
             + array_reduce(
                 $restFields,
                 fn (array $result, FieldInterface $field): array => [$field->getName() => $field->getValue($this->product)] + $result,
-                $baseData);
+                $baseData
+            );
     }
 
     public function getProduct(): Product

--- a/src/Model/Export/Catalog/Entity/ProductVariation.php
+++ b/src/Model/Export/Catalog/Entity/ProductVariation.php
@@ -12,20 +12,11 @@ use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 
 class ProductVariation implements ExportEntityInterface
 {
-    /** @var Product */
-    private $product;
-
-    /** @var Product */
-    private $configurable;
-
-    /** @var NumberFormatter */
-    private $numberFormatter;
-
-    /** @var array */
-    private $configurableData;
-
-    /** @var FieldProvider */
-    private $fieldprovider;
+    private Product $product;
+    private Product $configurable;
+    private NumberFormatter $numberFormatter;
+    private array $configurableData;
+    private FieldProvider $fieldprovider;
 
     public function __construct(
         Product $product,
@@ -62,9 +53,10 @@ class ProductVariation implements ExportEntityInterface
         $splicedFilterAttributes = str_replace('||', '|', $parentAttributes . $variantAttributes);
 
         return ($splicedFilterAttributes ? ['FilterAttributes' => $splicedFilterAttributes] : [])
-            + array_reduce($restFields, function (array $result, FieldInterface $field): array {
-                return [$field->getName() => $field->getValue($this->product)] + $result;
-            }, $baseData);
+            + array_reduce(
+                $restFields,
+                fn (array $result, FieldInterface $field): array => [$field->getName() => $field->getValue($this->product)] + $result,
+                $baseData);
     }
 
     public function getProduct(): Product
@@ -79,9 +71,7 @@ class ProductVariation implements ExportEntityInterface
 
     private function extractFilterAttributes(array $fields): array
     {
-        $withoutFilterAttributes = array_filter($fields, function (FieldInterface $field) {
-            return $field->getName() !== 'FilterAttributes';
-        });
+        $withoutFilterAttributes = array_filter($fields, fn (FieldInterface $field): bool => $field->getName() !== 'FilterAttributes');
 
         $filterAttributes = $fields['FilterAttributes'] ?? [];
 

--- a/src/Model/Export/Catalog/FieldProvider.php
+++ b/src/Model/Export/Catalog/FieldProvider.php
@@ -11,23 +11,12 @@ use Omikron\Factfinder\Model\Export\Catalog\ProductField\GenericFieldFactory;
 
 class FieldProvider implements FieldProviderInterface
 {
-    /** @var ExportConfig */
-    private $config;
-
-    /** @var GenericFieldFactory */
-    private $fieldFactory;
-
-    /** @var FieldInterface[] */
-    private $productFieldProviders;
-
-    /** @var FieldInterface[] */
-    private $variantFieldProviders;
-
-    /** @var array */
-    private $cachedVariantFields;
-
-    /** @var array */
-    private $cachedFields;
+    private ExportConfig $config;
+    private GenericFieldFactory $fieldFactory;
+    private array $productFieldProviders;
+    private array $variantFieldProviders;
+    private array $cachedVariantFields;
+    private array $cachedFields;
 
     public function __construct
     (

--- a/src/Model/Export/Catalog/FieldProvider.php
+++ b/src/Model/Export/Catalog/FieldProvider.php
@@ -18,8 +18,7 @@ class FieldProvider implements FieldProviderInterface
     private array $cachedVariantFields;
     private array $cachedFields;
 
-    public function __construct
-    (
+    public function __construct(
         ExportConfig $config,
         GenericFieldFactory $fieldFactory,
         array $productFields = [],

--- a/src/Model/Export/Catalog/ProductField/CategoryPath.php
+++ b/src/Model/Export/Catalog/ProductField/CategoryPath.php
@@ -14,11 +14,8 @@ use Magento\Catalog\Model\Product;
 
 class CategoryPath implements FieldInterface
 {
-    /** @var CategoryRepositoryInterface */
-    private $categoryRepository;
-
-    /** @var string */
-    private $fieldName;
+    private CategoryRepositoryInterface $categoryRepository;
+    private string $fieldName;
 
     public function __construct(CategoryRepositoryInterface $categoryRepository, string $fieldName = 'CategoryPath')
     {
@@ -38,13 +35,12 @@ class CategoryPath implements FieldInterface
      */
     public function getValue(AbstractModel $product): string
     {
-        $paths = array_map(function (int $categoryId) use ($product): array {
-            return $this->getPath($categoryId, $product->getStore());
-        }, $product->getCategoryIds());
+        $paths = array_map(
+            fn (int $categoryId): array => $this->getPath($categoryId, $product->getStore()),
+            $product->getCategoryIds()
+        );
 
-        return implode('|', array_map(function (array $path): string {
-            return implode('/', array_map('urlencode', $path));
-        }, array_filter($paths)));
+        return implode('|', array_map(fn (array $path): string => implode('/', array_map('urlencode', $path)), array_filter($paths)));
     }
 
     /**
@@ -57,9 +53,10 @@ class CategoryPath implements FieldInterface
     {
         try {
             $storeId = (int) $store->getId();
-            return array_map(function (int $id) use ($storeId): string {
-                return trim($this->getCategory($id, $storeId)->getName());
-            }, $this->getPathIds($this->getCategory($categoryId, $storeId), $store));
+            return array_map(
+                fn (int $id): string => trim($this->getCategory($id, $storeId)->getName()),
+                $this->getPathIds($this->getCategory($categoryId, $storeId), $store)
+            );
         } catch (NoSuchEntityException $e) {
             return [];
         }

--- a/src/Model/Export/Catalog/ProductField/FilterAttributes.php
+++ b/src/Model/Export/Catalog/ProductField/FilterAttributes.php
@@ -14,26 +14,13 @@ use Omikron\Factfinder\Model\Export\Catalog\AttributeValuesExtractor;
 
 class FilterAttributes implements FieldInterface
 {
-    /** @var bool  */
-    protected $numerical = false;
-
-    /** @var string  */
-    protected $name = 'FilterAttributes';
-
-    /** @var ExportConfig */
-    private $exportConfig;
-
-    /** @var ProductResource */
-    private $productResource;
-
-    /** @var Attribute[][] */
-    private $attributes = [];
-
-    /** @var FilterInterface */
-    private $filter;
-
-    /** @var AttributeValuesExtractor */
-    private $valuesExtractor;
+    protected bool $numerical = false;
+    protected string $name = 'FilterAttributes';
+    private ExportConfig $exportConfig;
+    private ProductResource $productResource;
+    private array $attributes = [];
+    private FilterInterface $filter;
+    private AttributeValuesExtractor $valuesExtractor;
 
     public function __construct(
         ExportConfig $exportConfig,
@@ -84,8 +71,6 @@ class FilterAttributes implements FieldInterface
 
     private function getAttributeLabel(int $storeId): callable
     {
-        return function (Attribute $attribute) use ($storeId): string {
-            return $this->filter->filterValue((string) $attribute->getStoreLabel($storeId));
-        };
+        return fn (Attribute $attribute): string => $this->filter->filterValue((string) $attribute->getStoreLabel($storeId));
     }
 }

--- a/src/Model/Export/Catalog/ProductField/GenericField.php
+++ b/src/Model/Export/Catalog/ProductField/GenericField.php
@@ -14,20 +14,11 @@ use Magento\Catalog\Model\Product;
 
 class GenericField implements FieldInterface
 {
-    /** @var ProductAttributeRepositoryInterface */
-    private $attributeRepository;
-
-    /** @var AttributeValuesExtractor */
-    private $valuesExtractor;
-
-    /** @var string */
-    private $attributeCode;
-
-    /** @var Attribute */
-    private $attribute;
-
-    /** @var StoreManagerInterface */
-    private $storeManager;
+    private ProductAttributeRepositoryInterface $attributeRepository;
+    private AttributeValuesExtractor $valuesExtractor;
+    private string $attributeCode;
+    private Attribute $attribute;
+    private StoreManagerInterface $storeManager;
 
     public function __construct(
         ProductAttributeRepositoryInterface $attributeRepository,

--- a/src/Model/Export/Catalog/ProductField/NumericalAttributes.php
+++ b/src/Model/Export/Catalog/ProductField/NumericalAttributes.php
@@ -9,9 +9,6 @@ use Magento\Framework\Model\AbstractModel;
 
 class NumericalAttributes extends FilterAttributes
 {
-    /** @var string */
-    protected $name = 'NumericalAttributes';
-
-    /** @var bool */
-    protected $numerical = true;
+    protected string $name = 'NumericalAttributes';
+    protected bool $numerical = true;
 }

--- a/src/Model/Export/Catalog/ProductField/ProductImage.php
+++ b/src/Model/Export/Catalog/ProductField/ProductImage.php
@@ -10,11 +10,8 @@ use Omikron\Factfinder\Api\Export\FieldInterface;
 
 class ProductImage implements FieldInterface
 {
-    /** @var ImageHelper */
-    private $imageHelper;
-
-    /** @var string */
-    private $imageId;
+    private ImageHelper $imageHelper;
+    private string $imageId;
 
     public function __construct(ImageHelper $imageHelper, string $imageId = 'ff_export_image_url')
     {

--- a/src/Model/Export/Catalog/ProductType/BundleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/BundleDataProvider.php
@@ -11,11 +11,8 @@ use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 
 class BundleDataProvider extends SimpleDataProvider
 {
-    /** @var CatalogPrice */
-    private $priceModel;
-
-    /** @var PriceCurrency */
-    private $priceCurrency;
+    private CatalogPrice $priceModel;
+    private PriceCurrency $priceCurrency;
 
     public function __construct(
         Product $product,

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -76,9 +76,11 @@ class ConfigurableDataProvider extends SimpleDataProvider
 
     private function getOptions(Product $product): array
     {
+        $sanitize = fn(string $phrase): string => $this->filter->filterValue($this->valueOrEmptyStr($phrase));
+
         return array_reduce($this->productType->getConfigurableOptions($product), function (array $res, array $option) {
             foreach ($option as ['sku' => $sku, 'super_attribute_label' => $label, 'option_title' => $value]) {
-                $res[$sku][] = "{$this->filter->filterValue($this->getValueOrEmptyString($label))}={$this->filter->filterValue($this->getValueOrEmptyString($value))}";
+                $res[$sku][] = "{$sanitize($label)}={$sanitize($value)}";
             }
             return $res;
         }, []);
@@ -92,12 +94,12 @@ class ConfigurableDataProvider extends SimpleDataProvider
     private function getChildren(Product $product): array
     {
         return $this->productRepository
-            ->getList($this->builder->addFilter('entity_id', $this->productType->getChildrenIds($this->product->getId()), 'in')
+            ->getList($this->builder->addFilter('entity_id', $this->productType->getChildrenIds($product->getId()), 'in')
             ->create())
             ->getItems();
     }
 
-    private function getValueOrEmptyString($value): string
+    private function valueOrEmptyStr($value): string
     {
         return is_string($value) ? $value : '';
     }

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -17,20 +17,11 @@ use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 
 class ConfigurableDataProvider extends SimpleDataProvider
 {
-    /** @var ConfigurableProductType */
-    private $productType;
-
-    /** @var FilterInterface */
-    private $filter;
-
-    /** @var ProductVariationFactory */
-    private $variationFactory;
-
-    /** @var ProductRepositoryInterface  */
-    private $productRepository;
-
-    /** @var SearchCriteriaBuilder  */
-    private $builder;
+    private ConfigurableProductType $productType;
+    private FilterInterface $filter;
+    private ProductVariationFactory $variationFactory;
+    private ProductRepositoryInterface $productRepository;
+    private SearchCriteriaBuilder $builder;
 
     public function __construct(
         Product $product,

--- a/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
@@ -12,14 +12,9 @@ use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 
 class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
 {
-    /** @var NumberFormatter */
-    protected $numberFormatter;
-
-    /** @var Product */
-    protected $product;
-
-    /** @var FieldInterface[] */
-    private $productFields;
+    protected NumberFormatter $numberFormatter;
+    protected Product $product;
+    private array $productFields;
 
     public function __construct(Product $product, NumberFormatter $numberFormatter, array $productFields = [])
     {
@@ -59,9 +54,11 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
             'MagentoId'     => $this->getId(),
         ];
 
-        return array_reduce($this->productFields, function (array $result, FieldInterface $field): array {
-            return [$field->getName() => $field->getValue($this->product)] + $result;
-        }, $data);
+        return array_reduce(
+            $this->productFields,
+            fn (array $result, FieldInterface $field): array  => [$field->getName() => $field->getValue($this->product)] + $result,
+            $data
+        );
     }
 
     public function getProduct(): Product

--- a/src/Model/Export/Catalog/Products.php
+++ b/src/Model/Export/Catalog/Products.php
@@ -13,14 +13,9 @@ use Magento\Store\Model\StoreManagerInterface;
 
 class Products implements \IteratorAggregate
 {
-    /** @var ProductRepositoryInterface */
-    private $productRepository;
-
-    /** @var SearchCriteriaBuilder */
-    private $searchCriteriaBuilder;
-
-    /** @var StoreManagerInterface */
-    private $storeManager;
+    private ProductRepositoryInterface $productRepository;
+    private SearchCriteriaBuilder $searchCriteriaBuilder;
+    private StoreManagerInterface $storeManager;
 
     /** @var int */
     private $batchSize;

--- a/src/Model/Export/Cms/DataProvider.php
+++ b/src/Model/Export/Cms/DataProvider.php
@@ -10,14 +10,9 @@ use Omikron\Factfinder\Api\Export\FieldInterface;
 
 class DataProvider implements DataProviderInterface
 {
-    /** @var Pages */
-    private $pages;
-
-    /** @var PageFactory */
-    private $pageFactory;
-
-    /** @var FieldInterface[] */
-    private $pageFields;
+    private Pages $pages;
+    private PageFactory $pageFactory;
+    private array $pageFields;
 
     public function __construct(Pages $pages, PageFactory $pageFactory, array $fields)
     {

--- a/src/Model/Export/Cms/Field/Content.php
+++ b/src/Model/Export/Cms/Field/Content.php
@@ -11,8 +11,7 @@ use Omikron\Factfinder\Api\Export\FieldInterface;
 
 class Content implements FieldInterface
 {
-    /** @var Filter */
-    private $filter;
+    private Filter $filter;
 
     public function __construct(Filter $filter)
     {

--- a/src/Model/Export/Cms/Field/Deeplink.php
+++ b/src/Model/Export/Cms/Field/Deeplink.php
@@ -12,11 +12,8 @@ use Magento\Framework\Model\AbstractModel;
 
 class Deeplink implements FieldInterface
 {
-    /** @var UrlInterface */
-    private $urlBuilder;
-
-    /** @var StoreManagerInterface */
-    private $storeManager;
+    private UrlInterface $urlBuilder;
+    private StoreManagerInterface $storeManager;
 
     public function __construct(UrlInterface $urlBuilder, StoreManagerInterface $storeManager)
     {

--- a/src/Model/Export/Cms/Field/Image.php
+++ b/src/Model/Export/Cms/Field/Image.php
@@ -11,8 +11,7 @@ use Magento\Framework\Model\AbstractModel;
 
 class Image implements FieldInterface
 {
-    /** @var Filter */
-    private $filter;
+    private Filter $filter;
 
     public function __construct(Filter $filter)
     {

--- a/src/Model/Export/Cms/Page.php
+++ b/src/Model/Export/Cms/Page.php
@@ -10,11 +10,8 @@ use Omikron\Factfinder\Api\Export\FieldInterface;
 
 class Page implements ExportEntityInterface
 {
-    /** @var PageInterface */
-    private $page;
-
-    /** @var PageFieldInterface[] */
-    private $pageFields;
+    private PageInterface $page;
+    private array $pageFields;
 
     public function __construct(PageInterface $page, array $pageFields = [])
     {
@@ -39,8 +36,10 @@ class Page implements ExportEntityInterface
             'MetaDescription' => (string) $this->page->getMetaDescription(),
         ];
 
-        return array_reduce($this->pageFields, function (array $result, FieldInterface $field): array {
-            return [$field->getName() => $field->getValue($this->page)] + $result;
-        }, $data);
+        return array_reduce(
+            $this->pageFields,
+            fn (array $result, FieldInterface $field): array => [$field->getName() => $field->getValue($this->page)] + $result,
+            $data
+        );
     }
 }

--- a/src/Model/Export/Cms/Pages.php
+++ b/src/Model/Export/Cms/Pages.php
@@ -14,17 +14,10 @@ use Omikron\Factfinder\Model\Config\CmsConfig;
 
 class Pages implements \IteratorAggregate
 {
-    /** @var PageRepositoryInterface */
-    private $pageRepository;
-
-    /** @var SearchCriteriaBuilder */
-    private $searchCriteriaBuilder;
-
-    /** @var CmsConfig */
-    private $cmsConfig;
-
-    /** @var StoreManagerInterface */
-    private $storeManager;
+    private PageRepositoryInterface $pageRepository;
+    private SearchCriteriaBuilder $searchCriteriaBuilder;
+    private CmsConfig $cmsConfig;
+    private StoreManagerInterface $storeManager;
 
     public function __construct(
         PageRepositoryInterface $pageRepository,

--- a/src/Model/Export/Feed.php
+++ b/src/Model/Export/Feed.php
@@ -15,17 +15,10 @@ use Omikron\Factfinder\Api\StreamInterface;
  */
 class Feed
 {
-    /** @var ExporterInterface */
-    private $exporter;
-
-    /** @var DataProviderInterface */
-    private $dataProvider;
-
-    /** @var FieldInterface[] */
-    private $fields;
-
-    /** @var array */
-    private $columns;
+    private ExporterInterface $exporter;
+    private DataProviderInterface $dataProvider;
+    private array $fields;
+    private array $columns;
 
     public function __construct(
         ExporterInterface $exporter,

--- a/src/Model/Export/FeedFactory.php
+++ b/src/Model/Export/FeedFactory.php
@@ -10,11 +10,8 @@ use Omikron\Factfinder\Api\Export\FieldProviderInterface;
 
 class FeedFactory
 {
-    /** @var ObjectManagerInterface */
-    private $objectManager;
-
-    /** @var string[] */
-    private $feedPool;
+    private ObjectManagerInterface $objectManager;
+    private array $feedPool;
 
     public function __construct(
         ObjectManagerInterface $objectManager,

--- a/src/Model/Export/FeedFactory.php
+++ b/src/Model/Export/FeedFactory.php
@@ -30,9 +30,10 @@ class FeedFactory
         $fieldProvider = $this->feedPool[$type]['fieldProvider'];
         $fields = is_array($fieldProvider)
             ? $fieldProvider
-            : call_user_func(function(FieldProviderInterface $fieldProvider) {
-                return $fieldProvider->getFields() + $fieldProvider->getVariantFields();
-            }, $this->objectManager->create($fieldProvider));
+            : call_user_func( //@phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
+                fn (FieldProviderInterface $fieldProvider) : array => $fieldProvider->getFields() + $fieldProvider->getVariantFields(),
+                $this->objectManager->create($fieldProvider)
+            );
 
         $dataProvider = $this->objectManager->create($this->feedPool[$type]['dataProvider'], ['fields' => $fields]);
 

--- a/src/Model/Exporter.php
+++ b/src/Model/Exporter.php
@@ -22,13 +22,12 @@ class Exporter implements ExporterInterface
     {
         $emptyRecord = array_combine($columns, array_fill(0, count($columns), ''));
         foreach ($dataProvider->getEntities() as $entity) {
-            $entityData = array_merge($emptyRecord, array_intersect_key($entity->toArray(), $emptyRecord)); // phpcs:ignore
-            $stream->addEntity($this->prepare($entityData));
+            $stream->addEntity($this->prepareRow($entity->toArray(), $emptyRecord));
         }
     }
 
-    private function prepare(array $data): array
+    private function prepareRow(array $entityData, array $emptyRecord): array
     {
-        return array_map([$this->filter, 'filterValue'], $data);
+        return array_map([$this->filter, 'filterValue'], array_merge($emptyRecord, array_intersect_key($entityData, $emptyRecord)));
     }
 }

--- a/src/Model/Exporter.php
+++ b/src/Model/Exporter.php
@@ -11,8 +11,7 @@ use Omikron\Factfinder\Api\StreamInterface;
 
 class Exporter implements ExporterInterface
 {
-    /** @var FilterInterface */
-    private $filter;
+    private FilterInterface $filter;
 
     public function __construct(FilterInterface $filter)
     {

--- a/src/Model/FieldRoles.php
+++ b/src/Model/FieldRoles.php
@@ -14,21 +14,11 @@ use Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProviderFactor
 class FieldRoles
 {
     private const PATH_PRODUCT_FIELD_ROLE = 'factfinder/general/tracking_product_number_field_role';
-
-    /** @var SerializerInterface */
-    private $serializer;
-
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
-
-    /** @var ConfigResource */
-    private $configResource;
-
-    /** @var SimpleDataProviderFactory */
-    private $dataProviderFactory;
-
-    /** @var array */
-    private $dataProviders = [];
+    private SerializerInterface $serializer;
+    private ScopeConfigInterface $scopeConfig;
+    private ConfigResource $configResource;
+    private SimpleDataProviderFactory $dataProviderFactory;
+    private array $dataProviders = [];
 
     public function __construct(
         SerializerInterface $serializer,

--- a/src/Model/Filesystem/Io/Factory.php
+++ b/src/Model/Filesystem/Io/Factory.php
@@ -12,11 +12,8 @@ use Omikron\Factfinder\Model\Config\FtpConfig;
 
 class Factory
 {
-    /** @var ObjectManagerInterface */
-    private $objectManager;
-
-    /** @var FtpConfig */
-    private $uploadConfig;
+    private ObjectManagerInterface $objectManager;
+    private FtpConfig $uploadConfig;
 
     public function __construct(FtpConfig $uploadConfig, ObjectManagerInterface $objectManager)
     {

--- a/src/Model/Filesystem/Io/SftpPublicKeyAuth.php
+++ b/src/Model/Filesystem/Io/SftpPublicKeyAuth.php
@@ -57,7 +57,7 @@ class SftpPublicKeyAuth extends SftpBase
         $index = array_search($this->uploadConfig->getKeyFileName(), $directoryContent);
 
         if ($index === false) {
-            throw new FileSystemException(__('Key file with a name stored in configuration does not exist in directiory app/etc/factfinder/sftp'));
+            throw new FileSystemException(__('The key file does not exist'));
         }
 
         return $index;

--- a/src/Model/Filesystem/Io/SftpPublicKeyAuth.php
+++ b/src/Model/Filesystem/Io/SftpPublicKeyAuth.php
@@ -15,11 +15,8 @@ use phpseclib\Net\SFTP;
 
 class SftpPublicKeyAuth extends SftpBase
 {
-    /** @var Filesystem */
-    private $fileSystem;
-
-    /** @var FtpConfig */
-    private $uploadConfig;
+    private Filesystem $fileSystem;
+    private FtpConfig $uploadConfig;
 
     public function __construct(Filesystem $fileSystem, FtpConfig $config)
     {

--- a/src/Model/FtpUploader.php
+++ b/src/Model/FtpUploader.php
@@ -12,14 +12,9 @@ use Omikron\Factfinder\Model\Filesystem\Io\Factory as UploadFactory;
 
 class FtpUploader
 {
-    /** @var FtpConfig */
-    private $config;
-
-    /** @var UploadFactory */
-    private $uploadFactory;
-
-    /** @var IoInterface */
-    private $client;
+    private FtpConfig $config;
+    private UploadFactory $uploadFactory;
+    private IoInterface $client;
 
     public function __construct(FtpConfig $config, UploadFactory $uploadFactory)
     {

--- a/src/Model/SessionData.php
+++ b/src/Model/SessionData.php
@@ -12,14 +12,9 @@ use Omikron\Factfinder\Api\Config\ParametersSourceInterface;
 
 class SessionData implements SectionSourceInterface, ParametersSourceInterface
 {
-    /** @var CustomerSession */
-    private $customerSession;
-
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
-
-    /** @var RemoteAddress */
-    private $remoteAddress;
+    private CustomerSession $customerSession;
+    private ScopeConfigInterface $scopeConfig;
+    private RemoteAddress $remoteAddress;
 
     public function __construct(
         CustomerSession $customerSession,

--- a/src/Model/Ssr/PriceFormatter.php
+++ b/src/Model/Ssr/PriceFormatter.php
@@ -11,14 +11,9 @@ use Omikron\Factfinder\Model\FieldRoles;
 
 class PriceFormatter
 {
-    /** @var PriceCurrencyInterface */
-    private $priceCurrency;
-
-    /** @var CommunicationConfig */
-    private $communicationConfig;
-
-    /** @var FieldRoles */
-    private $fieldRoles;
+    private PriceCurrencyInterface $priceCurrency;
+    private CommunicationConfig $communicationConfig;
+    private FieldRoles $fieldRoles;
 
     public function __construct(
         CommunicationConfig $communicationConfig,

--- a/src/Model/Ssr/SearchAdapter.php
+++ b/src/Model/Ssr/SearchAdapter.php
@@ -14,17 +14,10 @@ use Psr\Http\Message\ResponseInterface;
 
 class SearchAdapter
 {
-    /** @var ClientBuilder */
-    private $clientBuilder;
-
-    /** @var CommunicationConfig */
-    private $communicationConfig;
-
-    /** @var CredentialsFactory */
-    private $credentialsFactory;
-
-    /** @var PriceFormatter */
-    private $priceFormatter;
+    private ClientBuilder $clientBuilder;
+    private CommunicationConfig $communicationConfig;
+    private CredentialsFactory $credentialsFactory;
+    private PriceFormatter $priceFormatter;
 
     public function __construct(
         ClientBuilder $clientBuilder,

--- a/src/Model/Ssr/Template/Engine.php
+++ b/src/Model/Ssr/Template/Engine.php
@@ -6,12 +6,11 @@ namespace Omikron\Factfinder\Model\Ssr\Template;
 
 use Magento\Framework\View\Element\BlockInterface;
 use Magento\Framework\View\TemplateEngineInterface;
-use Mustache_Engine;
+use Mustache_Engine as Mustache;
 
 class Engine implements TemplateEngineInterface
 {
-    /** @var Mustache_Engine */
-    private $engine;
+    private Mustache $engine;
 
     public function __construct(Mustache_Engine $engine)
     {

--- a/src/Model/Ssr/Template/Filter.php
+++ b/src/Model/Ssr/Template/Filter.php
@@ -9,8 +9,7 @@ use Omikron\Factfinder\Model\FieldRoles;
 
 class Filter implements FilterInterface
 {
-    /** @var FieldRoles */
-    private $fieldRoles;
+    private FieldRoles $fieldRoles;
 
     public function __construct(FieldRoles $fieldRoles)
     {

--- a/src/Model/Ssr/Template/Loader.php
+++ b/src/Model/Ssr/Template/Loader.php
@@ -10,11 +10,8 @@ use Omikron\Factfinder\Api\Filter\FilterInterface;
 
 class Loader implements Mustache_Loader
 {
-    /** @var Mustache_Loader */
-    private $loader;
-
-    /** @var FilterInterface */
-    private $filter;
+    private Mustache_Loader $loader;
+    private FilterInterface $filter;
 
     public function __construct(Mustache_Loader $loader, FilterInterface $filter)
     {

--- a/src/Model/StoreEmulation.php
+++ b/src/Model/StoreEmulation.php
@@ -10,11 +10,8 @@ use Magento\Store\Model\App\Emulation;
 
 class StoreEmulation
 {
-    /** @var Emulation */
-    private $emulation;
-
-    /** @var AreaList */
-    private $areaList;
+    private Emulation $emulation;
+    private AreaList $areaList;
 
     public function __construct(Emulation $emulation, AreaList $areaList)
     {

--- a/src/Model/Stream/Csv.php
+++ b/src/Model/Stream/Csv.php
@@ -11,14 +11,9 @@ use Omikron\Factfinder\Api\StreamInterface;
 
 class Csv implements StreamInterface
 {
-    /** @var Filesystem */
-    private $filesystem;
-
-    /** @var WriteInterface|null */
-    private $stream;
-
-    /** @var string */
-    private $filename;
+    private Filesystem $filesystem;
+    private ?WriteInterface $stream = null;
+    private string $filename;
 
     public function __construct(Filesystem $filesystem, string $filename = 'factfinder/export.csv')
     {

--- a/src/Model/Stream/Stdout.php
+++ b/src/Model/Stream/Stdout.php
@@ -5,13 +5,21 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Stream;
 
 use BadMethodCallException;
+use Magento\Framework\Filesystem\DriverInterface;
 use Omikron\Factfinder\Api\StreamInterface;
 
 class Stdout implements StreamInterface
 {
+    private DriverInterface $file;
+
+    public function __construct(DriverInterfac $file)
+    {
+        $this->file = $file;
+    }
+
     public function addEntity(array $entity): void
     {
-        fputcsv(STDOUT, array_values($entity), ';', '"');
+        $this->file->filePutCsv(STDOUT, array_values($entity), ';', '"');
     }
 
     public function getContent(): string

--- a/src/Observer/CategoryView.php
+++ b/src/Observer/CategoryView.php
@@ -12,11 +12,8 @@ use Omikron\Factfinder\Model\Config\FeatureConfig;
 
 class CategoryView implements ObserverInterface
 {
-    /** @var Registry */
-    private $registry;
-
-    /** @var FeatureConfig */
-    private $config;
+    private Registry $registry;
+    private FeatureConfig $config;
 
     public function __construct(Registry $registry, FeatureConfig $config)
     {

--- a/src/Observer/ExportAuthentication.php
+++ b/src/Observer/ExportAuthentication.php
@@ -16,14 +16,9 @@ use Omikron\Factfinder\Model\Export\BasicAuth as Authentication;
  */
 class ExportAuthentication implements ObserverInterface
 {
-    /** @var ActionFlag */
-    private $actionFlag;
-
-    /** @var Authentication */
-    private $authentication;
-
-    /** @var Credentials */
-    private $credentials;
+    private ActionFlag $actionFlag;
+    private Authentication $authentication;
+    private Credentials $credentials;
 
     public function __construct(
         ActionFlag $actionFlag,

--- a/src/Observer/RedirectSearch.php
+++ b/src/Observer/RedirectSearch.php
@@ -13,14 +13,9 @@ use Omikron\Factfinder\Model\Config\CommunicationConfig;
 
 class RedirectSearch implements ObserverInterface
 {
-    /** @var RedirectInterface */
-    private $redirect;
-
-    /** @var ResponseInterface */
-    private $response;
-
-    /** @var CommunicationConfig */
-    private $config;
+    private RedirectInterface $redirect;
+    private ResponseInterface $response;
+    private CommunicationConfig $config;
 
     public function __construct(
         RedirectInterface $redirect,

--- a/src/Observer/Ssr.php
+++ b/src/Observer/Ssr.php
@@ -11,11 +11,8 @@ use Magento\Store\Model\ScopeInterface;
 
 class Ssr implements ObserverInterface
 {
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
-
-    /** @var string[] */
-    private $useForHandles;
+    private ScopeConfigInterface $scopeConfig;
+    private array $useForHandles;
 
     public function __construct(
         ScopeConfigInterface $scopeConfig,

--- a/src/Plugin/AssetMinificationPlugin.php
+++ b/src/Plugin/AssetMinificationPlugin.php
@@ -14,6 +14,6 @@ class AssetMinificationPlugin
 
     public function afterGetExcludes($subject, array $result, string $contentType): array
     {
-        return array_merge($result, $contentType === 'js' ? [self::JS_LIBRARY] : []);
+        return $result + ($contentType === 'js' ? [self::JS_LIBRARY] : []);
     }
 }

--- a/src/Plugin/AssetMinificationPlugin.php
+++ b/src/Plugin/AssetMinificationPlugin.php
@@ -10,7 +10,7 @@ namespace Omikron\Factfinder\Plugin;
 class AssetMinificationPlugin
 {
     /** Web Components library location */
-    const JS_LIBRARY = '/Omikron_Factfinder/ff-web-components/';
+    public const JS_LIBRARY = '/Omikron_Factfinder/ff-web-components/';
 
     public function afterGetExcludes($subject, array $result, string $contentType): array
     {

--- a/src/Plugin/LogExceptions.php
+++ b/src/Plugin/LogExceptions.php
@@ -12,11 +12,8 @@ use Psr\Log\LoggerInterface;
 
 class LogExceptions
 {
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
-
-    /** @var LoggerInterface */
-    private $logger;
+    private ScopeConfigInterface $scopeConfig;
+    private LoggerInterface $logger;
 
     public function __construct(ScopeConfigInterface $scopeConfig, LoggerInterface $logger)
     {

--- a/src/Service/FeedFileService.php
+++ b/src/Service/FeedFileService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Service;
 
 use Exception;
+use Magento\Framework\Exception\InvalidArgumentException;
 
 class FeedFileService
 {
@@ -19,11 +20,11 @@ class FeedFileService
     public function getFeedExportFilename(string $exportType, string $channel): string
     {
         if (empty($exportType)) {
-            throw new Exception('Export type should not be empty');
+            throw new InvalidArgumentException(__('Argument $exportType must not be empty'));
         }
 
         if (empty($channel)) {
-            throw new Exception('Channel should not be empty');
+            throw new InvalidArgumentException(__('Argument $channel must not be empty'));
         }
 
         return str_replace(['%type%', '%channel%'], [$exportType, $channel], self::FEED_FILENAME_PATTERN);

--- a/src/Test/Integration/Block/SSR/RecordListTest.php
+++ b/src/Test/Integration/Block/SSR/RecordListTest.php
@@ -97,7 +97,8 @@ class RecordListTest extends AbstractController
                     ['price', null, 'Price'],
                     ['deeplink', null, 'Deeplink'],
                     ['imageUrl', null, 'ImageURl']
-                ]);
+                ]
+            );
 
         //enable ssr
         $this->_objectManager->get(\Magento\Config\Model\ResourceModel\Config::class)->saveConfig('factfinder/general/use_ssr', 1);

--- a/src/Test/Integration/Model/FieldRolesTest.php
+++ b/src/Test/Integration/Model/FieldRolesTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Test\Integration\Model;
+
+use PHPUnit\Framework\TestCase;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Omikron\Factfinder\Model\FieldRoles as FieldRolesModel;
+
+class FieldRolesTest extends TestCase
+{
+    private ObjectManagerInterface $objectManager;
+
+    public function test_will_store_field_roles_correctly_for_specific_scope()
+    {
+        $fieldRoles = $this->objectManager->get(FieldRolesModel::class);
+        $scopeConfig = $this->objectManager->get(SCopeConfigInterface::class);
+
+        $fieldRoles->saveFieldRoles(['productNumber' => 'ProductNumber'], 0);
+        $fieldRoles->saveFieldRoles(['productNumber' => 'ProductIdentifier'], 1);
+
+        $this->assertEqual('ProductNumber', $this->getFieldRole('productNumber', 0));
+        $this->assertEqual('ProductIdentifier', $this->getFieldRole('productNumber', 1));
+    }
+
+    public function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+    }
+}

--- a/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\Model\Export\Catalog\Entity;
 
-use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\Model\AbstractModel;
 use Omikron\Factfinder\Model\Export\Catalog\FieldProvider;
@@ -63,7 +62,8 @@ class ProductVariationTest extends TestCase
                 'MagentoId'     => 2,
                 'HasVariants'   => 0,
                 'ImageUrl'      => 'http://specific-variant-image.png',
-            ], $productVariation->toArray()
+            ],
+            $productVariation->toArray()
         );
     }
 
@@ -92,8 +92,9 @@ class ProductVariationTest extends TestCase
             ['FilterAttributes' => '|Color=Red|Size=XS|'] + $this->configurableProductData
         );
 
-        $this->assertEquals('|Color=Red|Size=XS|Eco Collection=No|New=No|Price=52.00|Quantity=In Stock|',
-                            $productVariation->toArray()['FilterAttributes']
+        $this->assertEquals(
+            '|Color=Red|Size=XS|Eco Collection=No|New=No|Price=52.00|Quantity=In Stock|',
+            $productVariation->toArray()['FilterAttributes']
         );
     }
 

--- a/src/Test/Unit/Model/Export/Catalog/ProductField/CategoryPathTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/ProductField/CategoryPathTest.php
@@ -50,76 +50,97 @@ class CategoryPathTest extends TestCase
         $this->assertStringNotContains('Default Category', $path);
     }
 
-
     protected function setUp(): void
     {
         $this->repositoryMock = $this->createMock(CategoryRepositoryInterface::class);
         $this->repositoryMock->method('get')->willReturnMap(
             [
                 [
-                    1, 1, $this->createConfiguredMock(
-                    CategoryInterface::class,
-                    [
-                        'getName'     => 'Root Catlog',
-                        'getPath'     => '1',
-                        'getIsActive' => true,
-                    ])
+                    1,
+                    1,
+                    $this->createConfiguredMock(
+                        CategoryInterface::class,
+                        [
+                            'getName'     => 'Root Catlog',
+                            'getPath'     => '1',
+                            'getIsActive' => true,
+                        ]
+                    )
                 ],
                 [
-                    2, 1, $this->createConfiguredMock(
-                    CategoryInterface::class,
-                    [
-                        'getName'     => 'Default Category',
-                        'getPath'     => '1/2',
-                        'getIsActive' => true,
-                    ])
+                    2,
+                    1,
+                    $this->createConfiguredMock(
+                        CategoryInterface::class,
+                        [
+                            'getName'     => 'Default Category',
+                            'getPath'     => '1/2',
+                            'getIsActive' => true,
+                        ]
+                    )
                 ],
                 [
-                    3, 1, $this->createConfiguredMock(
-                    CategoryInterface::class,
-                    [
-                        'getName'     => 'Clothes',
-                        'getPath'     => '1/2/3',
-                        'getIsActive' => true,
-                    ])
+                    3,
+                    1,
+                    $this->createConfiguredMock(
+                        CategoryInterface::class,
+                        [
+                            'getName'     => 'Clothes',
+                            'getPath'     => '1/2/3',
+                            'getIsActive' => true,
+                        ]
+                    )
                 ],
                 [
-                    4, 1, $this->createConfiguredMock(
-                    CategoryInterface::class,
-                    [
-                        'getName'     => 'Trousers & Pants',
-                        'getPath'     => '1/2/3/4',
-                        'getIsActive' => true,
-                    ])
+                    4,
+                    1,
+                    $this->createConfiguredMock(
+                        CategoryInterface::class,
+                        [
+                            'getName'     => 'Trousers & Pants',
+                            'getPath'     => '1/2/3/4',
+                            'getIsActive' => true,
+                        ]
+                    )
                 ],
                 [
-                    5, 1, $this->createConfiguredMock(
-                    CategoryInterface::class,
-                    [
-                        'getName'     => '5/6 Length Trousers',
-                        'getPath'     => '1/2/3/4/5',
-                        'getIsActive' => true,
-                    ])
+                    5,
+                    1,
+                    $this->createConfiguredMock(
+                        CategoryInterface::class,
+                        [
+                            'getName'     => '5/6 Length Trousers',
+                            'getPath'     => '1/2/3/4/5',
+                            'getIsActive' => true,
+                        ]
+                    )
                 ],
                 [
-                    6, 1, $this->createConfiguredMock(
-                    CategoryInterface::class,
-                    [
-                        'getName'     => 'Short Trousers',
-                        'getPath'     => '1/2/3/4/6',
-                        'getIsActive' => true,
-                    ])
+                    6,
+                    1,
+                    $this->createConfiguredMock(
+                        CategoryInterface::class,
+                        [
+                            'getName'     => 'Short Trousers',
+                            'getPath'     => '1/2/3/4/6',
+                            'getIsActive' => true,
+                        ]
+                    )
                 ],
                 [
-                    7, 1, $this->createConfiguredMock(
-                    CategoryInterface::class,
-                    [
-                        'getName'     => 'Not Active category',
-                        'getPath'     => '1/2/7',
-                        'getIsActive' => false,
-                    ])
+                    7,
+                    1,
+                    $this->createConfiguredMock(
+                        CategoryInterface::class,
+                        [
+                            'getName'     => 'Not Active category',
+                            'getPath'     => '1/2/7',
+                            'getIsActive' => false,
+                        ]
+                    )
                 ],
-            ]);
+            ]
+        );
         $this->productMock = $this->getMockBuilder(AbstractModel::class)
             ->disableOriginalConstructor()
             ->setMethods(['getStore', 'getCategoryIds'])

--- a/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
@@ -20,42 +20,42 @@ class ConfigurableDataProviderTest extends TestCase
     private $configurableDataProvider;
 
     /**
-     * @covers ConfigurableDataProvider::getValueOrEmptyString
+     * @covers ConfigurableDataProvider::valueOrEmptyStr
      */
     public function test_will_return_string_on_string_value()
     {
-        $getValueOrEmptyStringMethod = $this->invokeMethod($this->configurableDataProvider, 'getValueOrEmptyString', ['test']);
-        $this->assertEquals('test', $getValueOrEmptyStringMethod);
+        $valueOrEmptyStrMethod = $this->invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', ['test']);
+        $this->assertEquals('test', $valueOrEmptyStrMethod);
     }
 
     /**
-     * @covers ConfigurableDataProvider::getValueOrEmptyString
+     * @covers ConfigurableDataProvider::valueOrEmptyStr
      */
     public function test_will_return_empty_string_on_null_value()
     {
-        $getValueOrEmptyStringMethod = $this->invokeMethod($this->configurableDataProvider, 'getValueOrEmptyString', [null]);
-        $this->assertEquals('', $getValueOrEmptyStringMethod);
+        $valueOrEmptyStrMethod = $this->invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', [null]);
+        $this->assertEquals('', $valueOrEmptyStrMethod);
     }
 
     /**
-     * @covers ConfigurableDataProvider::getValueOrEmptyString
+     * @covers ConfigurableDataProvider::valueOrEmptyStr
      */
     public function test_will_return_empty_string_on_bool_value()
     {
-        $getValueOrEmptyStringMethod = $this->invokeMethod($this->configurableDataProvider, 'getValueOrEmptyString', [false]);
-        $this->assertEquals('', $getValueOrEmptyStringMethod);
+        $valueOrEmptyStrMethod = $this->invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', [false]);
+        $this->assertEquals('', $valueOrEmptyStrMethod);
     }
 
     /**
-     * @covers ConfigurableDataProvider::getValueOrEmptyString
+     * @covers ConfigurableDataProvider::valueOrEmptyStr
      */
     public function test_will_return_empty_string_on_array_value()
     {
-        $getValueOrEmptyStringMethod = $this->invokeMethod($this->configurableDataProvider, 'getValueOrEmptyString', [[]]);
-        $this->assertEquals('', $getValueOrEmptyStringMethod);
+        $valueOrEmptyStrMethod = $this->invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', [[]]);
+        $this->assertEquals('', $valueOrEmptyStrMethod);
     }
 
-    public function invokeMethod(&$object, $methodName, array $parameters = array())
+    public function invokeMethod(&$object, $methodName, array $parameters = [])
     {
         $reflection = new \ReflectionClass(get_class($object));
         $method = $reflection->getMethod($methodName);

--- a/src/Test/Unit/Plugin/LogExceptionsTest.php
+++ b/src/Test/Unit/Plugin/LogExceptionsTest.php
@@ -26,16 +26,12 @@ class LogExceptionsTest extends TestCase
 
     public function test_proceed_if_no_exception_is_raised()
     {
-        $this->assertSame(true, $this->plugin->aroundExecute(null, function () {
-            return true;
-        }));
+        $this->assertSame(true, $this->plugin->aroundExecute(null, fn () => true));
     }
 
     public function test_return_false_on_exception()
     {
-        $this->assertSame(false, $this->plugin->aroundExecute(null, function () {
-            throw new ClientException();
-        }));
+        $this->assertSame(false, $this->plugin->aroundExecute(null, fn () => throw new ClientException()));
     }
 
     public function test_log_exception_if_logging_is_enabled()
@@ -47,9 +43,7 @@ class LogExceptionsTest extends TestCase
 
         $this->logger->expects($this->once())->method('error');
 
-        $this->assertSame(false, $this->plugin->aroundExecute(null, function () {
-            throw new ClientException();
-        }));
+        $this->assertSame(false, $this->plugin->aroundExecute(null, fn () => throw new ClientException()));
     }
 
     protected function setUp(): void

--- a/src/Test/Unit/Plugin/LogExceptionsTest.php
+++ b/src/Test/Unit/Plugin/LogExceptionsTest.php
@@ -26,12 +26,16 @@ class LogExceptionsTest extends TestCase
 
     public function test_proceed_if_no_exception_is_raised()
     {
-        $this->assertSame(true, $this->plugin->aroundExecute(null, fn () => true));
+        $this->assertSame(true, $this->plugin->aroundExecute(null, function () {
+            return true;
+        }));
     }
 
     public function test_return_false_on_exception()
     {
-        $this->assertSame(false, $this->plugin->aroundExecute(null, fn () => throw new ClientException()));
+        $this->assertSame(false, $this->plugin->aroundExecute(null, function () {
+            throw new ClientException();
+        }));
     }
 
     public function test_log_exception_if_logging_is_enabled()
@@ -43,7 +47,9 @@ class LogExceptionsTest extends TestCase
 
         $this->logger->expects($this->once())->method('error');
 
-        $this->assertSame(false, $this->plugin->aroundExecute(null, fn () => throw new ClientException()));
+        $this->assertSame(false, $this->plugin->aroundExecute(null, function () {
+            throw new ClientException();
+        }));
     }
 
     protected function setUp(): void

--- a/src/Test/Unit/Service/FeedFileServiceTest.php
+++ b/src/Test/Unit/Service/FeedFileServiceTest.php
@@ -3,6 +3,7 @@
 
 namespace Omikron\Factfinder\Service;
 
+use Magento\Framework\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,15 +26,15 @@ class FeedFileServiceTest extends TestCase
 
     public function test_will_throw_exception_on_empty_export_type()
     {
-        $this->expectException('Exception');
-        $this->expectExceptionMessage('Export type should not be empty');
+        $this->expectException('Magento\Framework\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Argument $exportType must not be empty');
         $this->assertSame('export.test_type.test_channel.csv', $this->feedFileService->getFeedExportFilename('', 'test_channel'));
     }
 
     public function test_will_throw_exception_on_empty_export_channel()
     {
-        $this->expectException('Exception');
-        $this->expectExceptionMessage('Channel should not be empty');
+        $this->expectException('Magento\Framework\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Argument $channel must not be empty');
         $this->assertSame('export.test_type.test_channel.csv', $this->feedFileService->getFeedExportFilename('test_type', ''));
     }
 
@@ -49,6 +50,5 @@ class FeedFileServiceTest extends TestCase
     protected function setUp(): void
     {
         $this->feedFileService = new FeedFileService();
-
     }
 }

--- a/src/Test/Unit/ViewModel/CartTest.php
+++ b/src/Test/Unit/ViewModel/CartTest.php
@@ -24,9 +24,8 @@ class CartTest extends TestCase
 
     protected function setUp(): void
     {
-        $quoteItems = array_map(function (string $sku): Quote\Item {
-            return $this->createConfiguredMock(Quote\Item::class, ['getProduct' => new DataObject(['sku' => $sku])]);
-        }, ['foo', 'bar', 'baz']);
+        $quoteItems = array_map(fn (string $sku): Quote\Item =>$this->createConfiguredMock(Quote\Item::class, ['getProduct' => new DataObject(['sku' => $sku])]),
+            ['foo', 'bar', 'baz']);
 
         $quoteMock   = $this->createConfiguredMock(Quote::class, ['getAllVisibleItems' => $quoteItems]);
         $sessionMock = $this->createConfiguredMock(Session::class, ['getQuote' => $quoteMock]);

--- a/src/Test/Unit/ViewModel/CartTest.php
+++ b/src/Test/Unit/ViewModel/CartTest.php
@@ -24,8 +24,10 @@ class CartTest extends TestCase
 
     protected function setUp(): void
     {
-        $quoteItems = array_map(fn (string $sku): Quote\Item =>$this->createConfiguredMock(Quote\Item::class, ['getProduct' => new DataObject(['sku' => $sku])]),
-            ['foo', 'bar', 'baz']);
+        $quoteItems = array_map(
+            fn (string $sku): Quote\Item =>$this->createConfiguredMock(Quote\Item::class, ['getProduct' => new DataObject(['sku' => $sku])]),
+            ['foo', 'bar', 'baz']
+        );
 
         $quoteMock   = $this->createConfiguredMock(Quote::class, ['getAllVisibleItems' => $quoteItems]);
         $sessionMock = $this->createConfiguredMock(Session::class, ['getQuote' => $quoteMock]);

--- a/src/Test/Unit/ViewModel/CategoryPathTest.php
+++ b/src/Test/Unit/ViewModel/CategoryPathTest.php
@@ -61,7 +61,6 @@ class CategoryPathTest extends TestCase
 
         $value = 'filter=CategoryPath%3AMen%2FTops';
         $this->assertSame($value, (string) $categoryPath->getCategoryPath());
-
     }
 
     protected function setUp(): void
@@ -77,8 +76,8 @@ class CategoryPathTest extends TestCase
         return $this->createConfiguredMock(Category::class, ['getName' => $name, 'getLevel' => $level]);
     }
 
-    private function newCategoryPath(CommunicationConfig $communicationConfig): CategoryPath
+    private function newCategoryPath(): CategoryPath
     {
-        return new CategoryPath($this->registry, $this->communicationConfig);;
+        return new CategoryPath($this->registry, $this->communicationConfig);
     }
 }

--- a/src/Test/Unit/ViewModel/OrderTest.php
+++ b/src/Test/Unit/ViewModel/OrderTest.php
@@ -34,8 +34,11 @@ class OrderTest extends TestCase
     protected function setUp(): void
     {
         $this->orderItemsMock = array_map(
-            fn (array $data): OrderModel\Item => $this->createConfiguredMock(OrderModel\Item::class,
-            ['getProduct' => new DataObject(['sku' => $data[0], 'qty' => $data[1]])]), [['foo', 1], ['bar', 3], ['baz', 2]]
+            fn (array $data): OrderModel\Item => $this->createConfiguredMock(
+                OrderModel\Item::class,
+                ['getProduct' => new DataObject(['sku' => $data[0], 'qty' => $data[1]])]
+            ),
+            [['foo', 1], ['bar', 3], ['baz', 2]]
         );
 
         $orderMock   = $this->createConfiguredMock(OrderModel::class, ['getAllVisibleItems' => $this->orderItemsMock]);

--- a/src/Test/Unit/ViewModel/OrderTest.php
+++ b/src/Test/Unit/ViewModel/OrderTest.php
@@ -33,9 +33,10 @@ class OrderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->orderItemsMock = array_map(function (array $data): OrderModel\Item {
-            return $this->createConfiguredMock(OrderModel\Item::class, ['getProduct' => new DataObject(['sku' => $data[0], 'qty' => $data[1]])]);
-        }, [['foo', 1], ['bar', 3], ['baz', 2]]);
+        $this->orderItemsMock = array_map(
+            fn (array $data): OrderModel\Item => $this->createConfiguredMock(OrderModel\Item::class,
+            ['getProduct' => new DataObject(['sku' => $data[0], 'qty' => $data[1]])]), [['foo', 1], ['bar', 3], ['baz', 2]]
+        );
 
         $orderMock   = $this->createConfiguredMock(OrderModel::class, ['getAllVisibleItems' => $this->orderItemsMock]);
         $sessionMock = $this->createConfiguredMock(Session::class, ['getLastRealOrder' => $orderMock]);

--- a/src/ViewModel/Cart.php
+++ b/src/ViewModel/Cart.php
@@ -11,8 +11,7 @@ use Magento\Quote\Model\Quote\Item as QuoteItem;
 
 class Cart implements ArgumentInterface
 {
-    /** @var Session */
-    private $checkoutSession;
+    private Session $checkoutSession;
 
     public function __construct(Session $checkoutSession)
     {
@@ -36,8 +35,6 @@ class Cart implements ArgumentInterface
      */
     public function getItemIds(): array
     {
-        return array_unique(array_map(function (QuoteItem $quoteItem): string {
-            return (string) $quoteItem->getProduct()->getData('sku');
-        }, $this->getItems()));
+        return array_unique(array_map(fn (QuoteItem $quoteItem) => (string) $quoteItem->getProduct()->getData('sku'), $this->getItems()));
     }
 }

--- a/src/ViewModel/CategoryPath.php
+++ b/src/ViewModel/CategoryPath.php
@@ -102,7 +102,18 @@ class CategoryPath implements ArgumentInterface
     private function encodeCategoryName(string $path): string
     {
         //important! do not override this method
-        return preg_replace('/\+/', '%2B',
-            preg_replace('/\//', '%2F', preg_replace('/%/', '%25', $path)));
+        return preg_replace(
+            '/\+/',
+            '%2B',
+            preg_replace(
+                '/\//',
+                '%2F',
+                preg_replace(
+                    '/%/',
+                    '%25',
+                    $path
+                )
+            )
+        );
     }
 }

--- a/src/ViewModel/CategoryPath.php
+++ b/src/ViewModel/CategoryPath.php
@@ -12,46 +12,43 @@ use Omikron\Factfinder\Model\Config\CommunicationConfig;
 
 class CategoryPath implements ArgumentInterface
 {
-    /** @var Registry */
-    private $registry;
-
-    /** @var CommunicationConfig */
-    private $communicationConfig;
-
-    /** @var string */
-    private $param;
-
-    /** @var string[] */
-    private $initial;
+    private Registry $registry;
+    private CommunicationConfig $communicationConfig;
+    private string $param;
+    private array $initial;
 
     public function __construct(
-        Registry $registry,
+        Registry            $registry,
         CommunicationConfig $communicationConfig,
-        string $param = 'CategoryPath',
-        array $initial = []
-    )
-    {
-        $this->param = $param;
-        $this->registry = $registry;
+        string              $param = 'CategoryPath',
+        array               $initial = []
+    ) {
+        $this->param               = $param;
+        $this->registry            = $registry;
         $this->communicationConfig = $communicationConfig;
-        $this->initial = $initial;
+        $this->initial             = $initial;
     }
 
     public function __toString()
     {
-        return $this->communicationConfig->getVersion() === Version::NG ? $this->getCategoryPath() : $this->getAddParams();
+        return $this->communicationConfig->getVersion() === Version::NG ? $this->getCategoryPath(
+        ) : $this->getAddParams();
     }
 
     public function getCategoryPath(): string
     {
-        if ($this->communicationConfig->getVersion() === Version::NG) return implode(',', $this->ngPath($this->getCurrentCategory()));
+        if ($this->communicationConfig->getVersion() === Version::NG) {
+            return implode(',', $this->ngPath($this->getCurrentCategory()));
+        }
 
         return '';
     }
 
     public function getAddParams(): string
     {
-        if ($this->communicationConfig->getVersion() === Version::NG) return '';
+        if ($this->communicationConfig->getVersion() === Version::NG) {
+            return '';
+        }
 
         return implode(',', $this->standardPath($this->getCurrentCategory()));
     }
@@ -76,9 +73,10 @@ class CategoryPath implements ArgumentInterface
 
     private function ngPath(?Category $category): array
     {
-        $path = array_map(function (Category $item): string {
-            return (string) $this->encodeCategoryName(trim($item->getName()));
-        }, $category ? $this->getParentCategories($category) : []);
+        $path = array_map(
+            fn (Category $item): string => (string) $this->encodeCategoryName(trim($item->getName())),
+            $category ? $this->getParentCategories($category) : []
+        );
 
         return [sprintf('filter=%s', urlencode($this->param . ':' . implode('/', $path)))];
     }
@@ -91,9 +89,7 @@ class CategoryPath implements ArgumentInterface
     private function getParentCategories(?Category $category): array
     {
         $categories = $category ? $category->getParentCategories() : [];
-        usort($categories, function (Category $a, Category $b): int {
-            return $a->getLevel() - $b->getLevel();
-        });
+        usort($categories, fn (Category $a, Category $b): int => $a->getLevel() - $b->getLevel());
 
         return $categories;
     }

--- a/src/ViewModel/Communication.php
+++ b/src/ViewModel/Communication.php
@@ -11,17 +11,13 @@ use Omikron\Factfinder\Model\FieldRoles;
 
 class Communication implements ArgumentInterface
 {
-    /** @var FieldRoles */
-    private $fieldRoles;
+    private FieldRoles $fieldRoles;
 
-    /** @var SerializerInterface */
-    private $serializer;
+    private SerializerInterface $serializer;
 
-    /** @var CommunicationParametersProvider */
-    private $parametersProvider;
+    private CommunicationParametersProvider $parametersProvider;
 
-    /** @var string[] */
-    private $mergeableParams;
+    private array $mergeableParams;
 
     public function __construct(
         FieldRoles $fieldRoles,
@@ -48,12 +44,8 @@ class Communication implements ArgumentInterface
 
     private function mergeParameters(array ...$params): array
     {
-        $params = array_map(function (array $param): array {
-            return array_intersect_key($param + $this->mergeableParams, $this->mergeableParams);
-        }, $params);
+        $params = array_map(fn (array $param) => array_intersect_key($param + $this->mergeableParams, $this->mergeableParams), $params);
 
-        return array_reduce(array_keys($this->mergeableParams), function ($result, $key) use ($params) {
-            return $result + [$key => implode(',', array_filter(array_column($params, $key)))];
-        }, []);
+        return array_reduce(array_keys($this->mergeableParams), fn ($result, $key) => $result + [$key => implode(',', array_filter(array_column($params, $key)))], []);
     }
 }

--- a/src/ViewModel/Communication.php
+++ b/src/ViewModel/Communication.php
@@ -34,7 +34,8 @@ class Communication implements ArgumentInterface
     public function getParameters(array $blockParams = []): array
     {
         $params = $this->parametersProvider->getParameters();
-        return ['version' => $params['version'] ?? 'ng'] + array_filter($this->mergeParameters($blockParams, $params) + $blockParams + $params, 'boolval');
+        return ['version' => $params['version'] ?? 'ng']
+            + array_filter($this->mergeParameters($blockParams, $params) + $blockParams + $params, 'boolval');
     }
 
     public function getFieldRoles(): string
@@ -46,6 +47,7 @@ class Communication implements ArgumentInterface
     {
         $params = array_map(fn (array $param) => array_intersect_key($param + $this->mergeableParams, $this->mergeableParams), $params);
 
-        return array_reduce(array_keys($this->mergeableParams), fn ($result, $key) => $result + [$key => implode(',', array_filter(array_column($params, $key)))], []);
+        return array_reduce(array_keys($this->mergeableParams), fn ($result, $key) => $result
+            + [$key => implode(',', array_filter(array_column($params, $key)))], []);
     }
 }

--- a/src/ViewModel/Order.php
+++ b/src/ViewModel/Order.php
@@ -12,11 +12,8 @@ use Omikron\Factfinder\Model\Config\CommunicationConfig;
 
 class Order implements ArgumentInterface
 {
-    /** @var Session */
-    private $checkoutSession;
-
-    /** @var CommunicationConfig */
-    private $communicationConfig;
+    private Session $checkoutSession;
+    private CommunicationConfig $communicationConfig;
 
     public function __construct(Session $checkoutSession, CommunicationConfig $communicationConfig)
     {

--- a/src/ViewModel/ProductBasedComponent.php
+++ b/src/ViewModel/ProductBasedComponent.php
@@ -16,17 +16,10 @@ class ProductBasedComponent implements ArgumentInterface
     private const PATH_SHOW_ADD_TO_CART_BUTTON = 'factfinder/general/show_add_to_cart_button';
     private const PATH_MAX_RESULT = 'factfinder/components_options/max_results_';
 
-    /** @var Image */
-    private $imageHelper;
-
-    /** @var ScopeConfigInterface */
-    private $scopeConfig;
-
-    /** @var UrlInterface */
-    private $urlBuilder;
-
-    /** @var Registry */
-    private $registry;
+    private Image $imageHelper;
+    private ScopeConfigInterface $scopeConfig;
+    private UrlInterface $urlBuilder;
+    private Registry $registry;
 
     public function __construct(
         Image $imageHelper,

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -3,6 +3,7 @@
     <module name="Omikron_Factfinder" setup_version="0.1.0">
         <sequence>
             <module name="Magento_Search" />
+            <module name="Magento_CatalogSearch"/>
         </sequence>
     </module>
 </config>

--- a/src/view/adminhtml/web/css/source/_module.less
+++ b/src/view/adminhtml/web/css/source/_module.less
@@ -1,11 +1,11 @@
 .admin__page {
-  .ff-config-tab&-nav-item a&-nav-link {
-    background-image: url('Omikron_Factfinder::images/logo.png');
-    background-repeat: no-repeat;
-    background-position: .5rem center;
+    .ff-config-tab&-nav-item a&-nav-link {
+        background-image: url('Omikron_Factfinder::images/logo.png');
+        background-repeat: no-repeat;
+        background-position: .5rem center;
 
-    span {
-      visibility: hidden;
+        span {
+            visibility: hidden;
+        }
     }
-  }
 }

--- a/src/view/frontend/templates/ff/similar.phtml
+++ b/src/view/frontend/templates/ff/similar.phtml
@@ -4,7 +4,7 @@
 $viewModel = $block->getViewModel();
 ?>
 
-<ff-similar-products <?php if ($viewModel): ?> max-results="<?= $viewModel->getMaxResult('similar_products') ?>" record-id="<?= $block->escapeHtmlAttr($viewModel->getProduct()->getSku()) ?>" id-type="productNumber" <?php endif; ?>unresolved>
+<ff-similar-products <?php if ($viewModel): ?> max-results="<?= $block->escapeHtmlAttr($viewModel->getMaxResult('similar_products')) ?>" record-id="<?= $block->escapeHtmlAttr($viewModel->getProduct()->getSku()) ?>" id-type="productNumber" <?php endif; ?> unresolved>
     <div class="block upsell" data-limit="0" data-shuffle="0">
         <div class="block-title title">
             <strong id="block-upsell-heading" role="heading" aria-level="2"><?= $block->escapeHtml(__('Similar products')) ?></strong>

--- a/src/view/frontend/web/css/source/ff/_asn.less
+++ b/src/view/frontend/web/css/source/ff/_asn.less
@@ -5,6 +5,7 @@ ff-asn, ff-asn-group, ff-asn-group-slider {
 
 .ff-asn {
     margin: 0 0 2rem;
+
     .hidden {
         display: none;
     }

--- a/src/view/frontend/web/css/source/ff/_breadcrumb.less
+++ b/src/view/frontend/web/css/source/ff/_breadcrumb.less
@@ -1,18 +1,18 @@
 ff-breadcrumb-trail {
-  margin: 0 1rem;
+    margin: 0 1rem;
 
-  &-item {
-    font-weight: @font-weight__regular;
-    color: @active__color;
-  }
+    &-item {
+        font-weight: @font-weight__regular;
+        color: @active__color;
+    }
 }
 
 .ff-breadcrumb-trail {
-  font-weight: @heading__font-weight__base;
-  font-size: 3rem;
-  margin: 0 0 2rem;
+    font-weight: @heading__font-weight__base;
+    font-size: 3rem;
+    margin: 0 0 2rem;
 
-  ff-template span {
-    font-weight: @font-weight__regular;
-  }
+    ff-template span {
+        font-weight: @font-weight__regular;
+    }
 }

--- a/src/view/frontend/web/css/source/ff/_common.less
+++ b/src/view/frontend/web/css/source/ff/_common.less
@@ -1,4 +1,4 @@
 [unresolved] {
-  opacity: 0;
-  display: none;
+    opacity: 0;
+    display: none;
 }

--- a/src/view/frontend/web/css/source/ff/_paging.less
+++ b/src/view/frontend/web/css/source/ff/_paging.less
@@ -1,36 +1,36 @@
 ff-paging-item {
-  line-height: 32px;
-  height: 32px;
+    line-height: 32px;
+    height: 32px;
 
-  .ffw-cursor {
-    padding: 0 13px;
-  }
-
-  &:hover {
-    background: #FF692C;
-    color: #FFF;
-  }
-
-  &[type="nextLink"], &[type="previousLink"] {
-    background: #FFF;
-  }
-
-  &[type="currentLink"] {
-    background-color: #393b3e;
-    color: #FFF;
-    font-weight: normal;
-  }
-
-  input.padd {
-    &, &:focus {
-      box-shadow: none;
-      outline: none;
+    .ffw-cursor {
+        padding: 0 13px;
     }
-  }
+
+    &:hover {
+        background: #FF692C;
+        color: #FFF;
+    }
+
+    &[type="nextLink"], &[type="previousLink"] {
+        background: #FFF;
+    }
+
+    &[type="currentLink"] {
+        background-color: #393b3e;
+        color: #FFF;
+        font-weight: normal;
+    }
+
+    input.padd {
+        &, &:focus {
+            box-shadow: none;
+            outline: none;
+        }
+    }
 }
 
 @media (max-width: 560px) {
-  .ff-paging {
-    margin: 10px auto;
-  }
+    .ff-paging {
+        margin: 10px auto;
+    }
 }

--- a/src/view/frontend/web/css/source/ff/_record-list.less
+++ b/src/view/frontend/web/css/source/ff/_record-list.less
@@ -1,35 +1,35 @@
 ff-record {
-  .product-image {
-    &-container {
-      display: block;
+    .product-image {
+        &-container {
+            display: block;
+        }
+
+        &-wrapper {
+            padding-bottom: 100%;
+        }
     }
 
-    &-wrapper {
-      padding-bottom: 100%;
-    }
-  }
+    .product-item-actions {
+        .actions-primary {
+            display: block;
+        }
 
-  .product-item-actions {
-    .actions-primary {
-      display: block;
+        .tocart {
+            width: 100%;
+        }
     }
-
-    .tocart {
-      width: 100%;
-    }
-  }
 }
 
 .ff-products-per-page {
-  .label {
-    display: none;
-  }
+    .label {
+        display: none;
+    }
 }
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
-  .ff-products-per-page {
-    .label {
-      display: inline;
+    .ff-products-per-page {
+        .label {
+            display: inline;
+        }
     }
-  }
 }

--- a/src/view/frontend/web/css/source/ff/_searchbox.less
+++ b/src/view/frontend/web/css/source/ff/_searchbox.less
@@ -1,65 +1,65 @@
 .search-wrapper {
-  .header & {
-    margin: 8px 30px 0 200px;
-  }
+    .header & {
+        margin: 8px 30px 0 200px;
+    }
 }
 
 .ff-searchbox {
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  border: 1px solid lightgray;
-  padding: 10px;
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    border: 1px solid lightgray;
+    padding: 10px;
 
-  .header & {
-    padding: 5px;
-  }
-
-  > * {
-    margin: 0 5px;
-
-    .header &:last-child {
-      order: -1;
-    }
-  }
-
-  .input-text {
-    border: 0;
-    flex: 1 1 auto;
-    background: transparent;
-
-    &:focus {
-      box-shadow: none;
-    }
-  }
-
-  button {
-    .lib-button-icon(@_icon-font-content: @icon-search);
-    padding: 0;
-    border: 0;
-    background: transparent;
-    box-shadow: none;
-    opacity: .5;
-
-    &::before {
-      line-height: 1em;
+    .header & {
+        padding: 5px;
     }
 
-    span {
-      .lib-visually-hidden();
+    > * {
+        margin: 0 5px;
+
+        .header &:last-child {
+            order: -1;
+        }
     }
-  }
+
+    .input-text {
+        border: 0;
+        flex: 1 1 auto;
+        background: transparent;
+
+        &:focus {
+            box-shadow: none;
+        }
+    }
+
+    button {
+        .lib-button-icon(@_icon-font-content: @icon-search);
+        padding: 0;
+        border: 0;
+        background: transparent;
+        box-shadow: none;
+        opacity: .5;
+
+        &::before {
+            line-height: 1em;
+        }
+
+        span {
+            .lib-visually-hidden();
+        }
+    }
 }
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
-  .header .search-wrapper {
-    margin-top: 0;
-    margin-left: 160px;
-  }
+    .header .search-wrapper {
+        margin-top: 0;
+        margin-left: 160px;
+    }
 }
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__s) {
-  .ff-searchbox > * {
-    order: unset !important;
-  }
+    .ff-searchbox > * {
+        order: unset !important;
+    }
 }


### PR DESCRIPTION
- Description: 
  - add PHP 7.4 syntax support
  - drop PHP 7.3 compatibility
  - use magento/coding-standards latest version for static analysis 
  - fix many static analysis warnings & potential errors
- Tested with Magento editions/versions: 
2.4.0
- Tested with PHP versions: 
7.4

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
