### PR TITLE
FFWEB-2805: Add product campaign to product detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Add
+- Add product campaign to product detail page
+
 ## [v4.1.7] - 2023.08.08
 ### Fix
 - Fix problems in factfinder_feed_export cron job by casting `storeid` to int.

--- a/src/view/frontend/layout/catalog_product_view.xml
+++ b/src/view/frontend/layout/catalog_product_view.xml
@@ -7,6 +7,11 @@
                     <argument name="view_model" xsi:type="object">Omikron\Factfinder\ViewModel\ProductBasedComponent</argument>
                 </arguments>
             </block>
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.pushed.products" template="Omikron_Factfinder::ff/campaign-pushed-products.phtml">
+                <arguments>
+                    <argument name="flag" xsi:type="string">is-product-campaign</argument>
+                </arguments>
+            </block>
             <block class="Magento\Framework\View\Element\Template" name="factfinder.recommendation" ifconfig="factfinder/components/recommendation" template="Omikron_Factfinder::ff/recommendation.phtml">
                 <arguments>
                     <argument name="view_model" xsi:type="object">Omikron\Factfinder\ViewModel\ProductBasedComponent</argument>


### PR DESCRIPTION
- Solves issue: FFWEB-2805
- Description: Add product campaign to product detail page
- Tested with Magento editions/versions: 2.4.6
- Tested with PHP versions: 8.1

