### PR TITLE
FFWEB-2723: Create one `ffwebc-sid` cookie per session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Create one `ffwebc-sid` cookie per session
+
 ## [v4.1.3] - 2023.05.15
 ### Fix
 - Add missing `sid` parameter for SSR FactFinder request

--- a/src/view/frontend/templates/ff/communication.phtml
+++ b/src/view/frontend/templates/ff/communication.phtml
@@ -46,7 +46,7 @@ $searchImmediate = $communicationParameters['search-immediate'] ?? 'false';
         }
 
         <?php if ($viewModel->isSsrEnable()): ?>
-            document.cookie = 'ffwebc_sid=' + factfinder.common.localStorage.getItem('ff_sid');
+            document.cookie = 'ffwebc_sid=' + factfinder.common.localStorage.getItem('ff_sid') + '; path=/;';
         <?php endif; ?>
 
         if (<?= /** @SuppressWarnings(PHPMD) */ $searchImmediate ?>) {


### PR DESCRIPTION
- Solves issue:
    - FFWEB-2723
- Description:
    - Create one `ffwebc-sid` cookie per session
- Tested with Magento editions/versions:
    - For example: 2.4.6
- Tested with PHP versions:
    - For example: 8.1
