### PR TITLE
FFWEB-2628: api version switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Add
+- Add option to switch between Api Version
+
 ## [v3.7.2] - 2022.11.29
 ### Fix
 - Category page

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": "~7.4.0||~8.1.0",
-    "omikron/factfinder-communication-sdk": "^0.9.5",
+    "omikron/factfinder-communication-sdk": "0.9.5",
     "magento/framework": "~103.0.4",
     "magento/module-catalog": "~104.0.4",
     "magento/module-configurable-product": "~100.4.4",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": "~7.4.0||~8.1.0",
-    "omikron/factfinder-communication-sdk": "^0.9",
+    "omikron/factfinder-communication-sdk": "^0.9.5",
     "magento/framework": "~103.0.4",
     "magento/module-catalog": "~104.0.4",
     "magento/module-configurable-product": "~100.4.4",

--- a/src/Controller/Adminhtml/FieldRoles/Update.php
+++ b/src/Controller/Adminhtml/FieldRoles/Update.php
@@ -65,7 +65,12 @@ class Update extends Action
                 ->withCredentials($this->credentialsFactory->create())
                 ->withServerUrl($this->communicationConfig->getAddress());
 
-            $searchAdapter = (new AdapterFactory($client, $this->communicationConfig->getVersion()))->getSearchAdapter();
+            $adapterFactory = new AdapterFactory(
+                $client,
+                $this->communicationConfig->getVersion(),
+                $this->communicationConfig->getApiVersion()
+            );
+            $searchAdapter = $adapterFactory->getSearchAdapter();
             $response      = $searchAdapter->search($this->communicationConfig->getChannel($storeId), 'Search.ff');
             $searchResult  = $this->communicationConfig->getVersion() === Version::NG ? $response : $response['searchResult'];
             $result->setData(['message' => __('Search result does not contain field roles')]);

--- a/src/Controller/Adminhtml/TestConnection/TestConnection.php
+++ b/src/Controller/Adminhtml/TestConnection/TestConnection.php
@@ -53,7 +53,12 @@ class TestConnection extends Action
                 ->withCredentials($this->getCredentials($this->getRequest()->getParams()))
                 ->withServerUrl($request->getParam('address'));
 
-            $searchAdapter = (new AdapterFactory($clientBuilder, $request->getParam('version')))->getSearchAdapter();
+            $adapterFactory = new AdapterFactory(
+                $clientBuilder,
+                $request->getParam('version'),
+                $request->getParam('ff_api_version')
+            );
+            $searchAdapter = $adapterFactory->getSearchAdapter();
             $searchAdapter->search($request->getParam('channel'), '*');
 
             $message = new Phrase('Connection successfully established.');

--- a/src/Model/Api/PushImport.php
+++ b/src/Model/Api/PushImport.php
@@ -52,7 +52,12 @@ class PushImport
             ->withServerUrl($this->communicationConfig->getAddress())
             ->withCredentials($this->credentialsFactory->create());
 
-        $importAdapter = (new AdapterFactory($clientBuilder, $this->communicationConfig->getVersion()))->getImportAdapter();
+        $adapterFactory = new AdapterFactory(
+            $clientBuilder,
+            $this->communicationConfig->getVersion(),
+            $this->communicationConfig->getApiVersion()
+        );
+        $importAdapter = $adapterFactory->getImportAdapter();
         $channel       = $this->communicationConfig->getChannel($storeId);
         $dataTypes     = $this->exportConfig->getPushImportDataTypes($storeId);
 

--- a/src/Model/Config/CommunicationConfig.php
+++ b/src/Model/Config/CommunicationConfig.php
@@ -59,11 +59,6 @@ class CommunicationConfig implements ParametersSourceInterface
         return (string) $this->scopeConfig->getValue(self::PATH_VERSION, ScopeInterface::SCOPE_STORES);
     }
 
-    public function getApiVersion(): string
-    {
-        return (string) $this->scopeConfig->getValue(self::PATH_API_VERSION, ScopeInterface::SCOPE_STORES);
-    }
-
     public function isLoggingEnabled(): bool
     {
         return $this->scopeConfig->isSetFlag(self::PATH_IS_LOGGING_ENABLED, ScopeInterface::SCOPE_STORES);
@@ -75,7 +70,12 @@ class CommunicationConfig implements ParametersSourceInterface
                 'url'     => $this->getServerUrl(),
                 'version' => $this->getVersion(),
                 'channel' => $this->getChannel(),
-            ] + ($this->getVersion() === Version::NG ? ['api' => $this->getApi()] : []);
+            ] + ($this->getVersion() === Version::NG ? ['api' => $this->getApiVersion()] : []);
+    }
+
+    public function getApiVersion(): string
+    {
+        return (string) $this->scopeConfig->getValue(self::PATH_API_VERSION, ScopeInterface::SCOPE_STORES) ?? 'v4';
     }
 
     private function getServerUrl(): string
@@ -85,10 +85,5 @@ class CommunicationConfig implements ParametersSourceInterface
         }
 
         return $this->getAddress();
-    }
-
-    private function getApi(): string
-    {
-        return 'v4';
     }
 }

