### PR TITLE
FFWEB-2963: Fix availability column data for UI export type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run Static analysis
         run: |
-            vendor/bin/phpcs --config-set installed_paths vendor/magento/magento-coding-standard,vendor/phpcompatibility/php-compatibility
+            vendor/bin/phpcs --config-set installed_paths vendor/magento/magento-coding-standard,vendor/magento/php-compatibility-fork
             vendor/bin/phpcs --standard=phpcs.xml.dist --extensions=php,phtml src
             vendor/bin/phpmd src text phpmd.xml.dist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 ## Unreleased
 ### Fix
 - Fix availability column data for UI export type
+- Fix deprecations from phpcs
+### Add
+- Add phpcs fixer as dev dependencies
+
 ## [v4.3.0] - 2024.01.16
 ### Add
 - Add landing page campaign

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+### Fix
+- Fix availability column data for UI export type
 ## [v4.3.0] - 2024.01.16
 ### Add
 - Add landing page campaign

--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,10 @@
       "mustache/mustache": true,
       "dealerdirect/phpcodesniffer-composer-installer": true
     }
+  },
+  "scripts": {
+    "post-install-cmd": [
+      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/,../../phpcompatibility/php-compatibility)"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "allow-plugins": {
       "magento/*": true,
       "omikron/*": true,
-      "mustache/mustache": true
+      "mustache/mustache": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "pdepend/pdepend": "^2.8",
     "phpmd/phpmd": "^2.9",
     "phpunit/phpunit": "~9.5.0",
-    "magento/magento-coding-standard": "*"
+    "magento/magento-coding-standard": "*",
+    "friendsofphp/php-cs-fixer": "^3.51"
   },
   "autoload": {
     "files": [

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,10 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/,../../phpcompatibility/php-compatibility)"
+      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/,../../magento/php-compatibility-fork)"
+    ],
+    "post-update-cmd": [
+      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/,../../magento/php-compatibility-fork)"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,12 +42,15 @@
       "dealerdirect/phpcodesniffer-composer-installer": true
     }
   },
-  "scripts": {
-    "post-install-cmd": [
-      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/,../../magento/php-compatibility-fork)"
-    ],
-    "post-update-cmd": [
-      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/,../../magento/php-compatibility-fork)"
-    ]
+  "minimum-stability": "stable",
+  "prefer-stable": true,
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://repo.magento.com/"
+    }
+  ],
+  "extra": {
+    "magento-force": "override"
   }
 }

