### PR TITLE
FFWEB-2698: Fix export preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 ### Fix
+- Export preview
 - Export
   - Fix problem with attribute values which are null in feeds with attributes that contain a number in the code
 

--- a/src/Model/Export/Catalog/ExportPreviewDataProvider.php
+++ b/src/Model/Export/Catalog/ExportPreviewDataProvider.php
@@ -20,7 +20,7 @@ class ExportPreviewDataProvider implements DataProviderInterface
     public function __construct(
         private readonly ExportPreviewProducts $products,
         private readonly ObjectManagerInterface $objectManager,
-        private readonly array $fields,
+        private readonly array $productFields,
         private readonly array $entityTypes,
         private readonly array $data,
     ) {}

--- a/src/Model/Stream/Json.php
+++ b/src/Model/Stream/Json.php
@@ -25,7 +25,5 @@ class Json implements StreamInterface
      */
     public function finalize(): void
     {
-        //@phpcs:ignore Magento2.Security.LanguageConstruct.ExitUsage
-        exit();
     }
 }

--- a/src/Test/Unit/Controller/Adminhtml/TestConnection/TestConnectionTest.php
+++ b/src/Test/Unit/Controller/Adminhtml/TestConnection/TestConnectionTest.php
@@ -16,6 +16,7 @@ use Omikron\Factfinder\Model\Config\AuthConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * @covers TestConnection
@@ -48,7 +49,8 @@ class TestConnectionTest extends TestCase
     {
         $credentialsFactory = $this->createConfiguredMock(CredentialsFactory::class, ['create' => $this->createMock(Credentials::class)]);
         $this->request      = $this->createMock(RequestInterface::class);
-        $clientMock         = $this->createConfiguredMock(ClientInterface::class, ['request' => $this->createConfiguredMock(ResponseInterface::class, ['getBody' => '{"status":"200"}'])]);
+        $body               = $this->createConfiguredMock(StreamInterface::class, ['getContents' => '{"status":"200"}']);
+        $clientMock         = $this->createConfiguredMock(ClientInterface::class, ['request' => $this->createConfiguredMock(ResponseInterface::class, ['getBody' => $body])]);
         $this->builderMock  = $this->createMock(ClientBuilder::class);
 
         $this->builderMock->method('withVersion')->willReturn($this->builderMock);

--- a/src/Test/Unit/Model/Api/PushImportTest.php
+++ b/src/Test/Unit/Model/Api/PushImportTest.php
@@ -99,12 +99,16 @@ class PushImportTest extends TestCase
 
     private function importRunningResponse(): ResponseInterface
     {
-        return $this->createConfiguredMock(ResponseInterface::class, ['getBody' => 'true']);
+        $body = $this->createConfiguredMock(StreamInterface::class, ['__toString' => 'true']);
+
+        return $this->createConfiguredMock(ResponseInterface::class, ['getBody' => $body]);
     }
 
     private function importNotRunningResponse(): ResponseInterface
     {
-        return $this->createConfiguredMock(ResponseInterface::class, ['getBody' => 'false']);
+        $body = $this->createConfiguredMock(StreamInterface::class, ['__toString' => 'false']);
+
+        return $this->createConfiguredMock(ResponseInterface::class, ['getBody' => $body]);
     }
 
     private function importResponseOk(): ResponseInterface

--- a/src/Test/Unit/Model/Api/PushImportTest.php
+++ b/src/Test/Unit/Model/Api/PushImportTest.php
@@ -12,6 +12,7 @@ use Omikron\Factfinder\Model\Config\ExportConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -108,7 +109,9 @@ class PushImportTest extends TestCase
 
     private function importResponseOk(): ResponseInterface
     {
-        return $this->createConfiguredMock(ResponseInterface::class, ['getBody' => '{"0": {"importType": "data", "statusMessages": {},"errorMessages": {}}}']);
+        $body = $this->createConfiguredMock(StreamInterface::class, ['getContents' => '{"0": {"importType": "data", "statusMessages": {},"errorMessages": {}}}']);
+
+        return $this->createConfiguredMock(ResponseInterface::class, ['getBody' => $body]);
     }
 
     private function importResponseBad(string $errorField): ResponseInterface

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -93,6 +93,12 @@
     </type>
     <type name="Omikron\Factfinder\Model\Export\Catalog\ExportPreviewDataProvider">
         <arguments>
+            <argument name="productFields" xsi:type="array">
+                <item name="CategoryPath" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\CategoryPath</item>
+                <item name="Brand" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\Brand</item>
+                <item name="FilterAttributes" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\FilterAttributes</item>
+                <item name="NumericalAttributes" xsi:type="object">Omikron\Factfinder\Model\Export\Catalog\ProductField\NumericalAttributes</item>
+            </argument>
             <argument name="entityTypes" xsi:type="array">
                 <item name="simple" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\SimpleDataProvider</item>
                 <item name="configurable" xsi:type="string">Omikron\Factfinder\Model\Export\Catalog\ProductType\ConfigurableDataProvider</item>


### PR DESCRIPTION
- Solves issue: 
  - FFWEB-2698
- Description: 
  - Fix export preview
- Tested with Magento editions/versions: 
  - 2.4.5-p1
- Tested with PHP versions: 
  - 8.1
