### PR TITLE
FFWEB-2718 Fix problem with SFTP key auth connection

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
-- Solves issue: 
-- Description: 
-- Tested with Magento editions/versions: 
-- Tested with PHP versions: 
-
-**Please note that the source and target branch must be `master` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
+- Solves issue:
+    - Issue or task number/code, for example: FFWEB-2718
+- Description:
+    - changes description
+- Tested with Magento editions/versions:
+    - For example: 2.4.6
+- Tested with PHP versions:
+    - For example: 8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fix
 - Fix problem with export cron configuration
 - Fix invalid return type for CLI export
+- Fix problem with SFTP key auth connection
 ## [v4.1.2] - 2023.04.14
 ### Fix
 - Export preview

--- a/src/Model/Filesystem/Io/SftpPublicKeyAuth.php
+++ b/src/Model/Filesystem/Io/SftpPublicKeyAuth.php
@@ -22,7 +22,7 @@ class SftpPublicKeyAuth extends SftpBase
      */
     public function __construct(
         private readonly Filesystem $fileSystem,
-        private readonly FtpConfig $config,
+        private readonly FtpConfig $uploadConfig,
     ) {}
 
     public function open(array $args = [])


### PR DESCRIPTION
- Solves issue: 
  - FFWEB-2718
- Description: 
  - Fix problem with SFTP key auth connection
- Tested with Magento editions/versions: 
  - 2.4.6
- Tested with PHP versions: 
  - 8.1