--- a/src/Block/Adminhtml/System/Config/Field/ProductsPerPage.php
+++ b/src/Block/Adminhtml/System/Config/Field/ProductsPerPage.php
@@ -15,7 +15,6 @@ use Magento\Framework\DataObject;
  */
 class ProductsPerPage extends AbstractFieldArray
 {
-
     protected function _prepareToRender()
     {
         $this->_addAfter = false;

--- a/src/Controller/Router.php
+++ b/src/Controller/Router.php
@@ -13,11 +13,9 @@ class Router implements RouterInterface
 {
     public const FRONT_NAME = 'fact-finder';
 
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly ActionFactory $actionFactory) {}
+    public function __construct(private readonly ActionFactory $actionFactory)
+    {
+    }
 
     /**
      * Test the incoming requests for matches to the factfinder url pattern

--- a/src/Controller/SkipCsrfValidation.php
+++ b/src/Controller/SkipCsrfValidation.php
@@ -1,4 +1,5 @@
 <?php
+
 //@
 declare(strict_types=1);
 

--- a/src/Cron/Feed.php
+++ b/src/Cron/Feed.php
@@ -35,7 +35,8 @@ class Feed
         private readonly PushImport             $pushImport,
         private readonly FeedFileService        $feedFileService,
         private readonly string                 $feedType,
-    ) {}
+    ) {
+    }
 
     public function execute(): void
     {

--- a/src/Helper/ConfigurationHelper.php
+++ b/src/Helper/ConfigurationHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Omikron\Factfinder\Helper;

--- a/src/Model/Adminhtml/System/Config/Source/Attribute.php
+++ b/src/Model/Adminhtml/System/Config/Source/Attribute.php
@@ -20,7 +20,7 @@ class Attribute implements OptionSourceInterface
     public function toOptionArray()
     {
         $options = array_map(
-            fn(EavAttribute $attr) => [
+            fn (EavAttribute $attr) => [
                 'value' => (string) $attr->getAttributeCode(),
                 'label' => (string) $attr->getDefaultFrontendLabel()
             ],

--- a/src/Model/Export/BasicAuth.php
+++ b/src/Model/Export/BasicAuth.php
@@ -12,11 +12,9 @@ class BasicAuth
     private const CONFIG_PATH_USERNAME = 'factfinder/basic_auth_data_transfer/ff_upload_url_user';
     private const CONFIG_PATH_PASSWORD = 'factfinder/basic_auth_data_transfer/ff_upload_url_password';
 
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly ScopeConfigInterface $scopeConfig) {}
+    public function __construct(private readonly ScopeConfigInterface $scopeConfig)
+    {
+    }
 
     public function authenticate(string $username, string $password): bool
     {

--- a/src/Model/Export/Catalog/AttributeValuesExtractor.php
+++ b/src/Model/Export/Catalog/AttributeValuesExtractor.php
@@ -13,14 +13,11 @@ use DateTime;
 
 class AttributeValuesExtractor
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly FilterInterface $filter,
         private readonly NumberFormatter $numberFormatter,
-    ) {}
+    ) {
+    }
 
     /**
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)

--- a/src/Model/Export/Catalog/DataProvider.php
+++ b/src/Model/Export/Catalog/DataProvider.php
@@ -12,16 +12,13 @@ use Omikron\Factfinder\Api\Export\ExportEntityInterface;
 
 class DataProvider implements DataProviderInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly Products $products,
         private readonly ObjectManagerInterface $objectManager,
         private readonly array $fields,
         private readonly array $entityTypes,
-    ) {}
+    ) {
+    }
 
     /**
      * @return ExportEntityInterface[]

--- a/src/Model/Export/Catalog/Entity/ProductVariation.php
+++ b/src/Model/Export/Catalog/Entity/ProductVariation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Export\Catalog\Entity;
 
 use Magento\Catalog\Model\Product;
+use Magento\CatalogInventory\Model\Stock\StockItemRepository as StockItem;
 use Omikron\Factfinder\Api\Export\ExportEntityInterface;
 use Omikron\Factfinder\Api\Export\FieldInterface;
 use Omikron\Factfinder\Model\Export\Catalog\FieldProvider;
@@ -19,12 +20,14 @@ class ProductVariation implements ExportEntityInterface
 
     /** @var string[] */
     private array $configurableData;
+    private StockItem $stockItem;
 
     public function __construct(
         Product $product,
         Product $configurable,
         NumberFormatter $numberFormatter,
         FieldProvider $variantFieldProvider,
+        StockItem $stockItem,
         array $data = []
     ) {
         $this->product          = $product;
@@ -32,6 +35,7 @@ class ProductVariation implements ExportEntityInterface
         $this->numberFormatter  = $numberFormatter;
         $this->configurableData = $data;
         $this->fieldprovider    = $variantFieldProvider;
+        $this->stockItem = $stockItem;
     }
 
     public function getId(): int
@@ -44,7 +48,7 @@ class ProductVariation implements ExportEntityInterface
         $baseData = [
                 'ProductNumber' => (string) $this->product->getSku(),
                 'Price'         => $this->numberFormatter->format((float) $this->product->getFinalPrice()),
-                'Availability'  => (int) $this->product->isAvailable(),
+                'Availability'  => (int) $this->getAvailability(),
                 'HasVariants'   => 0,
                 'MagentoId'     => $this->getId(),
             ] + $this->configurableData;
@@ -79,5 +83,16 @@ class ProductVariation implements ExportEntityInterface
         $filterAttributes = $fields['FilterAttributes'] ?? [];
 
         return [$filterAttributes, $withoutFilterAttributes];
+    }
+
+    private function getAvailability(): bool
+    {
+        if ($this->product->hasData('is_salable')) {
+            return $this->product->isAvailable();
+        }
+
+        $quantity = $this->stockItem->get($this->product->getId());
+
+        return $quantity->getIsInStock();
     }
 }

--- a/src/Model/Export/Catalog/ExportPreviewDataProvider.php
+++ b/src/Model/Export/Catalog/ExportPreviewDataProvider.php
@@ -13,17 +13,14 @@ use Omikron\Factfinder\Api\Export\FieldInterface;
 
 class ExportPreviewDataProvider implements DataProviderInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly ExportPreviewProducts $products,
         private readonly ObjectManagerInterface $objectManager,
         private readonly array $productFields,
         private readonly array $entityTypes,
         private readonly array $data,
