### PR TITLE
FFWEB-2760: Set default value for $pushImportResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Set default value for $pushImportResult to prevent initialization exception
+
 ## [v4.1.5] - 2023.07.05
 ### Fix
 - Fix sending sid for first session request (when SSR is active)

--- a/src/Model/Api/PushImport.php
+++ b/src/Model/Api/PushImport.php
@@ -19,7 +19,7 @@ class PushImport
     private ExportConfig $exportConfig;
     private LoggerInterface $logger;
     private ClientBuilder $clientBuilder;
-    private string $pushImportResult;
+    private string $pushImportResult = '';
 
     public function __construct(
         ClientBuilder $clientBuilder,


### PR DESCRIPTION
- Solves issue: FFWEB-2760
- Description: Set default value for $pushImportResult to prevent initialization exception
- Tested with Magento editions/versions: 2.4.6
- Tested with PHP versions: 8.1
