### PR TITLE
FFWEB-2759: Fix problems in factfinder_feed_export cron job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Fix problems in factfinder_feed_export cron job by casting `storeid` to int.
+
 ## [v4.1.6] - 2023.07.19
 ### Fix
 - Set default value for $pushImportResult to prevent initialization exception

--- a/src/Cron/Feed.php
+++ b/src/Cron/Feed.php
@@ -45,7 +45,7 @@ class Feed
 
         foreach ($this->storeManager->getStores() as $store) {
             $this->storeEmulation->runInStore((int) $store->getId(), function () use ($store) {
-                $storeId = $store->getId();
+                $storeId = (int) $store->getId();
                 if ($this->communicationConfig->isChannelEnabled($storeId)) {
                     $filename = $this->feedFileService->getFeedExportFilename(
                         $this->feedType,


### PR DESCRIPTION
- Solves issue: FFWEB-2759
- Description: Fix problems in factfinder_feed_export cron job by casting `storeid` to int.
- Tested with Magento editions/versions: 2.4.6
- Tested with PHP versions: 8.1