-    ) {}
+    ) {
+    }
 
     /**
      * @return ExportEntityInterface[]

--- a/src/Model/Export/Catalog/ExportPreviewProducts.php
+++ b/src/Model/Export/Catalog/ExportPreviewProducts.php
@@ -12,14 +12,11 @@ use Traversable;
 
 class ExportPreviewProducts implements \IteratorAggregate
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly ProductRepositoryInterface $productRepository,
         private readonly RequestInterface $request,
-    ) {}
+    ) {
+    }
 
     /**
      * @return Traversable|ProductInterface[]

--- a/src/Model/Export/Catalog/FieldProvider.php
+++ b/src/Model/Export/Catalog/FieldProvider.php
@@ -13,16 +13,13 @@ class FieldProvider implements FieldProviderInterface
     private ?array $cachedFields;
     private ?array $cachedVariantFields;
 
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly ExportConfig $config,
         private readonly GenericFieldFactory $fieldFactory,
         private readonly array $productFields = [],
         private readonly array $variantFields = [],
-    ) {}
+    ) {
+    }
 
     public function getVariantFields(): array
     {

--- a/src/Model/Export/Catalog/ProductField/GenericField.php
+++ b/src/Model/Export/Catalog/ProductField/GenericField.php
@@ -14,16 +14,13 @@ use Magento\Catalog\Model\Product;
 
 class GenericField implements FieldInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly ProductAttributeRepositoryInterface $attributeRepository,
         private readonly AttributeValuesExtractor $valuesExtractor,
         private readonly StoreManagerInterface $storeManager,
         private readonly string $attributeCode,
-    ) {}
+    ) {
+    }
 
     public function getName(): string
     {

--- a/src/Model/Export/Catalog/ProductField/ProductImage.php
+++ b/src/Model/Export/Catalog/ProductField/ProductImage.php
@@ -10,14 +10,11 @@ use Omikron\Factfinder\Api\Export\FieldInterface;
 
 class ProductImage implements FieldInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly ImageHelper $imageHelper,
         private readonly string $imageId = 'ff_export_image_url',
-    ) {}
+    ) {
+    }
 
     public function getName(): string
     {

--- a/src/Model/Export/Catalog/ProductType/BundleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/BundleDataProvider.php
@@ -6,6 +6,7 @@ namespace Omikron\Factfinder\Model\Export\Catalog\ProductType;
 
 use Magento\Bundle\Model\Product\CatalogPrice;
 use Magento\Catalog\Model\Product;
+use Magento\CatalogInventory\Model\Stock\StockItemRepository as StockItem;
 use Magento\Directory\Model\PriceCurrency;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 
@@ -16,14 +17,16 @@ class BundleDataProvider extends SimpleDataProvider
         protected NumberFormatter $numberFormatter,
         private readonly PriceCurrency     $priceCurrency,
         private readonly CatalogPrice      $priceModel,
+        StockItem $stockItem,
         protected array             $productFields = []
     ) {
-        parent::__construct($product, $numberFormatter, $productFields);
+        parent::__construct($product, $numberFormatter, $stockItem, $productFields);
     }
 
     public function toArray(): array
     {
         $price = (float) $this->priceCurrency->convert($this->priceModel->getCatalogPrice($this->product));
+
         return ['Price' => $this->numberFormatter->format($price)] + parent::toArray();
     }
 }

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -67,7 +67,7 @@ class ConfigurableDataProvider extends SimpleDataProvider
 
     private function getOptions(Product $product): array
     {
-        $sanitize = fn(mixed $phrase): string => $this->filter->filterValue($this->valueOrEmptyStr($phrase));
+        $sanitize = fn (mixed $phrase): string => $this->filter->filterValue($this->valueOrEmptyStr($phrase));
 
         return array_reduce($this->productType->getConfigurableOptions($product), function (array $res, array $option) use ($sanitize) {
             foreach ($option as ['sku' => $sku, 'super_attribute_label' => $label, 'option_title' => $value]) {

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -7,6 +7,7 @@ namespace Omikron\Factfinder\Model\Export\Catalog\ProductType;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
+use Magento\CatalogInventory\Model\Stock\StockItemRepository as StockItem;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableProductType;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Omikron\Factfinder\Api\Export\ExportEntityInterface;
@@ -24,9 +25,10 @@ class ConfigurableDataProvider extends SimpleDataProvider
         private readonly ProductVariationFactory    $variationFactory,
         private readonly ProductRepositoryInterface $productRepository,
         private readonly SearchCriteriaBuilder      $builder,
+        StockItem $stockItem,
         protected array                    $productFields = []
     ) {
-        parent::__construct($product, $numberFormatter, $productFields);
+        parent::__construct($product, $numberFormatter, $stockItem, $productFields);
     }
 
     public function getEntities(): iterable

--- a/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
@@ -13,16 +13,13 @@ use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 
 class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         protected Product $product,
         protected NumberFormatter $numberFormatter,
         protected StockItem $stockItem,
         protected array $productFields = [],
-    ) {}
+    ) {
+    }
 
     /**
      * @inheritdoc
@@ -57,7 +54,7 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
 
         return array_reduce(
             $this->productFields,
-            fn (array $result, FieldInterface $field): array  => [$field->getName() => $field->getValue($this->product)] + $result,
+            fn (array $result, FieldInterface $field): array => [$field->getName() => $field->getValue($this->product)] + $result,
             $data
         );
     }

--- a/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Export\Catalog\ProductType;
 
 use Magento\Catalog\Model\Product;
+use Magento\CatalogInventory\Model\Stock\StockItemRepository as StockItem;
 use Omikron\Factfinder\Api\Export\FieldInterface;
 use Omikron\Factfinder\Api\Export\DataProviderInterface;
 use Omikron\Factfinder\Api\Export\ExportEntityInterface;
@@ -19,6 +20,7 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
     public function __construct(
         protected Product $product,
         protected NumberFormatter $numberFormatter,
+        protected StockItem $stockItem,
         protected array $productFields = [],
     ) {}
 
@@ -48,7 +50,7 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
             'Short'         => (string) $this->product->getData('short_description'),
             'Deeplink'      => (string) $this->product->getUrlInStore(),
             'Price'         => $this->numberFormatter->format((float) $this->product->getFinalPrice()),
-            'Availability'  => (int) $this->product->isAvailable(),
+            'Availability'  => (int) $this->getAvailability(),
             'HasVariants'   => 0,
             'MagentoId'     => $this->getId(),
         ];
@@ -63,5 +65,16 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
     public function getProduct(): Product
     {
         return $this->product;
+    }
+
+    private function getAvailability(): bool
+    {
+        if ($this->product->hasData('is_salable')) {
+            return $this->product->isAvailable();
+        }
+
+        $quantity = $this->stockItem->get($this->product->getId());
+
+        return $quantity->getIsInStock();
     }
 }

--- a/src/Model/Export/Catalog/Products.php
+++ b/src/Model/Export/Catalog/Products.php
@@ -14,16 +14,13 @@ use Traversable;
 
 class Products implements \IteratorAggregate
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly ProductRepositoryInterface $productRepository,
         private readonly SearchCriteriaBuilder $searchCriteriaBuilder,
         private readonly StoreManagerInterface $storeManager,
         private readonly int $batchSize = 300,
-    ) {}
+    ) {
+    }
 
     /**
      * @return Traversable|ProductInterface[]

--- a/src/Model/Export/Category/Categories.php
+++ b/src/Model/Export/Category/Categories.php
@@ -14,15 +14,12 @@ use Traversable;
 
 class Categories implements IteratorAggregate
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly SearchCriteriaBuilder $searchCriteriaBuilder,
         private readonly StoreManagerInterface $storeManager,
         private readonly CategoryListInterface $categoryList,
-    ) {}
+    ) {
+    }
 
     /**
      * @return Traversable|CategoryInterface[]

--- a/src/Model/Export/Category/Category.php
+++ b/src/Model/Export/Category/Category.php
@@ -10,14 +10,11 @@ use Omikron\Factfinder\Api\Export\FieldInterface;
 
 class Category implements ExportEntityInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly CategoryInterface $category,
         private readonly array $categoryFields,
-    ) {}
+    ) {
+    }
 
     public function getId(): int
     {

--- a/src/Model/Export/Category/DataProvider.php
+++ b/src/Model/Export/Category/DataProvider.php
@@ -8,15 +8,12 @@ use Omikron\Factfinder\Api\Export\DataProviderInterface;
 
 class DataProvider implements DataProviderInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly Categories      $categories,
         private readonly CategoryFactory $categoryFactory,
         private readonly array           $fields
-    ) {}
+    ) {
+    }
 
     public function getEntities(): iterable
     {

--- a/src/Model/Export/Category/Field/ParentCategory.php
+++ b/src/Model/Export/Category/Field/ParentCategory.php
@@ -10,11 +10,9 @@ use Omikron\Factfinder\Model\Formatter\CategoryPathFormatter;
 
 class ParentCategory implements FieldInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly CategoryPathFormatter $categoryPathFormatter) {}
+    public function __construct(private readonly CategoryPathFormatter $categoryPathFormatter)
+    {
+    }
 
     public function getName(): string
     {

--- a/src/Model/Export/Cms/DataProvider.php
+++ b/src/Model/Export/Cms/DataProvider.php
@@ -9,15 +9,12 @@ use Omikron\Factfinder\Api\Export\ExportEntityInterface;
 
 class DataProvider implements DataProviderInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly Pages $pages,
         private readonly PageFactory $pageFactory,
         private readonly array $fields,
-    ) {}
+    ) {
+    }
 
     /**
      * @return ExportEntityInterface[]

--- a/src/Model/Export/Cms/Field/Content.php
+++ b/src/Model/Export/Cms/Field/Content.php
@@ -11,11 +11,9 @@ use Omikron\Factfinder\Api\Export\FieldInterface;
 
 class Content implements FieldInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly Filter $filter) {}
+    public function __construct(private readonly Filter $filter)
+    {
+    }
 
     public function getName(): string
     {

--- a/src/Model/Export/Cms/Field/Deeplink.php
+++ b/src/Model/Export/Cms/Field/Deeplink.php
@@ -12,14 +12,11 @@ use Magento\Framework\Model\AbstractModel;
 
 class Deeplink implements FieldInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly UrlInterface $urlBuilder,
         private readonly StoreManagerInterface $storeManager,
-    ) {}
+    ) {
+    }
 
     public function getName(): string
     {

--- a/src/Model/Export/Cms/Field/Image.php
+++ b/src/Model/Export/Cms/Field/Image.php
@@ -11,11 +11,9 @@ use Magento\Framework\Model\AbstractModel;
 
 class Image implements FieldInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly Filter $filter) {}
+    public function __construct(private readonly Filter $filter)
+    {
+    }
 
     public function getName(): string
     {

--- a/src/Model/Export/Cms/Page.php
+++ b/src/Model/Export/Cms/Page.php
@@ -10,14 +10,11 @@ use Omikron\Factfinder\Api\Export\FieldInterface;
 
 class Page implements ExportEntityInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly PageInterface $page,
         private readonly array $pageFields = [],
-    ) {}
+    ) {
+    }
 
     public function getId(): int
     {

--- a/src/Model/Export/Cms/Pages.php
+++ b/src/Model/Export/Cms/Pages.php
@@ -15,16 +15,13 @@ use Traversable;
 
 class Pages implements \IteratorAggregate
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly PageRepositoryInterface $pageRepository,
         private readonly SearchCriteriaBuilder   $searchCriteriaBuilder,
         private readonly CmsConfig               $cmsConfig,
         private readonly StoreManagerInterface   $storeManager,
-    ) {}
+    ) {
+    }
 
     /**
      * @return Traversable|PageInterface[]

--- a/src/Model/Export/Feed.php
+++ b/src/Model/Export/Feed.php
@@ -24,7 +24,8 @@ class Feed
         private readonly DataProviderInterface $dataProvider,
         private readonly array $fields,
         private readonly array $columns
-    ) {}
+    ) {
+    }
 
     public function generate(StreamInterface $stream): void
     {

--- a/src/Model/Export/FeedFactory.php
+++ b/src/Model/Export/FeedFactory.php
@@ -17,7 +17,8 @@ class FeedFactory
     public function __construct(
         private readonly ObjectManagerInterface $objectManager,
         private readonly array $feedPool
-    ) {}
+    ) {
+    }
 
     public function create(string $type, array $data = []): Feed
     {
@@ -29,7 +30,7 @@ class FeedFactory
         $fields = is_array($fieldProvider)
             ? $fieldProvider
             : call_user_func( //@phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
-                fn (FieldProviderInterface $fieldProvider) : array => $fieldProvider->getFields() + $fieldProvider->getVariantFields(),
+                fn (FieldProviderInterface $fieldProvider): array => $fieldProvider->getFields() + $fieldProvider->getVariantFields(),
                 $this->objectManager->create($fieldProvider)
             );
 

--- a/src/Model/Exporter.php
+++ b/src/Model/Exporter.php
@@ -11,11 +11,9 @@ use Omikron\Factfinder\Api\StreamInterface;
 
 class Exporter implements ExporterInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly FilterInterface $filter) {}
+    public function __construct(private readonly FilterInterface $filter)
+    {
+    }
 
     public function exportEntities(StreamInterface $stream, DataProviderInterface $dataProvider, array $columns): void
     {

--- a/src/Model/FieldRoles.php
+++ b/src/Model/FieldRoles.php
@@ -15,16 +15,13 @@ class FieldRoles
 {
     private const PATH_PRODUCT_FIELD_ROLE = 'factfinder/general/tracking_product_number_field_role';
 
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly SerializerInterface $serializer,
         private readonly ScopeConfigInterface $scopeConfig,
         private readonly ConfigResource $configResource,
         private readonly SimpleDataProviderFactory $dataProviderFactory
-    ) {}
+    ) {
+    }
 
     public function getFieldRoles(int $scopeId = null): array
     {

--- a/src/Model/Filesystem/Io/SftpPublicKeyAuth.php
+++ b/src/Model/Filesystem/Io/SftpPublicKeyAuth.php
@@ -16,14 +16,11 @@ use phpseclib3\Net\SFTP;
 
 class SftpPublicKeyAuth extends SftpBase
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly Filesystem $fileSystem,
         private readonly FtpConfig $uploadConfig,
-    ) {}
+    ) {
+    }
 
     public function open(array $args = [])
     {

--- a/src/Model/Formatter/CategoryPathFormatter.php
+++ b/src/Model/Formatter/CategoryPathFormatter.php
@@ -11,11 +11,9 @@ use Magento\Store\Model\Store;
 
 class CategoryPathFormatter
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly CategoryRepositoryInterface $categoryRepository) {}
+    public function __construct(private readonly CategoryRepositoryInterface $categoryRepository)
+    {
+    }
 
     public function format(int $categoryId, Store $store): string
     {

--- a/src/Model/SessionData.php
+++ b/src/Model/SessionData.php
@@ -12,15 +12,12 @@ use Omikron\Factfinder\Api\Config\ParametersSourceInterface;
 
 class SessionData implements SectionSourceInterface, ParametersSourceInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly CustomerSession      $customerSession,
         private readonly ScopeConfigInterface $scopeConfig,
         private readonly RemoteAddress        $remoteAddress,
-    ) {}
+    ) {
+    }
 
     public function getUserId(): string
     {

--- a/src/Model/Ssr/PriceFormatter.php
+++ b/src/Model/Ssr/PriceFormatter.php
@@ -11,15 +11,12 @@ use Omikron\FactFinder\Communication\Version;
 
 class PriceFormatter
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly CommunicationConfig $communicationConfig,
         private readonly PriceCurrencyInterface $priceCurrency,
         private readonly FieldRoles $fieldRoles,
-    ) {}
+    ) {
+    }
 
     public function format(array $searchResult): array
     {

--- a/src/Model/Ssr/SearchAdapter.php
+++ b/src/Model/Ssr/SearchAdapter.php
@@ -13,16 +13,13 @@ use Psr\Http\Message\ResponseInterface;
 
 class SearchAdapter
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly ClientBuilder $clientBuilder,
         private readonly CommunicationConfig $communicationConfig,
         private readonly CredentialsFactory $credentialsFactory,
         private readonly PriceFormatter $priceFormatter,
-    ) {}
+    ) {
+    }
 
     public function search(string $paramString, bool $navigationRequest): array
     {

--- a/src/Model/Ssr/Template/Engine.php
+++ b/src/Model/Ssr/Template/Engine.php
@@ -10,11 +10,9 @@ use Mustache_Engine as Mustache;
 
 class Engine implements TemplateEngineInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly Mustache $engine) {}
+    public function __construct(private readonly Mustache $engine)
+    {
+    }
 
     public function render(BlockInterface $block, $templateFile, array $dictionary = [])
     {

--- a/src/Model/Ssr/Template/Filter.php
+++ b/src/Model/Ssr/Template/Filter.php
@@ -9,11 +9,9 @@ use Omikron\Factfinder\Model\FieldRoles;
 
 class Filter implements FilterInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly FieldRoles $fieldRoles) {}
+    public function __construct(private readonly FieldRoles $fieldRoles)
+    {
+    }
 
     public function filterValue(string $value): string
     {

--- a/src/Model/Ssr/Template/Loader.php
+++ b/src/Model/Ssr/Template/Loader.php
@@ -10,14 +10,11 @@ use Omikron\Factfinder\Api\Filter\FilterInterface;
 
 class Loader implements Mustache_Loader
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly Mustache_Loader $loader,
         private readonly FilterInterface $filter,
-    ) {}
+    ) {
+    }
 
     /**
      * @inheritDoc

--- a/src/Model/Stream/Csv.php
+++ b/src/Model/Stream/Csv.php
@@ -15,14 +15,11 @@ class Csv implements StreamInterface
 {
     private ?WriteInterface $stream;
 
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly Filesystem $filesystem,
         private readonly string     $filename = 'factfinder/export.csv'
-    ) {}
+    ) {
+    }
 
     /**
      * @param array $entity

--- a/src/Model/Stream/Stdout.php
+++ b/src/Model/Stream/Stdout.php
@@ -10,11 +10,9 @@ use Omikron\Factfinder\Api\StreamInterface;
 
 class Stdout implements StreamInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly DriverInterface $file) {}
+    public function __construct(private readonly DriverInterface $file)
+    {
+    }
 
     public function addEntity(array $entity): void
     {

--- a/src/Observer/CategoryView.php
+++ b/src/Observer/CategoryView.php
@@ -12,14 +12,11 @@ use Omikron\Factfinder\Model\Config\FeatureConfig;
 
 class CategoryView implements ObserverInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly Registry $registry,
         private readonly FeatureConfig $config,
-    ) {}
+    ) {
+    }
 
     public function execute(Observer $observer)
     {

--- a/src/Observer/ExportAuthentication.php
+++ b/src/Observer/ExportAuthentication.php
@@ -16,15 +16,12 @@ use Omikron\Factfinder\Model\Export\BasicAuth as Authentication;
  */
 class ExportAuthentication implements ObserverInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly ActionFlag     $actionFlag,
         private readonly Authentication $authentication,
         private readonly Credentials    $credentials,
