### PR TITLE
FFWEB-2626: Fixed problem with not working filters when category page fired in new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Fixes problem with not working filters when category page fired in new tab
+
 ## [v3.7.1] - 2022.10.17
 ### Change
 - Upgrade Web Components version to v4.2.1

--- a/src/view/frontend/templates/ff/ssr/record-list.phtml
+++ b/src/view/frontend/templates/ff/ssr/record-list.phtml
@@ -3,11 +3,9 @@
 ?>
 <?= $block->getChildHtml() ?>
 <script>
-    require(['factfinder'], function (ff) {
-        document.addEventListener('WebComponentsReady', function (event) {
-            const searchResult = {FF_SEARCH_RESULT};
-            ff.communication.EventAggregator.currentSearchResult = searchResult;
-            ff.communication.ResultDispatcher.dispatchRaw(searchResult);
-        });
+    document.addEventListener('ffCommunicationReady', function ({factfinder}) {
+        const searchResult = {FF_SEARCH_RESULT};
+        factfinder.communication.EventAggregator.currentSearchResult = searchResult;
+        factfinder.communication.ResultDispatcher.dispatchRaw(searchResult);
     });
 </script>


### PR DESCRIPTION
- Solves issue: 
Fixes problem with not working filters when category page fired in new tab
- Tested with Magento editions/versions: 
2.4.4
- Tested with PHP versions: 
7.4
