### PR TITLE
Change type to mixed

### DIFF
--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -65,7 +65,7 @@ class ConfigurableDataProvider extends SimpleDataProvider
 
     private function getOptions(Product $product): array
     {
-        $sanitize = fn(string $phrase): string => $this->filter->filterValue($this->valueOrEmptyStr($phrase));
+        $sanitize = fn(mixed $phrase): string => $this->filter->filterValue($this->valueOrEmptyStr($phrase));
 
         return array_reduce($this->productType->getConfigurableOptions($product), function (array $res, array $option) use ($sanitize) {
             foreach ($option as ['sku' => $sku, 'super_attribute_label' => $label, 'option_title' => $value]) {
@@ -93,7 +93,7 @@ class ConfigurableDataProvider extends SimpleDataProvider
             ->getItems();
     }
 
-    private function valueOrEmptyStr($value): string
+    private function valueOrEmptyStr(mixed $value): string
     {
         return is_string($value) ? $value : '';
     }


### PR DESCRIPTION
- Solves issue: No Issue created.
- Description:   
The Problem is that the Export will fail if the label or value are false, which can happen if they are unset. Due to the strict string typing the mixed to string conversion with `valueOrEmptyStr` cannot function properly.  See as well the Magento [source](https://github.com/magento/magento2/blob/2.4.5-p1/app/code/Magento/ConfigurableProduct/Model/AttributeOptionProvider.php#L70).
To reproduce create a configurable with Attributes without default labels, then try to export it.  
The error is:
```
TypeError: Omikron\Factfinder\Model\Export\Catalog\ProductType\ConfigurableDataProvider::Omikron\Factfinder\Model\Export\Catalog\ProductType\{closure}(): Argument #1 ($phrase) must be of type string, bool given, called in vendor/omikron/magento2-factfinder/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php on line 72 and defined in vendor/omikron/magento2-factfinder/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php:68

```
- Tested with Magento editions/versions: Commerce 2.4.5-p1
- Tested with PHP versions: 8.1

**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