-    ) {}
+    ) {
+    }
 
     public function execute(Observer $observer)
     {

--- a/src/Observer/RedirectSearch.php
+++ b/src/Observer/RedirectSearch.php
@@ -13,15 +13,12 @@ use Omikron\Factfinder\Model\Config\CommunicationConfig;
 
 class RedirectSearch implements ObserverInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly RedirectInterface $redirect,
         private readonly ResponseInterface $response,
         private readonly CommunicationConfig $config,
-    ) {}
+    ) {
+    }
 
     public function execute(Observer $observer)
     {

--- a/src/Observer/Ssr.php
+++ b/src/Observer/Ssr.php
@@ -11,14 +11,11 @@ use Magento\Store\Model\ScopeInterface;
 
 class Ssr implements ObserverInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly ScopeConfigInterface $scopeConfig,
         private readonly array $useForHandles = ['factfinder_result_index', 'factfinder_category_view'],
-    ) {}
+    ) {
+    }
 
     public function execute(Observer $observer)
     {

--- a/src/Plugin/AnonymizeUserId.php
+++ b/src/Plugin/AnonymizeUserId.php
@@ -12,11 +12,9 @@ class AnonymizeUserId
 {
     private const PATH_ANONYMIZE_USER_ID = 'factfinder/advanced/anonymize_user_id';
 
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly ScopeConfigInterface $scopeConfig) {}
+    public function __construct(private readonly ScopeConfigInterface $scopeConfig)
+    {
+    }
 
     /**
      * @param SessionData $_

--- a/src/Plugin/LogExceptions.php
+++ b/src/Plugin/LogExceptions.php
@@ -12,14 +12,11 @@ use Psr\Log\LoggerInterface;
 
 class LogExceptions
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly ScopeConfigInterface $scopeConfig,
         private readonly LoggerInterface $logger,
-    ) {}
+    ) {
+    }
 
     /**
      * @param PushImport $subject

--- a/src/Plugin/MapFieldRoles.php
+++ b/src/Plugin/MapFieldRoles.php
@@ -10,11 +10,9 @@ use Omikron\Factfinder\Model\FieldRoles;
 
 class MapFieldRoles
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly CommunicationConfig $communicationConfig) {}
+    public function __construct(private readonly CommunicationConfig $communicationConfig)
+    {
+    }
 
     /**
      * @param FieldRoles $subject

--- a/src/Service/FeedFileService.php
+++ b/src/Service/FeedFileService.php
@@ -6,7 +6,7 @@ namespace Omikron\Factfinder\Service;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem;
-use \InvalidArgumentException;
+use InvalidArgumentException;
 
 class FeedFileService
 {
@@ -16,7 +16,9 @@ class FeedFileService
      * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
      * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
      */
-    public function __construct(private readonly Filesystem $fileSystem) {}
+    public function __construct(private readonly Filesystem $fileSystem)
+    {
+    }
 
     public function getFeedExportFilename(string $exportType, string $channel): string
     {

--- a/src/Test/Integration/_files/ng_search_response.php
+++ b/src/Test/Integration/_files/ng_search_response.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 return '{
    "records":[

--- a/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Export\Catalog\Entity;
 
 use Magento\Catalog\Model\Product;
+use Magento\CatalogInventory\Api\Data\StockItemInterface;
 use Magento\CatalogInventory\Model\Stock\StockItemRepository;
 use Magento\Framework\Model\AbstractModel;
 use Omikron\Factfinder\Model\Export\Catalog\FieldProvider;
@@ -52,7 +53,12 @@ class ProductVariationTest extends TestCase
             $this->createMock(Product::class),
             new NumberFormatter(),
             $fieldProviderMock,
-            $this->createMock(StockItemRepository::class),
+            $this->createConfiguredMock(StockItemRepository::class, [
+                'get' => $this->createConfiguredMock(
+                    StockItemInterface::class, [
+                        'getIsInStock' => true
+                ])
+            ]),
             $this->configurableProductData
         );
 
@@ -91,6 +97,12 @@ class ProductVariationTest extends TestCase
             $this->createMock(Product::class),
             new NumberFormatter(),
             $fieldProviderMock,
+            $this->createConfiguredMock(StockItemRepository::class, [
+                'get' => $this->createConfiguredMock(
+                    StockItemInterface::class, [
+                    'getIsInStock' => true
+                ])
+            ]),
             ['FilterAttributes' => '|Color=Red|Size=XS|'] + $this->configurableProductData
         );
 

--- a/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Export\Catalog\Entity;
 
 use Magento\Catalog\Model\Product;
+use Magento\CatalogInventory\Model\Stock\StockItemRepository;
 use Magento\Framework\Model\AbstractModel;
 use Omikron\Factfinder\Model\Export\Catalog\FieldProvider;
 use Omikron\Factfinder\Model\Export\Catalog\ProductField\FilterAttributes;
@@ -51,6 +52,7 @@ class ProductVariationTest extends TestCase
             $this->createMock(Product::class),
             new NumberFormatter(),
             $fieldProviderMock,
+            $this->createMock(StockItemRepository::class),
             $this->configurableProductData
         );
 

