### PR TITLE
FFWEB-2665: Fix export error when Configurable has no children

### DIFF
--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -84,7 +84,7 @@ class ConfigurableDataProvider extends SimpleDataProvider
     {
         $childrenIds = $this->productType->getChildrenIds($product->getId());
         //if $childrenIds is empty the entity_id filter will thrown an SQL syntax error
-        if (empty($childrenIds)) {
+        if (empty($childrenIds) || empty($childrenIds[0])) {
             return [];
         }
         return $this->productRepository

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -83,10 +83,15 @@ class ConfigurableDataProvider extends SimpleDataProvider
     private function getChildren(Product $product): array
     {
         $childrenIds = $this->productType->getChildrenIds($product->getId());
+
         //if $childrenIds is empty the entity_id filter will thrown an SQL syntax error
-        if (empty($childrenIds) || empty($childrenIds[0])) {
+        if (
+            empty($childrenIds)
+            || empty($childrenIds[0])
+        ) {
             return [];
         }
+
         return $this->productRepository
             ->getList($this->builder->addFilter('entity_id', $childrenIds, 'in')
             ->create())


### PR DESCRIPTION
- Solves issue: 
  - FFWEB-2665
- Description: 
  - Fix export error when Configurable has no children
- Tested with Magento editions/versions: 
  - 2.4.5-p1
- Tested with PHP versions: 
  - 8.1