### PR TITLE
FFWEB-2455: Check configurable has variants RELEASE/v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [Unreleased]
+
+### Fix
+ - Export
+  - fix `Model\Export\Catalog\ProductType\ConfigurableDataProvider::getChildren` throws an SQL syntax error if configurable product has no variants assigned   
+
 ## [v4.0.0-rc.1] - 2022.03.10
 ### BREAKING
  - drop PHP 7.3 support

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -8,7 +8,6 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableProductType;
-use Magento\Framework\Api\Filter;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Omikron\Factfinder\Api\Export\ExportEntityInterface;
 use Omikron\Factfinder\Api\Filter\FilterInterface;
@@ -93,8 +92,13 @@ class ConfigurableDataProvider extends SimpleDataProvider
      */
     private function getChildren(Product $product): array
     {
+        $childrenIds = $this->productType->getChildrenIds($product->getId());
+        //if $childrenIds is empty the entity_id filter will thrown an SQL syntax error
+        if (empty($childrenIds)) {
+            return [];
+        }
         return $this->productRepository
-            ->getList($this->builder->addFilter('entity_id', $this->productType->getChildrenIds($product->getId()), 'in')
+            ->getList($this->builder->addFilter('entity_id', $childrenIds, 'in')
             ->create())
             ->getItems();
     }

--- a/src/Test/TestHelper.php
+++ b/src/Test/TestHelper.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Test;
+
+use ReflectionClass;
+
+class TestHelper
+{
+    public static function invokeMethod(&$object, $methodName, array $parameters = [])
+    {
+        $reflection = new ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+        return $method->invokeArgs($object, $parameters);
+    }
+}

--- a/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
@@ -11,6 +11,7 @@ use Magento\Framework\Api\SearchCriteriaBuilder;
 use Omikron\Factfinder\Api\Filter\FilterInterface;
 use Omikron\Factfinder\Model\Export\Catalog\Entity\ProductVariationFactory;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
+use Omikron\Factfinder\Test\TestHelper;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurableDataProviderTest extends TestCase
@@ -23,7 +24,7 @@ class ConfigurableDataProviderTest extends TestCase
      */
     public function test_will_return_string_on_string_value()
     {
-        $valueOrEmptyStrMethod = $this->invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', ['test']);
+        $valueOrEmptyStrMethod = TestHelper::invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', ['test']);
         $this->assertEquals('test', $valueOrEmptyStrMethod);
     }
 
@@ -32,7 +33,7 @@ class ConfigurableDataProviderTest extends TestCase
      */
     public function test_will_return_empty_string_on_null_value()
     {
-        $valueOrEmptyStrMethod = $this->invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', [null]);
+        $valueOrEmptyStrMethod = TestHelper::invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', [null]);
         $this->assertEquals('', $valueOrEmptyStrMethod);
     }
 
@@ -41,7 +42,7 @@ class ConfigurableDataProviderTest extends TestCase
      */
     public function test_will_return_empty_string_on_bool_value()
     {
-        $valueOrEmptyStrMethod = $this->invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', [false]);
+        $valueOrEmptyStrMethod = TestHelper::invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', [false]);
         $this->assertEquals('', $valueOrEmptyStrMethod);
     }
 
@@ -50,25 +51,20 @@ class ConfigurableDataProviderTest extends TestCase
      */
     public function test_will_return_empty_string_on_array_value()
     {
-        $valueOrEmptyStrMethod = $this->invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', [[]]);
+        $valueOrEmptyStrMethod = TestHelper::invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', [[]]);
         $this->assertEquals('', $valueOrEmptyStrMethod);
     }
 
+    /**
+     * @covers ConfigurableDataProvider::getChildren
+     */
     public function test_will_no_throw_error_if_there_is_no_chlidren_ids()
     {
         $this->productMock->method('getId')->willReturn('1');
         $this->configurableProductTypeMock->method('getChildrenIds')->with('1')
             ->willReturn([]);
-        $variants = $this->invokeMethod($this->configurableDataProvider, 'getChildren', [$this->productMock]);
+        $variants = TestHelper::invokeMethod($this->configurableDataProvider, 'getChildren', [$this->productMock]);
         $this->assertEquals([], $variants);
-    }
-
-    public function invokeMethod(&$object, $methodName, array $parameters = [])
-    {
-        $reflection = new \ReflectionClass(get_class($object));
-        $method = $reflection->getMethod($methodName);
-        $method->setAccessible(true);
-        return $method->invokeArgs($object, $parameters);
     }
 
     protected function setUp(): void

--- a/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\Model\Export\Catalog\ProductType;
 
-use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableProductType;
@@ -53,6 +52,15 @@ class ConfigurableDataProviderTest extends TestCase
     {
         $valueOrEmptyStrMethod = $this->invokeMethod($this->configurableDataProvider, 'valueOrEmptyStr', [[]]);
         $this->assertEquals('', $valueOrEmptyStrMethod);
+    }
+
+    public function test_will_no_throw_error_if_there_is_no_chlidren_ids()
+    {
+        $this->productMock->method('getId')->willReturn('1');
+        $this->configurableProductTypeMock->method('getChildrenIds')->with('1')
+            ->willReturn([]);
+        $variants = $this->invokeMethod($this->configurableDataProvider, 'getChildren', [$this->productMock]);
+        $this->assertEquals([], $variants);
     }
 
     public function invokeMethod(&$object, $methodName, array $parameters = [])


### PR DESCRIPTION
- Description: 
fix `Model\Export\Catalog\ProductType\ConfigurableDataProvider::getChildren` throws an SQL syntax error if configurable product has no variants assigned
- Tested with Magento editions/versions: 
2.4.2
- Tested with PHP versions
7.4