--- a/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
@@ -6,6 +6,8 @@ namespace Omikron\Factfinder\Model\Export\Catalog\ProductType;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
+use Magento\CatalogInventory\Api\Data\StockItemInterface;
+use Magento\CatalogInventory\Model\Stock\StockItemRepository;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableProductType;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Omikron\Factfinder\Api\Filter\FilterInterface;
@@ -111,7 +113,13 @@ class ConfigurableDataProviderTest extends TestCase
             $this->filterMock,
             $this->variantFactoryMock,
             $this->repositoryMock,
-            $this->builderMock
+            $this->builderMock,
+            $this->createConfiguredMock(StockItemRepository::class, [
+                'get' => $this->createConfiguredMock(
+                    StockItemInterface::class, [
+                    'getIsInStock' => true
+                ])
+            ]),
         );
     }
 }

--- a/src/Test/Unit/Model/Export/Catalog/ProductsTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/ProductsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Omikron\Factfinder\Test\Unit\Model\Export\Category;

--- a/src/Test/Unit/Model/Export/Category/CategoriesTest.php
+++ b/src/Test/Unit/Model/Export/Category/CategoriesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Omikron\Factfinder\Test\Unit\Model\Export\Category;

--- a/src/Test/Unit/Plugin/MapFieldRolesTest.php
+++ b/src/Test/Unit/Plugin/MapFieldRolesTest.php
@@ -34,7 +34,7 @@ class MapFieldRolesTest extends TestCase
     public function test_it_will_map_field_roles_in_ng()
     {
         $this->configMock->method('getVersion')->willReturn('ng');
-        $callbackMock = fn(array $fieldRoles, int $storeId) => $this->assertArrayHasKey('masterArticleNumber', $fieldRoles);
+        $callbackMock = fn (array $fieldRoles, int $storeId) => $this->assertArrayHasKey('masterArticleNumber', $fieldRoles);
         $this->plugin->aroundSaveFieldRoles($this->createMock(FieldRoles::class), $callbackMock, $this->fieldRoles, 1);
     }
 

