### PR TITLE
FFWEB-2580 - add user-id to all kind of tracking if user is logged in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Add
+ - Tracking
+   - add `user-id` to all kind of tracking if user is logged in
+
 ## [v3.6.0] - 2022.08.25
 ### BREAKING
  - `Omikron\Factfinder\Model\Export\Catalog\Products`

--- a/src/Plugin/AnonymizeUserId.php
+++ b/src/Plugin/AnonymizeUserId.php
@@ -29,7 +29,7 @@ class AnonymizeUserId
      */
     public function afterGetUserId(SessionData $_, string $userId)
     {
-        return $this->isAnonymizationEnabled() ? md5($userId) : $userId; // phpcs:ignore
+        return $this->isAnonymizationEnabled() && $userId !== '' ? md5($userId) : $userId; // phpcs:ignore
     }
 
     private function isAnonymizationEnabled(): bool

--- a/src/etc/frontend/sections.xml
+++ b/src/etc/frontend/sections.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Customer:etc/sections.xsd">
-    <action name="checkout/cart/add">
-        <section name="ffcommunication" />
-    </action>
-    <action name="customer/ajax/login">
-        <section name="ffcommunication" />
-    </action>
-    <action name="wishlist/index/add">
+    <action name="*">
         <section name="ffcommunication" />
     </action>
 </config>

--- a/src/view/frontend/web/js/catalog-add-to-cart-mixin.js
+++ b/src/view/frontend/web/js/catalog-add-to-cart-mixin.js
@@ -28,7 +28,8 @@ define([
                         id: cartItem.product_sku,
                         price: cartItem.product_price_value,
                         masterId: eventData.sku || cartItem.product_sku,
-                        count: parseInt(qtyInput.value)
+                        count: parseInt(qtyInput.value),
+                        userId: factfinder.communication.globalCommunicationParameter.userId
                     });
                 }
 

--- a/src/view/frontend/web/js/view/ffcommunication.js
+++ b/src/view/frontend/web/js/view/ffcommunication.js
@@ -22,6 +22,3 @@ define(['Magento_Customer/js/customer-data', 'factfinder','underscore',], functi
         sessionData.valueHasMutated();
     };
 });
-
-
-

--- a/src/view/frontend/web/js/view/ffcommunication.js
+++ b/src/view/frontend/web/js/view/ffcommunication.js
@@ -11,13 +11,17 @@ define(['Magento_Customer/js/customer-data', 'factfinder','underscore',], functi
                 if (uidKey) factfinder.common.localStorage.setItem(uidKey, null);
             }
 
-            const storedUserId = factfinder.common.localStorage.getItem(factfinder.common.localStorage.getItem('ff_sid') + ':' + data.uid);
-            if (data.uid && data.uid !== element.userId && (!storedUserId || storedUserId !== data.uid.toString())) {
-                element.userId = data.uid;
+            if (data.uid) {
+                element.setAttribute('user-id', data.uid);
             }
 
-            if (data.internal) element.addParams = (element.addParams ? element.addParams + ',' : '') + 'log=internal';
+            if (data.internal) {
+                element.setAttribute('add-params', (element.addParams ? element.addParams + ',' : '') + 'log=internal');
+            }
         });
         sessionData.valueHasMutated();
     };
 });
+
+
+


### PR DESCRIPTION
- Solves issue: 
  - FFWEB-2580
- Description: 
  - Add `user-id` to all kind of tracking if user is logged in
- Tested with Magento editions/versions: 
  - 2.4.4
- Tested with PHP versions: 
  - 8.1