### PR TITLE
FFWEB-2521 fix array to string conversion on recommendation.phtml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Fix
+ - Cart Page
+  - fix array to string conversion error in recommendation template 
+ 
 ## [v2.6.2] - 2022.05.30
 ### Fix
  - Configuration

--- a/src/ViewModel/ProductBasedComponent.php
+++ b/src/ViewModel/ProductBasedComponent.php
@@ -60,7 +60,7 @@ class ProductBasedComponent implements ArgumentInterface
         return $this->scopeConfig->isSetFlag(self::PATH_SHOW_ADD_TO_CART_BUTTON);
     }
 
-    public function getMaxResult(string $component): int
+    public function getMaxResult(string $component = 'recommendation'): int
     {
         $storedValue      = (int) $this->scopeConfig->getValue(self::PATH_MAX_RESULT . $component);
         $defaultMaxResult = 4;

--- a/src/view/frontend/layout/checkout_cart_index.xml
+++ b/src/view/frontend/layout/checkout_cart_index.xml
@@ -15,6 +15,7 @@
             <block class="Magento\Framework\View\Element\Template" name="factfinder.recommendation.cart" ifconfig="factfinder/components/ff_recommendation" template="Omikron_Factfinder::ff/recommendation.phtml">
                 <arguments>
                     <argument name="record_id" xsi:type="helper" helper="Omikron\Factfinder\ViewModel\Cart::getItemIds" />
+                    <argument name="max_results" xsi:type="helper" helper="Omikron\Factfinder\ViewModel\ProductBasedComponent::getMaxResult" />
                 </arguments>
             </block>
         </referenceContainer>

--- a/src/view/frontend/templates/ff/recommendation.phtml
+++ b/src/view/frontend/templates/ff/recommendation.phtml
@@ -3,7 +3,9 @@
 /** @var ?Omikron\Factfinder\ViewModel\ProductBasedComponent $viewModel */
 $viewModel = $block->getViewModel();
 ?>
-<ff-recommendation max-results="<?=$block->escapeHtmlAttr($viewModel ? $viewModel->getMaxResult('recommendation') : $block->getData('record_id')) ?>" record-id="<?= $block->escapeHtmlAttr($viewModel ? $viewModel->getProduct()->getSku() : implode(',', (array) $block->getData('record_id'))) ?>" unresolved>
+<ff-recommendation max-results="<?=$block->escapeHtmlAttr($viewModel ? $viewModel->getMaxResult('recommendation') : $block->getData('max_results')) ?>"
+                   record-id="<?= $block->escapeHtmlAttr($viewModel ? $viewModel->getProduct()->getSku() : implode(',', (array) $block->getData('record_id'))) ?>"
+                   unresolved>
     <div class="block upsell">
         <div class="block-title title">
             <strong role="heading" aria-level="2"><?= $block->escapeHtml(__('Recommendations')) ?></strong>


### PR DESCRIPTION
- Description: 
 fix array to string conversion in recommendation template
- Tested with Magento editions/versions: 
2.4.4
- Tested with PHP versions: 
8.1
