### PR TITLE
FFWEB-2749: Handle sid for first session request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Fix sending sid for first session request (when SSR is active)
+
 ## [v4.1.4] - 2023.05.22
 ### Fix
 - Create one `ffwebc_sid` cookie per session

--- a/src/view/frontend/templates/ff/communication.phtml
+++ b/src/view/frontend/templates/ff/communication.phtml
@@ -7,6 +7,39 @@ $parameters = $viewModel->getParameters($communicationParameters);
 $searchImmediate = $communicationParameters['search-immediate'] ?? 'false';
 ?>
 <ff-communication<?php foreach ($parameters as $key => $value) /* @noEscape */ echo sprintf(' %s="%s"', $key, $block->escapeHtmlAttr($value)) ?>></ff-communication>
+
+<?php if ($viewModel->isSsrEnable()): ?>
+    <script>
+            function generateSid() {
+                var length = 30;
+                var characterSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+                var text = "";
+                for (var i = 0; i < length; i++) {
+                    text += characterSet.charAt(Math.floor(Math.random() * characterSet.length));
+                }
+                return text;
+            }
+
+            const ffCookies = document.cookie.split('; ').reduce((acc, cookie) => {
+                const cookieData = cookie.split('=');
+                const [key, value] = cookieData;
+                acc[key] = value;
+
+                return acc;
+            }, {});
+
+            const ffcommunication = document.querySelector('ff-communication');
+
+            if (!ffCookies['ffwebc_sid']) {
+                const sid = generateSid();
+                document.cookie = 'ffwebc_sid=' + sid + '; path=/;';
+                ffcommunication.setAttribute('sid', sid);
+            } else {
+                ffcommunication.setAttribute('sid', ffCookies['ffwebc_sid']);
+            }
+    </script>
+
+<?php endif; ?>
 <!-- Set FieldRoles -->
 <script>
     document.addEventListener('ffReady', function () {
@@ -44,13 +77,6 @@ $searchImmediate = $communicationParameters['search-immediate'] ?? 'false';
                 factfinder.communication.sessionManager.clearAllSessionData();
             }
         }
-
-        <?php if ($viewModel->isSsrEnable()): ?>
-            const eventAggregator = factfinder.communication.EventAggregator;
-            eventAggregator.addBeforeDispatchingCallback(function (event) {
-                document.cookie = 'ffwebc_sid=' + factfinder.common.localStorage.getItem('ff_sid') + '; path=/;';
-            });
-        <?php endif; ?>
 
         if (<?= /** @SuppressWarnings(PHPMD) */ $searchImmediate ?>) {
             searchImmediate();

--- a/src/view/frontend/templates/ff/communication.phtml
+++ b/src/view/frontend/templates/ff/communication.phtml
@@ -38,8 +38,8 @@ $searchImmediate = $communicationParameters['search-immediate'] ?? 'false';
                 ffcommunication.setAttribute('sid', ffCookies['ffwebc_sid']);
             }
     </script>
-
 <?php endif; ?>
+
 <!-- Set FieldRoles -->
 <script>
     document.addEventListener('ffReady', function () {


### PR DESCRIPTION
- Solves issue:
    - FFWEB-2749
- Description:
    - Handle sid for first session request when SSR is active
- Tested with Magento editions/versions:
    - For example: 2.4.6
- Tested with PHP versions:
    - For example: 8.1

