### PR TITLE
FFWEB-2456: Rework StreamInterface injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,29 @@
 # Changelog
-## [Unreleased]
-
+## [v4.0.0-rc.2]
+### BREAKING
+    - `Omikron\Factfinder\Controller\Adminhtml\Export\Feed`
+        - change constructor argument `Omikron\Factfinder\Model\Stream\CsvFactory` to `Omikron\Factfinder\Api\StreamInterfaceFactory`
+     - `Omikron\Factfinder\Controller\Export\Product`
+        - change constructor argument `Omikron\Factfinder\Model\Stream\CsvFactory` to `Omikron\Factfinder\Api\StreamInterfaceFactory`
+    - `Omikron\Factfinder\Console\Command\Export`
+        - change constructor argument `Omikron\Factfinder\Model\Stream\CsvFactory` to `Omikron\Factfinder\Api\StreamInterfaceFactory`
+    - `Omikron\Factfinder\Cron\Feed`
+        - change constructor argument `Omikron\Factfinder\Model\Stream\CsvFactory` to `Omikron\Factfinder\Api\StreamInterfaceFactory`
+        
+### Add
+   - `Omikron\Factfinder\Controller\Adminhtml\Export\Feed`, `Omikron\Factfinder\Controller\Export\Product`, `Omikron\Factfinder\Console\Command\Export`, `Omikron\Factfinder\Cron\Feed`
+     - add possibility to pass custom implementation of `Omikron\Factfinder\Api\StreamInterface`
+   - `Omikron\Factfinder\Model\Stream\Csv`
+     - Throws an `RuntimeException` if feed file is empty or contains only headers
+         
 ### Fix
  - Export
-  - fix `Model\Export\Catalog\ProductType\ConfigurableDataProvider::getChildren` throws an SQL syntax error if configurable product has no variants assigned   
+   - fix `Model\Export\Catalog\ProductType\ConfigurableDataProvider::getChildren` throws an SQL syntax error if configurable product has no variants assigned   
 
 ## [v4.0.0-rc.1] - 2022.03.10
 ### BREAKING
  - drop PHP 7.3 support
- - add PHP7.4 syntaxt
+ - add PHP7.4 syntax
 
 ### Change
  - use Magento/Coding-Standards for code styles

--- a/src/Api/StreamInterface.php
+++ b/src/Api/StreamInterface.php
@@ -18,4 +18,9 @@ interface StreamInterface
      * @return string
      */
     public function getContent(): string;
+
+    /**
+     * This method allows to add logic that should be executed after the feed is generated
+     */
+    public function finalize(): void;
 }

--- a/src/Model/Export/Catalog/FieldProvider.php
+++ b/src/Model/Export/Catalog/FieldProvider.php
@@ -15,8 +15,8 @@ class FieldProvider implements FieldProviderInterface
     private GenericFieldFactory $fieldFactory;
     private array $productFieldProviders;
     private array $variantFieldProviders;
