### PR TITLE
FFWEB-2704: Fix problem with export cron configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+### Fix
+- Fix problem with export cron configuration
 ## [v4.1.2] - 2023.04.14
 ### Fix
 - Export preview

--- a/src/Cron/Feed.php
+++ b/src/Cron/Feed.php
@@ -34,7 +34,7 @@ class Feed
         private readonly CommunicationConfig    $communicationConfig,
         private readonly PushImport             $pushImport,
         private readonly FeedFileService        $feedFileService,
-        private readonly string                 $feedTypetype,
+        private readonly string                 $feedType,
     ) {}
 
     public function execute(): void

--- a/src/etc/crontab/di.xml
+++ b/src/etc/crontab/di.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <virtualType name="ProductExportCron" type="Omikron\Factfinder\Cron\Feed">
         <arguments>
-            <argument name="type" xsi:type="string">product</argument>
+            <argument name="feedType" xsi:type="string">product</argument>
         </arguments>
     </virtualType>
 </config>


### PR DESCRIPTION
- Solves issue: 
  - FFWEB-2704
- Description: 
  - Fix problem with export cron configuration
- Tested with Magento editions/versions: 
  - 2.4.5-p1
- Tested with PHP versions: 
  - 8.1
