### PR TITLE
FFWEB-2685: Fix export for attributes that contain a number in the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Fix
+- Export
+  - Fix problem with attribute values which are null in feeds with attributes that contain a number in the code
+
 ## [v4.1.1] - 2023.03.13
 ### Change
 - Upgrade Web Components version to v4.2.5

--- a/src/Model/Export/Catalog/AttributeValuesExtractor.php
+++ b/src/Model/Export/Catalog/AttributeValuesExtractor.php
@@ -34,7 +34,7 @@ class AttributeValuesExtractor
     public function getAttributeValues(Product $product, Attribute $attribute): array
     {
         $code   = $attribute->getAttributeCode();
-        $value  = $product->getDataUsingMethod($code);
+        $value  = $product->getDataUsingMethod($code) ?? $product->getData($code);
         $values = [];
 
         switch ($attribute->getFrontendInput()) {


### PR DESCRIPTION
- Solves issue: 
  - FFWEB-2685
- Description: 
  - Fix problem with exporting attribute values which are null in feeds with attributes that contain a number in the code
- Tested with Magento editions/versions: 
  - 2.4.5-p1
- Tested with PHP versions: 
  - 8.1