--- a/src/Test/Unit/Service/FeedFileServiceTest.php
+++ b/src/Test/Unit/Service/FeedFileServiceTest.php
@@ -5,7 +5,7 @@ namespace Omikron\Factfinder\Test\Unit\Service;
 use Magento\Framework\Filesystem;
 use Omikron\Factfinder\Service\FeedFileService;
 use PHPUnit\Framework\TestCase;
-use \InvalidArgumentException;
+use InvalidArgumentException;
 
 /**
  * @covers FeedFileService

--- a/src/Test/Unit/ViewModel/CartTest.php
+++ b/src/Test/Unit/ViewModel/CartTest.php
@@ -24,7 +24,7 @@ class CartTest extends TestCase
     protected function setUp(): void
     {
         $quoteItems = array_map(
-            fn (string $sku): Quote\Item =>$this->createConfiguredMock(Quote\Item::class, ['getProduct' => new DataObject(['sku' => $sku])]),
+            fn (string $sku): Quote\Item => $this->createConfiguredMock(Quote\Item::class, ['getProduct' => new DataObject(['sku' => $sku])]),
             ['foo', 'bar', 'baz']
         );
 

--- a/src/Utilities/Validator/ExportPreviewValidator.php
+++ b/src/Utilities/Validator/ExportPreviewValidator.php
@@ -13,15 +13,12 @@ use Omikron\Factfinder\Exception\ExportPreviewValidationException;
 
 class ExportPreviewValidator implements ValidatorInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly ProductRepositoryInterface $productRepository,
         private readonly ConfigurableType           $configurableType,
         private readonly int                        $entityId,
-    ) {}
+    ) {
+    }
 
     public function validate(): void
     {

--- a/src/ViewModel/Cart.php
+++ b/src/ViewModel/Cart.php
@@ -11,11 +11,9 @@ use Magento\Quote\Model\Quote\Item as QuoteItem;
 
 class Cart implements ArgumentInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
-    public function __construct(private readonly Session $checkoutSession) {}
+    public function __construct(private readonly Session $checkoutSession)
+    {
+    }
 
     /**
      * @return QuoteItem[]

--- a/src/ViewModel/CategoryPath.php
+++ b/src/ViewModel/CategoryPath.php
@@ -12,16 +12,13 @@ use Omikron\Factfinder\Model\Config\CommunicationConfig;
 
 class CategoryPath implements ArgumentInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly Registry            $registry,
         private readonly CommunicationConfig $communicationConfig,
         private readonly string              $param = 'CategoryPath',
         private readonly array               $initial = [],
-    ) {}
+    ) {
+    }
 
     public function __toString()
     {

--- a/src/ViewModel/Order.php
+++ b/src/ViewModel/Order.php
@@ -12,14 +12,11 @@ use Omikron\Factfinder\Model\Config\CommunicationConfig;
 
 class Order implements ArgumentInterface
 {
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly Session $checkoutSession,
         private readonly CommunicationConfig $communicationConfig,
-    ) {}
+    ) {
+    }
 
     /**
      * @return OrderItem[]

--- a/src/ViewModel/ProductBasedComponent.php
+++ b/src/ViewModel/ProductBasedComponent.php
@@ -16,16 +16,13 @@ class ProductBasedComponent implements ArgumentInterface
     private const PATH_SHOW_ADD_TO_CART_BUTTON = 'factfinder/general/show_add_to_cart_button';
     private const PATH_MAX_RESULT = 'factfinder/components_options/max_results_';
 
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly Image                $imageHelper,
         private readonly ScopeConfigInterface $scopeConfig,
         private readonly UrlInterface         $urlBuilder,
         private readonly Registry             $registry,
-    ) {}
+    ) {
+    }
 
     public function getProduct(): ProductInterface
     {

--- a/src/ViewModel/ProductsPerPage.php
+++ b/src/ViewModel/ProductsPerPage.php
@@ -13,14 +13,11 @@ class ProductsPerPage implements ArgumentInterface
 {
     private const PRODUCT_PER_PAGE_CONFIG_PATH = 'factfinder/components_options/products_per_page';
 
-    /**
-     * phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
-     * phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-     */
     public function __construct(
         private readonly ScopeConfigInterface $scopeConfig,
         private readonly Json $serializer
-    ) {}
+    ) {
+    }
 
     public function getProductsPerPageConfiguration(): string
     {

--- a/src/view/frontend/templates/ff/campaign-landing-page.phtml
+++ b/src/view/frontend/templates/ff/campaign-landing-page.phtml
@@ -1,7 +1,7 @@
 <?php
-/** @var Magento\Framework\View\Element\Template $block */
+/** @var Magento\Framework\Escaper $escaper */
 $objectManagerCms = \Magento\Framework\App\ObjectManager::getInstance();
-$cmsPage = $objectManagerCms->get('\Magento\Cms\Model\Page');
+$cmsPage = $objectManagerCms->get(\Magento\Cms\Model\Page::class);
 ?>
 
-<ff-campaign-landing-page page-id="<?=  $cmsPage->getIdentifier() ?>"></ff-campaign-landing-page>
+<ff-campaign-landing-page page-id="<?= $escaper->escapeHtml($cmsPage->getIdentifier()) ?>"></ff-campaign-landing-page>


### PR DESCRIPTION
- Solves issue: 
    - FFWEB-2963
- Description:
    - Fix availability column data for UI export type
- Tested with Magento editions/versions:
    - For example: 2.4.6
- Tested with PHP versions:
    - For example: 8.1