-    private array $cachedVariantFields;
-    private array $cachedFields;
+    private array $cachedVariantFields = [];
+    private array $cachedFields = [];
 
     public function __construct(
         ExportConfig $config,

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -77,7 +77,7 @@ class ConfigurableDataProvider extends SimpleDataProvider
     {
         $sanitize = fn(string $phrase): string => $this->filter->filterValue($this->valueOrEmptyStr($phrase));
 
-        return array_reduce($this->productType->getConfigurableOptions($product), function (array $res, array $option) {
+        return array_reduce($this->productType->getConfigurableOptions($product), function (array $res, array $option) use ($sanitize) {
             foreach ($option as ['sku' => $sku, 'super_attribute_label' => $label, 'option_title' => $value]) {
                 $res[$sku][] = "{$sanitize($label)}={$sanitize($value)}";
             }

--- a/src/Model/Export/Catalog/Products.php
+++ b/src/Model/Export/Catalog/Products.php
@@ -53,6 +53,7 @@ class Products implements \IteratorAggregate
     {
         return $this->searchCriteriaBuilder
             ->addFilter('status', Status::STATUS_ENABLED)
+            ->addFilter('entity_id', '1')
             ->addFilter('store_id', $this->storeManager->getStore()->getId())
             ->addFilter('visibility', Visibility::VISIBILITY_NOT_VISIBLE, 'neq')
             ->setPageSize($this->batchSize)

--- a/src/Model/Export/Feed.php
+++ b/src/Model/Export/Feed.php
@@ -37,6 +37,7 @@ class Feed
         $columns = $this->getColumns($this->fields);
         $stream->addEntity($columns);
         $this->exporter->exportEntities($stream, $this->dataProvider, $columns);
+        $stream->finalize();
     }
 
     private function getColumns(array $fields): array

--- a/src/Model/Ssr/Template/Engine.php
+++ b/src/Model/Ssr/Template/Engine.php
@@ -12,7 +12,7 @@ class Engine implements TemplateEngineInterface
 {
     private Mustache $engine;
 
-    public function __construct(Mustache_Engine $engine)
+    public function __construct(Mustache $engine)
     {
         $this->engine = $engine;
     }

--- a/src/Model/Stream/Stdout.php
+++ b/src/Model/Stream/Stdout.php
@@ -12,7 +12,7 @@ class Stdout implements StreamInterface
 {
     private DriverInterface $file;
 
-    public function __construct(DriverInterfac $file)
+    public function __construct(DriverInterface $file)
     {
         $this->file = $file;
     }
@@ -25,5 +25,15 @@ class Stdout implements StreamInterface
     public function getContent(): string
     {
         throw new BadMethodCallException('Not implemented');
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD)
+     */
+    public function finalize(): void
+    {
+        //after export we need to exit, output has been sent to STDOUT so it is not possible to upload it
+        //@phpcs:ignore Magento2.Security.LanguageConstruct.ExitUsage
+        exit();
     }
 }

--- a/src/Service/FeedFileService.php
+++ b/src/Service/FeedFileService.php
@@ -4,12 +4,20 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\Service;
 
-use Exception;
-use Magento\Framework\Exception\InvalidArgumentException;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
+use \InvalidArgumentException;
 
 class FeedFileService
 {
     private const FEED_FILENAME_PATTERN = 'export.%type%.%channel%.csv';
+
+    private FileSystem $fileSystem;
+
+    public function __construct(Filesystem $fileSystem)
+    {
+        $this->fileSystem = $fileSystem;
+    }
 
     /**
      * @param string $exportType
@@ -20,13 +28,19 @@ class FeedFileService
     public function getFeedExportFilename(string $exportType, string $channel): string
     {
         if (empty($exportType)) {
-            throw new InvalidArgumentException(__('Argument $exportType must not be empty'));
+            throw new InvalidArgumentException('Export type must not be empty');
         }
 
         if (empty($channel)) {
-            throw new InvalidArgumentException(__('Argument $channel must not be empty'));
+            throw new InvalidArgumentException('Channel must not be empty');
         }
 
         return str_replace(['%type%', '%channel%'], [$exportType, $channel], self::FEED_FILENAME_PATTERN);
+    }
+
+    public function getExportPath(string $fileName): string
+    {
+        return $this->fileSystem->getDirectoryWrite(DirectoryList::VAR_DIR)
+            ->getAbsolutePath('factfinder' . DIRECTORY_SEPARATOR . $fileName);
     }
 }

--- a/src/Test/Integration/Block/SSR/RecordListTest.php
+++ b/src/Test/Integration/Block/SSR/RecordListTest.php
@@ -19,14 +19,13 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class RecordListTest extends AbstractController
 {
-    /** @var MockObject|ClientInterface */
-    private $clientMock;
+    private ObjectManagerInterface $objectManager;
 
-    /** @var ObjectManagerInterface */
-    private $objectManager;
+    /** @var MockObject|ClientInterface */
+    private MockObject $clientMock;
 
     /** @var MockObject|Redirect */
-    private $redirectMock;
+    private MockObject $redirectMock;
 
     public function test_will_redirect_to_product_page_on_articleNumberSearch()
     {

--- a/src/Test/Integration/Controller/ProxyCallTest.php
+++ b/src/Test/Integration/Controller/ProxyCallTest.php
@@ -18,10 +18,10 @@ use Psr\Http\Message\StreamInterface;
 class ProxyCallTest extends AbstractController
 {
     /** @var MockObject|ClientBuilder */
-    private $clientBuilderMock;
+    private MockObject $clientBuilderMock;
 
     /** @var MockObject|ClientInterface */
-    private $clientMock;
+    private MockObject $clientMock;
 
     public function test_JSON_endpoints_are_accepted_by_the_proxy_controller()
     {

--- a/src/Test/Unit/Controller/Adminhtml/TestConnection/TestConnectionTest.php
+++ b/src/Test/Unit/Controller/Adminhtml/TestConnection/TestConnectionTest.php
@@ -22,14 +22,13 @@ use Psr\Http\Message\ResponseInterface;
  */
 class TestConnectionTest extends TestCase
 {
-    /** @var TestConnection */
-    private $controller;
+    private TestConnection $controller;
 
     /** @var MockObject|RequestInterface */
-    private $request;
+    private MockObject $request;
 
     /** @var MockObject|Builder */
-    private $builderMock;
+    private MockObject $builderMock;
 
     public function test_prevent_errors_without_post_data()
     {

--- a/src/Test/Unit/Controller/Adminhtml/TestConnection/TestFtpConnectionTest.php
+++ b/src/Test/Unit/Controller/Adminhtml/TestConnection/TestFtpConnectionTest.php
@@ -18,17 +18,16 @@ use PHPUnit\Framework\TestCase;
  */
 class TestFtpConnectionTest extends TestCase
 {
-    /** @var TestFtpConnection */
-    private $controller;
+    private TestFtpConnection $controller;
 
     /** @var MockObject|RequestInterface */
-    private $request;
+    private MockObject $request;
 
     /** @var MockObject|FtpUploader */
-    private $ftpUploader;
+    private MockObject $ftpUploader;
 
     /** @var MockObject|JsonResult */
-    private $jsonResult;
+    private MockObject $jsonResult;
 
     public function test_prevent_errors_without_post_data()
     {
@@ -71,10 +70,10 @@ class TestFtpConnectionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->request      = $this->createConfiguredMock(RequestInterface::class, ['getParams' =>[]]);
-        $this->ftpUploader  = $this->createMock(FtpUploader::class);
-        $this->jsonResult   = $this->createConfiguredMock(JsonResult::class, ['setData' => $this]);
-        $this->controller   = new TestFtpConnection(
+        $this->request     = $this->createConfiguredMock(RequestInterface::class, ['getParams' => []]);
+        $this->ftpUploader = $this->createMock(FtpUploader::class);
+        $this->jsonResult  = $this->createConfiguredMock(JsonResult::class, ['setData' => $this]);
+        $this->controller  = new TestFtpConnection(
             $this->createConfiguredMock(Context::class, ['getRequest' => $this->request]),
             $this->createConfiguredMock(JsonFactory::class, ['create' => $this->jsonResult]),
             $this->ftpUploader,

--- a/src/Test/Unit/Model/Api/PushImportTest.php
+++ b/src/Test/Unit/Model/Api/PushImportTest.php
@@ -19,23 +19,22 @@ use Psr\Log\LoggerInterface;
  */
 class PushImportTest extends TestCase
 {
+    private PushImport $pushImport;
+
     /** @var MockObject|ClientInterface */
-    private $factFinderClientMock;
+    private MockObject $factFinderClientMock;
 
     /** @var MockObject|CommunicationConfig */
-    private $communicationConfigMock;
+    private MockObject $communicationConfigMock;
 
     /** @var MockObject|ExportConfig */
-    private $exportConfigMock;
+    private MockObject $exportConfigMock;
 
     /** @var MockObject|ClientBuilder */
-    private $builderMock;
+    private MockObject $builderMock;
 
     /** @var MockObject|ClientInterface */
-    private $clientMock;
-
-    /** @var PushImport */
-    private $pushImport;
+    private MockObject $clientMock;
 
     public function test_should_throw_if_import_is_running()
     {

--- a/src/Test/Unit/Model/Config/Source/AttributeTest.php
+++ b/src/Test/Unit/Model/Config/Source/AttributeTest.php
@@ -15,11 +15,10 @@ use PHPUnit\Framework\TestCase;
  */
 class AttributeTest extends TestCase
 {
-    /** @var MockObject|AttributeCollectionFactory */
-    private $attributeCollectionFactory;
+    private Attribute $sourceModel;
 
-    /** @var Attribute */
-    private $sourceModel;
+    /** @var MockObject|AttributeCollectionFactory */
+    private MockObject $attributeCollectionFactory;
 
     public function test_items_are_sorted_correctly()
     {

--- a/src/Test/Unit/Model/Export/BasicAuthTest.php
+++ b/src/Test/Unit/Model/Export/BasicAuthTest.php
@@ -12,8 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class BasicAuthTest extends TestCase
 {
-    /** @var BasicAuth */
-    private $basicAuth;
+    private BasicAuth $basicAuth;
 
     public function test_it_authenticates_the_user_with_valid_credentials()
     {

--- a/src/Test/Unit/Model/Export/Catalog/AttributeValuesExtractorTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/AttributeValuesExtractorTest.php
@@ -15,11 +15,10 @@ use PHPUnit\Framework\TestCase;
  */
 class AttributeValuesExtractorTest extends TestCase
 {
-    /** @var NumberFormatter|MockObject  */
-    private $numberFormatter;
+    private AttributeValuesExtractor $attributeExtractor;
 
-    /** @var AttributeValuesExtractor  */
-    private $attributeExtractor;
+    /** @var NumberFormatter|MockObject  */
+    private MockObject $numberFormatter;
 
     public function test_it_returns_scalar_value()
     {

--- a/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 class ProductVariationTest extends TestCase
 {
     /** @var MockObject|AbstractModel */
-    private $variantMock;
+    private MockObject $variantMock;
 
     private $configurableProductData = [
         'ProductNumber' => 'sku-configurable',

--- a/src/Test/Unit/Model/Export/Catalog/ProductField/CategoryPathTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/ProductField/CategoryPathTest.php
@@ -18,14 +18,13 @@ use PHPUnit\Framework\TestCase;
  */
 class CategoryPathTest extends TestCase
 {
-    /** @var CategoryPath */
-    private $categoryPath;
+    private CategoryPath $categoryPath;
 
     /** @var MockObject|CategoryRepositoryInterface */
-    private $repositoryMock;
+    private MockObject $repositoryMock;
 
     /** @var MockObject|AbstractModel */
-    private $productMock;
+    private MockObject $productMock;
 
     public function test_path_will_be_encoded()
     {

--- a/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
@@ -12,12 +12,34 @@ use Omikron\Factfinder\Api\Filter\FilterInterface;
 use Omikron\Factfinder\Model\Export\Catalog\Entity\ProductVariationFactory;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 use Omikron\Factfinder\Test\TestHelper;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurableDataProviderTest extends TestCase
 {
     /** @var ConfigurableDataProvider */
     private $configurableDataProvider;
+
+    /** @var MockObject|ProductRepositoryInterface */
+    private MockObject $repositoryMock;
+
+    /** @var MockObject|NumberFormatter */
+    private MockObject $numberFormatMock;
+
+    /** @var MockObject|ConfigurableProductType| */
+    private MockObject $configurableProductTypeMock;
+
+    /** @var MockObject|FilterInterface */
+    private MockObject $filterMock;
+
+    /** @var MockObject|ProductVariationFactory| */
+    private MockObject $variantFactoryMock;
+
+    /** @var MockObject|SearchCriteriaBuilder */
+    private MockObject $builderMock;
+
+    /** @var MockObject|Product */
+    private MockObject $productMock;
 
     /**
      * @covers ConfigurableDataProvider::valueOrEmptyStr
@@ -69,14 +91,14 @@ class ConfigurableDataProviderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->repositoryMock = $this->createMock(ProductRepositoryInterface::class);
-        $this->numberFormatMock = $this->createMock(NumberFormatter::class);
+        $this->repositoryMock              = $this->createMock(ProductRepositoryInterface::class);
+        $this->numberFormatMock            = $this->createMock(NumberFormatter::class);
         $this->configurableProductTypeMock = $this->createMock(ConfigurableProductType::class);
-        $this->filterInterfaceMock = $this->createMock(FilterInterface::class);
-        $this->variantFactoryMock = $this->getMockBuilder(ProductVariationFactory::class)
+        $this->filterMock                  = $this->createMock(FilterInterface::class);
+        $this->variantFactoryMock          = $this->getMockBuilder(ProductVariationFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->builderMock = $this->createMock(SearchCriteriaBuilder::class);
+        $this->builderMock                 = $this->createMock(SearchCriteriaBuilder::class);
 
         $this->productMock = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
@@ -86,7 +108,7 @@ class ConfigurableDataProviderTest extends TestCase
             $this->productMock,
             $this->numberFormatMock,
             $this->configurableProductTypeMock,
-            $this->filterInterfaceMock,
+            $this->filterMock,
             $this->variantFactoryMock,
             $this->repositoryMock,
             $this->builderMock

--- a/src/Test/Unit/Model/FieldRolesTest.php
+++ b/src/Test/Unit/Model/FieldRolesTest.php
@@ -19,20 +19,20 @@ use PHPUnit\Framework\TestCase;
  */
 class FieldRolesTest extends TestCase
 {
-    /** @var MockObject|ScopeConfigInterface */
-    private $scopeConfigMock;
-
-    /** @var MockObject|ConfigResource */
-    private $configResourceMock;
-
     /** @var FieldRoles */
-    private $fieldRoles;
+    private FieldRoles $fieldRoles;
 
     /** @var JsonSerializer */
     private $serializer;
 
-    /** @var SimpleDataProvider */
-    private $dataProvider;
+    /** @var MockObject|ScopeConfigInterface */
+    private MockObject $scopeConfigMock;
+
+    /** @var MockObject|ConfigResource */
+    private MockObject $configResourceMock;
+
+    /** @var MockObject|SimpleDataProvider */
+    private MockObject $dataProviderMock;
 
     /** @var string */
     private $roles = '{"description":"Description","masterArticleNumber":"Master","price":"Price","productName":"Name","trackingProductNumber":"ProductNumber","brand":"Brand"}';
@@ -57,7 +57,7 @@ class FieldRolesTest extends TestCase
     {
         $productMock = $this->createConfiguredMock(ProductInterface::class, ['getSku' => 'sku-1']);
         $this->scopeConfigMock->method('getValue')->with('factfinder/general/tracking_product_number_field_role', Scope::SCOPE_STORES)->willReturn($this->roles);
-        $this->dataProvider->expects($this->once())->method('toArray')->willReturn([
+        $this->dataProviderMock->expects($this->once())->method('toArray')->willReturn([
             'ProductNumber' => 'sku-1',
             'Master'        => 'sku-1',
             'Name'          => 'product name',
@@ -80,13 +80,13 @@ class FieldRolesTest extends TestCase
         $this->serializer         = new JsonSerializer();
         $this->scopeConfigMock    = $this->createMock(ScopeConfigInterface::class);
         $this->configResourceMock = $this->createMock(ConfigResource::class);
-        $this->dataProvider       = $this->createMock(SimpleDataProvider::class);
+        $this->dataProviderMock   = $this->createMock(SimpleDataProvider::class);
 
         $dataProviderFactory = $this->getMockBuilder(SimpleDataProviderFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
-        $dataProviderFactory->method('create')->willReturn($this->dataProvider);
+        $dataProviderFactory->method('create')->willReturn($this->dataProviderMock);
 
         $this->fieldRoles = new FieldRoles(
             $this->serializer,

--- a/src/Test/Unit/Model/Filter/ExtendedTextFilterTest.php
+++ b/src/Test/Unit/Model/Filter/ExtendedTextFilterTest.php
@@ -12,8 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ExtendedTextFilterTest extends TestCase
 {
-    /** @var TextFilter */
-    private $filter;
+    private TextFilter $filter;
 
     public function test_it_is_a_filter()
     {

--- a/src/Test/Unit/Model/Filter/TextFilterTest.php
+++ b/src/Test/Unit/Model/Filter/TextFilterTest.php
@@ -12,8 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class TextFilterTest extends TestCase
 {
-    /** @var TextFilter */
-    private $filter;
+    private TextFilter $filter;
 
     public function test_it_is_a_filter()
     {

--- a/src/Test/Unit/Model/Formatter/NumberFormatterTest.php
+++ b/src/Test/Unit/Model/Formatter/NumberFormatterTest.php
@@ -11,8 +11,7 @@ use PHPUnit\Framework\TestCase;
  */
 class NumberFormatterTest extends TestCase
 {
-    /** @var NumberFormatter */
-    private $formatter;
+    private NumberFormatter $formatter;
 
     public function test_it_formats_the_number_with_right_precision()
     {

--- a/src/Test/Unit/Model/SessionDataTest.php
+++ b/src/Test/Unit/Model/SessionDataTest.php
@@ -16,17 +16,16 @@ use PHPUnit\Framework\TestCase;
  */
 class SessionDataTest extends TestCase
 {
-    /** @var SessionData */
-    private $sessionData;
+    private SessionData $sessionData;
 
     /** @var MockObject|CustomerSession */
-    private $sessionMock;
+    private MockObject $sessionMock;
 
     /** @var MockObject|ScopeConfigInterface */
-    private $scopeConfigMock;
+    private MockObject $scopeConfigMock;
 
-    /** @var RemoteAddress|ScopeConfigInterface */
-    private $remoteAddressMock;
+    /** @var MockObject|RemoteAddress */
+    private MockObject $remoteAddressMock;
 
     /**
      * @testdox User ID is fetched from the customer session

--- a/src/Test/Unit/Observer/CategoryViewTest.php
+++ b/src/Test/Unit/Observer/CategoryViewTest.php
@@ -18,14 +18,13 @@ use PHPUnit\Framework\TestCase;
  */
 class CategoryViewTest extends TestCase
 {
-    /** @var CategoryView */
-    private $testee;
+    private CategoryView $testee;
 
     /** @var MockObject|Registry */
-    private $registry;
+    private MockObject $registry;
 
     /** @var MockObject|FeatureConfig */
-    private $config;
+    private MockObject $config;
 
     public function test_only_activate_for_category_pages()
     {

--- a/src/Test/Unit/Observer/ExportAuthenticationTest.php
+++ b/src/Test/Unit/Observer/ExportAuthenticationTest.php
@@ -16,14 +16,13 @@ use PHPUnit\Framework\TestCase;
  */
 class ExportAuthenticationTest extends TestCase
 {
-    /** @var ExportAuthentication */
-    private $observer;
+    private ExportAuthentication $observer;
 
     /** @var MockObject|ActionFlag */
-    private $flagMock;
+    private MockObject $flagMock;
 
     /** @var MockObject|Authentication */
-    private $authMock;
+    private MockObject $authMock;
 
     public function test_it_checks_user_authentication_before_dispatch()
     {

--- a/src/Test/Unit/Observer/RedirectSearchTest.php
+++ b/src/Test/Unit/Observer/RedirectSearchTest.php
@@ -18,17 +18,16 @@ use PHPUnit\Framework\TestCase;
  */
 class RedirectSearchTest extends TestCase
 {
-    /** @var RedirectSearch */
-    private $observer;
+    private RedirectSearch $observer;
 
     /** @var MockObject|CommunicationConfig */
-    private $config;
+    private MockObject $config;
 
     /** @var MockObject|RedirectInterface */
-    private $redirect;
+    private MockObject $redirect;
 
     /** @var MockObject|ResponseInterface */
-    private $response;
+    private MockObject $response;
 
     public function test_it_is_an_observer()
     {

--- a/src/Test/Unit/Observer/SsrTest.php
+++ b/src/Test/Unit/Observer/SsrTest.php
@@ -9,18 +9,17 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\View\Layout\ProcessorInterface;
 use Magento\Framework\View\LayoutInterface;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @covers Ssr
  */
 class SsrTest extends TestCase
 {
-    /** @var Ssr */
-    private $observer;
+    private Ssr $observer;
 
     /** @var MockObject|ScopeConfigInterface */
-    private $scopeConfig;
+    private MockObject $scopeConfigMock;
 
     public function test_add_handle_to_layout()
     {
@@ -51,13 +50,13 @@ class SsrTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
-        $this->observer    = new Ssr($this->scopeConfig, ['handle_with_ssr']);
+        $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
+        $this->observer        = new Ssr($this->scopeConfigMock, ['handle_with_ssr']);
     }
 
     private function featureActive(bool $active): void
     {
-        $this->scopeConfig->method('isSetFlag')
+        $this->scopeConfigMock->method('isSetFlag')
             ->with('factfinder/general/use_ssr', $this->stringStartsWith('store'), $this->anything())
             ->willReturn($active);
     }

--- a/src/Test/Unit/Plugin/AssetMinificationPluginTest.php
+++ b/src/Test/Unit/Plugin/AssetMinificationPluginTest.php
@@ -11,8 +11,7 @@ use PHPUnit\Framework\TestCase;
  */
 class AssetMinificationPluginTest extends TestCase
 {
-    /** @var AssetMinificationPlugin */
-    private $plugin;
+    private AssetMinificationPlugin $plugin;
 
     public function test_js_library_is_added_to_the_exclusion()
     {

--- a/src/Test/Unit/Plugin/LogExceptionsTest.php
+++ b/src/Test/Unit/Plugin/LogExceptionsTest.php
@@ -15,14 +15,13 @@ use Psr\Log\LoggerInterface;
  */
 class LogExceptionsTest extends TestCase
 {
-    /** @var LogExceptions */
-    private $plugin;
+    private LogExceptions $plugin;
 
     /** @var MockObject|LoggerInterface */
-    private $logger;
+    private MockObject $logger;
 
     /** @var MockObject|ScopeConfigInterface */
-    private $scopeConfig;
+    private MockObject $scopeConfig;
 
     public function test_proceed_if_no_exception_is_raised()
     {

--- a/src/Test/Unit/Service/FeedFileServiceTest.php
+++ b/src/Test/Unit/Service/FeedFileServiceTest.php
@@ -1,18 +1,17 @@
 <?php
 
-
 namespace Omikron\Factfinder\Service;
 
-use Magento\Framework\Exception\InvalidArgumentException;
+use Magento\Framework\Filesystem;
 use PHPUnit\Framework\TestCase;
+use \InvalidArgumentException;
 
 /**
  * @covers FeedFileService
  */
 class FeedFileServiceTest extends TestCase
 {
-    /** @var FeedFileService */
-    private $feedFileService;
+    private FeedFileService $feedFileService;
 
     /**
      * @dataProvider validDataProvider
@@ -26,15 +25,15 @@ class FeedFileServiceTest extends TestCase
 
     public function test_will_throw_exception_on_empty_export_type()
     {
-        $this->expectException('Magento\Framework\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('Argument $exportType must not be empty');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Export type must not be empty');
         $this->assertSame('export.test_type.test_channel.csv', $this->feedFileService->getFeedExportFilename('', 'test_channel'));
     }
 
     public function test_will_throw_exception_on_empty_export_channel()
     {
-        $this->expectException('Magento\Framework\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('Argument $channel must not be empty');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Channel must not be empty');
         $this->assertSame('export.test_type.test_channel.csv', $this->feedFileService->getFeedExportFilename('test_type', ''));
     }
 
@@ -49,6 +48,6 @@ class FeedFileServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->feedFileService = new FeedFileService();
+        $this->feedFileService = new FeedFileService($this->createMock(Filesystem::class));
     }
 }

--- a/src/Test/Unit/ViewModel/CartTest.php
+++ b/src/Test/Unit/ViewModel/CartTest.php
@@ -14,8 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CartTest extends TestCase
 {
-    /** @var Cart */
-    private $cart;
+    private Cart $cart;
 
     public function test_get_item_ids()
     {

--- a/src/Test/Unit/ViewModel/CategoryPathTest.php
+++ b/src/Test/Unit/ViewModel/CategoryPathTest.php
@@ -15,17 +15,14 @@ use PHPUnit\Framework\TestCase;
  */
 class CategoryPathTest extends TestCase
 {
-    /** @var CategoryPath */
-    private $categoryPath;
+    private CategoryPath $categoryPath;
+    private Registry $registry;
 
     /** @var MockObject|Category */
-    private $currentCategory;
+    private MockObject $currentCategory;
 
     /** @var MockObject|CommunicationConfig */
-    private $communicationConfig;
-
-    /** @var MockObject|Registry */
-    private $registry;
+    private MockObject $communicationConfig;
 
     public function test_category_path_for_ng_version()
     {

--- a/src/Test/Unit/ViewModel/CommunicationTest.php
+++ b/src/Test/Unit/ViewModel/CommunicationTest.php
@@ -16,16 +16,16 @@ use PHPUnit\Framework\TestCase;
 class CommunicationTest extends TestCase
 {
     /** @var MockObject|FieldRoles */
-    private $fieldRolesMock;
+    private MockObject $fieldRolesMock;
 
     /** @var MockObject|SerializerInterface */
-    private $serializerMock;
+    private MockObject $serializerMock;
 
     /** @var MockObject|CommunicationParametersProvider */
-    private $parametersProviderMock;
+    private MockObject $parametersProviderMock;
 
     /** @var Communication */
-    private $communication;
+    private Communication $communication;
 
     public function test_get_parameters_filter_null_values()
     {

--- a/src/Test/Unit/ViewModel/OrderTest.php
+++ b/src/Test/Unit/ViewModel/OrderTest.php
@@ -16,10 +16,9 @@ use PHPUnit\Framework\TestCase;
  */
 class OrderTest extends TestCase
 {
-    /** @var Order */
-    private $order;
+    private Order $order;
 
-    private $orderItemsMock;
+    private array $orderItemsMock;
 
     public function test_returns_order_items()
     {

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -2,6 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Omikron\Factfinder\Api\ExporterInterface" type="Omikron\Factfinder\Model\Exporter" />
     <preference for="Omikron\Factfinder\Api\Filter\FilterInterface" type="Omikron\Factfinder\Model\Filter\TextFilter" />
+    <preference for="Omikron\Factfinder\Api\StreamInterface" type="Omikron\Factfinder\Model\Stream\Csv" />
 
     <type name="Magento\Framework\View\TemplateEngineFactory">
         <arguments>


### PR DESCRIPTION
- Solves issue: 
Right now module offers a `StreamInterface` and even two implementations of it `Stdout` and `Csv`. The problem is in all export paths we don't pass `StreamInterfaceFactory` but `CsvFactory` to constructor which makes passing custom implementation impossible without overriding big parts of the code

- Tested with Magento editions/versions: 
2.4.2

- Tested with PHP versions: 
7.4

