### PR TITLE
FfWEB-2708 Fix invalid return type for CLIexport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Fix
 - Fix problem with export cron configuration
+- Fix invalid return type for CLI export
 ## [v4.1.2] - 2023.04.14
 ### Fix
 - Export preview

--- a/src/Console/Command/Export.php
+++ b/src/Console/Command/Export.php
@@ -86,6 +86,8 @@ class Export extends Command
                 }
             });
         }
+
+        return 0;
     }
 
     private function getStoreIds(int $storeId): array

--- a/src/Model/Export/Cms/DataProvider.php
+++ b/src/Model/Export/Cms/DataProvider.php
@@ -26,7 +26,7 @@ class DataProvider implements DataProviderInterface
     {
         yield from [];
         foreach ($this->pages as $page) {
-            yield $this->pageFactory->create(['page' => $page, 'pageFields' => $this->pageFields]);
+            yield $this->pageFactory->create(['page' => $page, 'pageFields' => $this->fields]);
         }
     }
 }


### PR DESCRIPTION
- Solves issue: 
  - FFWEB-2708
- Description: 
  - Fix invalid return type for FF export CLI and DataProvider dependency
- Tested with Magento editions/versions: 
  - 2.4.5-p1
- Tested with PHP versions: 
  - 8.1
