### PR TITLE
FFWEB-2681: Upgrade phpseclib to version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## Unreleased
+### Change
+- Export
+  - Upgrade phpseclib to phpseclib3
+  - Fix upload data feed via SFTP using key auth
+
 ## [v4.1.0] - 2023.02.23
 ### Add
 - Add option to switch between Api Version

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -76,6 +76,8 @@ class ConfigurableDataProvider extends SimpleDataProvider
     }
 
     /**
+     * phpcs:disable PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace
+     *
      * @param Product $product
      *
      * @return ProductInterface[]

--- a/src/Model/Filesystem/Io/SftpPublicKeyAuth.php
+++ b/src/Model/Filesystem/Io/SftpPublicKeyAuth.php
@@ -10,8 +10,9 @@ use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Io\Sftp as SftpBase;
 use Omikron\Factfinder\Model\Config\FtpConfig;
-use phpseclib\Crypt\RSA;
-use phpseclib\Net\SFTP;
+use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\Common\PrivateKey;
+use phpseclib3\Net\SFTP;
 
 class SftpPublicKeyAuth extends SftpBase
 {
@@ -32,17 +33,16 @@ class SftpPublicKeyAuth extends SftpBase
         }
     }
 
-    protected function getKey(string $passphrase): Rsa
+    protected function getKey(string $passphrase): PrivateKey
     {
-        $privateKey      = new Rsa();
         $configDirectory = $this->fileSystem->getDirectoryRead(DirectoryList::CONFIG);
         $filesInLocation = $configDirectory->read('factfinder/sftp');
         $keyFile         = $configDirectory->readFile($filesInLocation[$this->getFileIndex($filesInLocation)]);
+        $privateKey      = PublicKeyLoader::loadPrivateKey($keyFile);
 
         if ($passphrase) {
-            $privateKey->setPassword($passphrase);
+            $privateKey = PublicKeyLoader::loadPrivateKey($keyFile, $passphrase);
         }
-        $privateKey->loadKey($keyFile);
 
         return $privateKey;
     }

--- a/src/Model/Filesystem/Io/SftpPublicKeyAuth.php
+++ b/src/Model/Filesystem/Io/SftpPublicKeyAuth.php
@@ -33,6 +33,9 @@ class SftpPublicKeyAuth extends SftpBase
         }
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
     protected function getKey(string $passphrase): PrivateKey
     {
         $configDirectory = $this->fileSystem->getDirectoryRead(DirectoryList::CONFIG);


### PR DESCRIPTION
- Solves issue: 
  - FFWEB-2681
- Description: 
  - Upgrade phpseclib to phpseclib3
  - Fix upload data feed via SFTP using key auth
- Tested with Magento editions/versions: 
  - 2.4.5-p1
- Tested with PHP versions: 
  - 8.1