### PR TITLE
Add php 8.2 and php 8.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "~8.1.0",
+    "php": "~8.1",
     "omikron/factfinder-communication-sdk": "^0.9.5",
     "magento/framework": "~103.0.4",
     "magento/module-catalog": "~104.0.4",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "~8.1",
+    "php": "^8.1",
     "omikron/factfinder-communication-sdk": "^0.9.5",
     "magento/framework": "~103.0.4",
     "magento/module-catalog": "~104.0.4",


### PR DESCRIPTION
Because your latest commit includes "PHP version 8.1 and higher".
I just replaced ~8.1.0 to ~8.1 (as your sdk) in order to authorize php 8.2 / php 8.3

Composer documentation :
The ~ operator is best explained by example: ~1.2 is equivalent to >=1.2 <2.0.0, while ~1.2.3 is equivalent to >=1.2.3 <1.3.0