--- a/src/Model/Config/CommunicationConfig.php
+++ b/src/Model/Config/CommunicationConfig.php
@@ -16,6 +16,7 @@ class CommunicationConfig implements ParametersSourceInterface
     private const PATH_CHANNEL              = 'factfinder/general/channel';
     private const PATH_ADDRESS              = 'factfinder/general/address';
     private const PATH_VERSION              = 'factfinder/general/version';
+    private const PATH_API_VERSION          = 'factfinder/general/ff_api_version';
     private const PATH_IS_ENABLED           = 'factfinder/general/is_enabled';
     private const PATH_USE_PROXY            = 'factfinder/general/ff_enrichment';
     private const PATH_DATA_TRANSFER_IMPORT = 'factfinder/data_transfer/ff_push_import_enabled';
@@ -56,6 +57,11 @@ class CommunicationConfig implements ParametersSourceInterface
     public function getVersion(): string
     {
         return (string) $this->scopeConfig->getValue(self::PATH_VERSION, ScopeInterface::SCOPE_STORES);
+    }
+
+    public function getApiVersion(): string
+    {
+        return (string) $this->scopeConfig->getValue(self::PATH_API_VERSION, ScopeInterface::SCOPE_STORES);
     }
 
     public function isLoggingEnabled(): bool

--- a/src/Model/Ssr/SearchAdapter.php
+++ b/src/Model/Ssr/SearchAdapter.php
@@ -64,10 +64,11 @@ class SearchAdapter
     private function createEndpoint(string $paramString, bool $navigationRequest)
     {
         $channel  = $this->communicationConfig->getChannel();
+        $apiVersion  = $this->communicationConfig->getApiVersion();
         $endpoint = $navigationRequest ? 'navigation' : 'search';
 
         return $this->communicationConfig->getVersion() == Version::NG
-            ? "rest/v4/{$endpoint}/{$channel}?{$paramString}"
+            ? "rest/{$apiVersion}/{$endpoint}/{$channel}?{$paramString}"
             : "Search.ff?channel={$channel}&{$paramString}&format=json";
     }
 }

--- a/src/Model/Ssr/SearchAdapter.php
+++ b/src/Model/Ssr/SearchAdapter.php
@@ -6,7 +6,6 @@ namespace Omikron\Factfinder\Model\Ssr;
 
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Client\ClientException;
-use Omikron\FactFinder\Communication\Resource\AdapterFactory;
 use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Model\Api\CredentialsFactory;
 use Omikron\Factfinder\Model\Config\CommunicationConfig;

--- a/src/Test/Unit/Controller/Adminhtml/TestConnection/TestConnectionTest.php
+++ b/src/Test/Unit/Controller/Adminhtml/TestConnection/TestConnectionTest.php
@@ -38,6 +38,7 @@ class TestConnectionTest extends TestCase
         $this->request->method('getParam')->willReturnMap([
             ['address', null, 'https://fake-factfinder.de/fact-finder'],
             ['version', null, 'ng'],
+            ['ff_api_version', null, 'v5'],
             ['channel', null, 'foo'],
         ]);
 

--- a/src/Test/Unit/Model/Api/PushImportTest.php
+++ b/src/Test/Unit/Model/Api/PushImportTest.php
@@ -42,7 +42,7 @@ class PushImportTest extends TestCase
     public function test_should_throw_if_import_is_running()
     {
         $this->exportConfigMock->method('getPushImportDataTypes')->with($this->anything())->willReturn(['search','suggest']);
-        $this->clientMock->method('request')->with('GET', 'rest/v4/import/running', $this->anything())
+        $this->clientMock->method('request')->with('GET', 'rest/v5/import/running', $this->anything())
             ->willReturn($this->importRunningResponse());
         $this->expectExceptionMessage("Can't start a new import process. Another one is still going");
         $this->pushImport->execute(1);
@@ -79,6 +79,7 @@ class PushImportTest extends TestCase
         $this->communicationConfigMock = $this->createMock(CommunicationConfig::class);
         $this->communicationConfigMock->method('getAddress')->willReturn('http://fake-factfinder.com/FACT-Finder-7.3');
         $this->communicationConfigMock->method('getVersion')->willReturn('ng');
+        $this->communicationConfigMock->method('getApiVersion')->willReturn('v5');
 
         $this->exportConfigMock = $this->createMock(ExportConfig::class);
         $this->clientMock       = $this->createMock(ClientInterface::class);

--- a/src/etc/adminhtml/system/general.xml
+++ b/src/etc/adminhtml/system/general.xml
@@ -27,6 +27,13 @@
                 <option label="7.2">7.2</option>
             </options>
         </field>
+        <field id="ff_api_version" translate="label comment" type="select" sortOrder="13" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>FACT-Finder Api version</label>
+            <options>
+                <option label="v4">v4</option>
+                <option label="v5">v5</option>
+            </options>
+        </field>
         <field id="username" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Username</label>
             <validate>required-entry</validate>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -13,6 +13,7 @@
             </general>
             <advanced>
                 <version>7.3</version>
+                <ff_api_version>v4</ff_api_version>
                 <use_url_parameter>1</use_url_parameter>
                 <only_search_params>1</only_search_params>
             </advanced>


### PR DESCRIPTION
- Solves issue: 
  - FFWEB-2628
- Description: 
  - Add option to switch between Api Version
- Tested with Magento editions/versions: 
  - 2.4.4
- Tested with PHP versions: 
  - 7.4

