### PR TITLE
FFWEB-2843: Add campaigns on category pages

### DIFF
--- a/src/view/frontend/layout/factfinder_category_view.xml
+++ b/src/view/frontend/layout/factfinder_category_view.xml
@@ -30,5 +30,12 @@
                 <argument name="search_params" xsi:type="helper" helper="Omikron\Factfinder\ViewModel\CategoryPath::__toString" />
             </arguments>
         </referenceBlock>
+
+        <container name="factfinder.campaigns">
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.advisor" ifconfig="factfinder/components/campaign_advisor" template="Omikron_Factfinder::ff/campaign-advisor.phtml" />
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.redirect" ifconfig="factfinder/components/campaign_redirect" template="Omikron_Factfinder::ff/campaign-redirect.phtml" />
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.pushedproducts" template="Omikron_Factfinder::ff/campaign-pushed-products.phtml" />
+        </container>
+        <move element="factfinder.campaigns" destination="content" before="factfinder.breadcrumb" />
     </body>
 </page>


### PR DESCRIPTION
- Solves issue: FFWEB-2843
- Description: Add campaigns on category pages
- Tested with Magento editions/versions: 2.4.6
- Tested with PHP versions: 8.1

