### PR TITLE
FFWEB-2534: added phrase "Your search for" inside ff-template with un…

### DIFF
--- a/src/view/frontend/templates/ff/breadcrumb.phtml
+++ b/src/view/frontend/templates/ff/breadcrumb.phtml
@@ -1,8 +1,10 @@
 <?php /** @var Magento\Framework\View\Element\Template $block */ ?>
 <div class="ff-breadcrumb-trail">
-    <ff-breadcrumb-trail unresolved></ff-breadcrumb-trail>
     <ff-template scope="result" unresolved>
         <span class="description"><?= $block->escapeHtml(__('Your search for:')) ?></span>
+    </ff-template>
+    <ff-breadcrumb-trail unresolved></ff-breadcrumb-trail>
+    <ff-template scope="result" unresolved>
         <?= $block->escapeHtml(__('produced <span>{{resultCount}}</span> results'), ['span']) ?>
     </ff-template>
 </div>


### PR DESCRIPTION
- Solves issue: 
  - FFWEB-2534
- Description: 
  - move phrase "Your search for" inside ff-template with unresolved property
- Tested with Magento editions/versions: 
  - 2.4.4
- Tested with PHP versions: 
  - 7.4
