### PR TITLE
FFWEB-2496: Fix Add to cart button shows on configurable products RELEASE/3.x 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Fix
+ - Category Page & Search Result Page
+  - fix "Add to cart" button randomly shows on configurable products tiles 
+  
 ## [v3.4.0] - 2022.04.05
 ### Add
  - Search Result Page, Category Page

--- a/src/view/frontend/templates/ff/record-list.phtml
+++ b/src/view/frontend/templates/ff/record-list.phtml
@@ -46,6 +46,20 @@ $viewModel = $block->getViewModel();
     </ff-record-list>
 </div>
 <script>
+    document.addEventListener('ffReady', function (event) {
+        event.resultDispatcher.addCallback(`records`, function (records) {
+            if (event.factfinder.communication.Util.isNg()) {
+                records.forEach(function (rec) {
+                    rec.record.HasVariants =
+                        rec.record.HasVariants ||
+                        rec.variantValues.some(function (variant) {
+                            return parseInt(variant.HasVariants) === 1;
+                        });
+                });
+            }
+        });
+    });
+
     require(['ffCallbacks'], function (ffCallbacks) {
         document.addEventListener('ffReady', function (ff) {
             factfinder.communication.EventAggregator.addBeforeDispatchingCallback(function (event) {


### PR DESCRIPTION
- Description: 
Determine `HasVariants` by inspecting values in all `variantValues`. `masterValues` does not contain data from "master product" row 
- Tested with Magento editions/versions: 
2.4.2
- Tested with PHP versions: 
7.4
