### PR TITLE
FFWEB-2947: Fix display conditionals for Landing page campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ##  Unreleased
 ### Add
 - Add landing page campaign
+
 ## [v4.2.2] - 2023.11.10
 ### Add
 - Add campaigns to category view page

--- a/src/view/frontend/layout/default.xml
+++ b/src/view/frontend/layout/default.xml
@@ -16,18 +16,18 @@
         </block>
 
         <referenceContainer name="after.body.start">
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.communication" ifconfig="factfinder/components/campaign_landing_page" template="Omikron_Factfinder::ff/communication.phtml" before="-">
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.communication" ifconfig="factfinder/general/is_enabled" template="Omikron_Factfinder::ff/communication.phtml" before="-">
                 <arguments>
                     <argument name="view_model" xsi:type="object">Omikron\Factfinder\ViewModel\Communication</argument>
                     <argument name="ppp" xsi:type="helper" helper="Omikron\Factfinder\ViewModel\Cart::getItemIds" />
                 </arguments>
             </block>
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.communication.ppp" ifconfig="factfinder/components/campaign_landing_page" template="Omikron_Factfinder::ff/products-per-page-configuration.phtml" after="factfinder.communication">
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.communication.ppp" ifconfig="factfinder/general/is_enabled" template="Omikron_Factfinder::ff/products-per-page-configuration.phtml" after="factfinder.communication">
                 <arguments>
                     <argument name="view_model" xsi:type="object">Omikron\Factfinder\ViewModel\ProductsPerPage</argument>
                 </arguments>
             </block>
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.search.redirect" ifconfig="factfinder/components/campaign_landing_page" template="Omikron_Factfinder::ff/search-redirect.phtml" after="factfinder.communication" />
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.search.redirect" ifconfig="factfinder/general/is_enabled" template="Omikron_Factfinder::ff/search-redirect.phtml" after="factfinder.communication" />
         </referenceContainer>
 
         <referenceBlock name="top.search">
@@ -40,13 +40,13 @@
         <block class="Omikron\Factfinder\Block\Ssr\RecordList" name="factfinder.ssr.recordlist" template="Omikron_Factfinder::ff/ssr/record-list.phtml" />
 
         <referenceContainer name="content">
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaignlandingpage" ifconfig="factfinder/general/is_enabled" template="Omikron_Factfinder::ff/campaign-landing-page.phtml" />
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaignlandingpage" ifconfig="factfinder/components/campaign_landing_page" template="Omikron_Factfinder::ff/campaign-landing-page.phtml" />
             <referenceBlock name="factfinder.feedbacktext">
                 <arguments>
                     <argument name="flag" xsi:type="string">is-landing-page-campaign</argument>
                 </arguments>
             </referenceBlock>
-            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.pushed.products" template="Omikron_Factfinder::ff/campaign-pushed-products.phtml">
+            <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.pushed.products" ifconfig="factfinder/components/campaign_landing_page" template="Omikron_Factfinder::ff/campaign-pushed-products.phtml">
                 <arguments>
                     <argument name="flag" xsi:type="string">is-landing-page-campaign</argument>
                 </arguments>


### PR DESCRIPTION
Fix display conditionals for Landing page campaign

- Solves issue: FFWEB-2947:
- Description: Fix display conditionals for Landing page campaign
- Tested with Magento editions/versions: 2.4.6
- Tested with PHP versions: 8.1
