### PR TITLE
Fix checkout-tracking

### DIFF
--- a/src/view/frontend/templates/ff/checkout-tracking.phtml
+++ b/src/view/frontend/templates/ff/checkout-tracking.phtml
@@ -1,12 +1,12 @@
 <?php
 /** @var Magento\Framework\View\Element\Template $block */
-/** @var Magento\Quote\Model\Quote\Item $item */
+/** @var Magento\Sales\Model\Order\Item $item */
 ?>
 <ff-checkout-tracking>
     <?php foreach ($block->getData('items') as $item): ?>
         <ff-checkout-tracking-item
             record-id="<?= /* @noEscape */ $item->getSku() ?>"
-            count="<?= /* @noEscape */ $item->getQty() ?>"
+            count="<?= /* @noEscape */ $item->getQtyOrdered() ?>"
             channel="<?= /* @noEscape */ $block->getData('channel') ?>">
         </ff-checkout-tracking-item>
     <?php endforeach; ?>


### PR DESCRIPTION
Currently the checkout tracking is not receiving a count for the ordered items. It will only output `count=""`.

This is because `$item->getQty()` is actually `null` - as `$item` is not of type `Magento\Quote\Model\Quote\Item` but rather `Magento\Sales\Model\Order\Item` as the layout XML passes the following to the block:

https://github.com/FACT-Finder-Web-Components/magento2-module/blob/7e7850784ffc16119db1dadc14df63755902d0a0/src/view/frontend/layout/checkout_onepage_success.xml#L7

`Magento\Sales\Model\Order\Item` does not have a `getQty()` method. With order items you need to access the ordered quantity instead for example.