### PR TITLE
FFWEB-3032: Support MSI - checking all inventory sources for export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+### Fix
+- Support MSI - checking all inventory sources during export feed
+- Fix feed path for UI export type
+
 ## [v4.3.2] - 2024.04.12
 ### Fix
 - Handle export problem for Multi Source Inventory module

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "magento/module-configurable-product": "~100.4.4",
     "magento/module-directory": "~100.4.4",
     "magento/module-store": "~101.1.4",
+    "magento/module-inventory": "1.2.*",
     "mustache/mustache": "^2.13",
     "ext-json": "*"
   },

--- a/src/Controller/Adminhtml/Export/Feed.php
+++ b/src/Controller/Adminhtml/Export/Feed.php
@@ -90,7 +90,7 @@ class Feed extends Action
                 $path     = $this->feedFileService->getExportPath($filename);
 
                 $this->feedGeneratorFactory->create($this->feedType)->generate($stream);
-                $messages[] = __('<li>Feed file for channel %1 has been generated under %2</li>', $channel, "$path/$filename");
+                $messages[] = __('<li>Feed file for channel %1 has been generated under %2</li>', $channel, $path);
 
                 try {
                     $this->ftpUploader->upload($filename, $stream);

--- a/src/Model/Export/Catalog/Entity/ProductVariation.php
+++ b/src/Model/Export/Catalog/Entity/ProductVariation.php
@@ -93,7 +93,7 @@ class ProductVariation implements ExportEntityInterface
 
         $sourceItems = $this->getSourceItemsBySku->execute($this->product->getSku());
 
-        foreach ($sourceItems as $sourceItemId => $sourceItem) {
+        foreach ($sourceItems as $sourceItem) {
             if ($sourceItem->getStatus()) {
                 return true;
             }

--- a/src/Model/Export/Catalog/Entity/ProductVariation.php
+++ b/src/Model/Export/Catalog/Entity/ProductVariation.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Export\Catalog\Entity;
 
 use Magento\Catalog\Model\Product;
-use Magento\CatalogInventory\Model\Stock\StockItemRepository as StockItem;
+use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
 use Omikron\Factfinder\Api\Export\ExportEntityInterface;
 use Omikron\Factfinder\Api\Export\FieldInterface;
 use Omikron\Factfinder\Model\Export\Catalog\FieldProvider;
@@ -20,14 +20,14 @@ class ProductVariation implements ExportEntityInterface
 
     /** @var string[] */
     private array $configurableData;
-    private StockItem $stockItem;
+    private GetSourceItemsBySku $getSourceItemsBySku;
 
     public function __construct(
         Product $product,
         Product $configurable,
         NumberFormatter $numberFormatter,
         FieldProvider $variantFieldProvider,
-        StockItem $stockItem,
+        GetSourceItemsBySku $getSourceItemsBySku,
         array $data = []
     ) {
         $this->product          = $product;
@@ -35,7 +35,7 @@ class ProductVariation implements ExportEntityInterface
         $this->numberFormatter  = $numberFormatter;
         $this->configurableData = $data;
         $this->fieldprovider    = $variantFieldProvider;
-        $this->stockItem = $stockItem;
+        $this->getSourceItemsBySku = $getSourceItemsBySku;
     }
 
     public function getId(): int
@@ -91,12 +91,14 @@ class ProductVariation implements ExportEntityInterface
             return $this->product->isAvailable();
         }
 
-        try {
-            $quantity = $this->stockItem->get($this->product->getId());
+        $sourceItems = $this->getSourceItemsBySku->execute($this->product->getSku());
 
-            return (bool) $quantity->getIsInStock();
-        } catch (\Exception $e) {
-            return $this->product->isAvailable();
+        foreach ($sourceItems as $sourceItemId => $sourceItem) {
+            if ($sourceItem->getStatus()) {
+                return true;
+            }
         }
+
+        return false;
     }
 }

--- a/src/Model/Export/Catalog/ProductType/BundleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/BundleDataProvider.php
@@ -6,8 +6,8 @@ namespace Omikron\Factfinder\Model\Export\Catalog\ProductType;
 
 use Magento\Bundle\Model\Product\CatalogPrice;
 use Magento\Catalog\Model\Product;
-use Magento\CatalogInventory\Model\Stock\StockItemRepository as StockItem;
 use Magento\Directory\Model\PriceCurrency;
+use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 
 class BundleDataProvider extends SimpleDataProvider
@@ -17,10 +17,10 @@ class BundleDataProvider extends SimpleDataProvider
         protected NumberFormatter $numberFormatter,
         private readonly PriceCurrency     $priceCurrency,
         private readonly CatalogPrice      $priceModel,
-        StockItem $stockItem,
+        protected GetSourceItemsBySku $getSourceItemsBySku,
         protected array             $productFields = []
     ) {
-        parent::__construct($product, $numberFormatter, $stockItem, $productFields);
+        parent::__construct($product, $numberFormatter, $getSourceItemsBySku, $productFields);
     }
 
     public function toArray(): array

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -7,9 +7,9 @@ namespace Omikron\Factfinder\Model\Export\Catalog\ProductType;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
-use Magento\CatalogInventory\Model\Stock\StockItemRepository as StockItem;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableProductType;
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
 use Omikron\Factfinder\Api\Export\ExportEntityInterface;
 use Omikron\Factfinder\Api\Filter\FilterInterface;
 use Omikron\Factfinder\Model\Export\Catalog\Entity\ProductVariationFactory;
@@ -25,10 +25,10 @@ class ConfigurableDataProvider extends SimpleDataProvider
         private readonly ProductVariationFactory    $variationFactory,
         private readonly ProductRepositoryInterface $productRepository,
         private readonly SearchCriteriaBuilder      $builder,
-        StockItem $stockItem,
+        protected GetSourceItemsBySku $getSourceItemsBySku,
         protected array                    $productFields = []
     ) {
-        parent::__construct($product, $numberFormatter, $stockItem, $productFields);
+        parent::__construct($product, $numberFormatter, $getSourceItemsBySku, $productFields);
     }
 
     public function getEntities(): iterable

--- a/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
@@ -72,7 +72,7 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
 
         $sourceItems = $this->getSourceItemsBySku->execute($this->product->getSku());
 
-        foreach ($sourceItems as $sourceItemId => $sourceItem) {
+        foreach ($sourceItems as $sourceItem) {
             if ($sourceItem->getStatus()) {
                 return true;
             }

--- a/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Export\Catalog\ProductType;
 
 use Magento\Catalog\Model\Product;
-use Magento\CatalogInventory\Model\Stock\StockItemRepository as StockItem;
+use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
 use Omikron\Factfinder\Api\Export\FieldInterface;
 use Omikron\Factfinder\Api\Export\DataProviderInterface;
 use Omikron\Factfinder\Api\Export\ExportEntityInterface;
@@ -16,7 +16,7 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
     public function __construct(
         protected Product $product,
         protected NumberFormatter $numberFormatter,
-        protected StockItem $stockItem,
+        protected GetSourceItemsBySku $getSourceItemsBySku,
         protected array $productFields = [],
     ) {
     }
@@ -70,12 +70,14 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
             return $this->product->isAvailable();
         }
 
-        try {
-            $quantity = $this->stockItem->get($this->product->getId());
+        $sourceItems = $this->getSourceItemsBySku->execute($this->product->getSku());
 
-            return (bool) $quantity->getIsInStock();
-        } catch (\Exception $e) {
-            return $this->product->isAvailable();
+        foreach ($sourceItems as $sourceItemId => $sourceItem) {
+            if ($sourceItem->getStatus()) {
+                return true;
+            }
         }
+
+        return false;
     }
 }

--- a/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
@@ -8,6 +8,8 @@ use Magento\Catalog\Model\Product;
 use Magento\CatalogInventory\Api\Data\StockItemInterface;
 use Magento\CatalogInventory\Model\Stock\StockItemRepository;
 use Magento\Framework\Model\AbstractModel;
+use Magento\Inventory\Model\SourceItem;
+use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
 use Omikron\Factfinder\Model\Export\Catalog\FieldProvider;
 use Omikron\Factfinder\Model\Export\Catalog\ProductField\FilterAttributes;
 use Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage;
@@ -48,16 +50,16 @@ class ProductVariationTest extends TestCase
             ]
         );
 
+        $sourceItems = [1 => $this->createConfiguredMock(SourceItem::class, ['getStatus' => 1])];
+//        $sourceItems = [];
+
         $productVariation = new ProductVariation(
             $this->variantMock,
             $this->createMock(Product::class),
             new NumberFormatter(),
             $fieldProviderMock,
-            $this->createConfiguredMock(StockItemRepository::class, [
-                'get' => $this->createConfiguredMock(
-                    StockItemInterface::class, [
-                        'getIsInStock' => true
-                ])
+            $this->createConfiguredMock(GetSourceItemsBySku::class, [
+                'execute' => $sourceItems
             ]),
             $this->configurableProductData
         );

--- a/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Export\Catalog\Entity;
 
 use Magento\Catalog\Model\Product;
-use Magento\CatalogInventory\Api\Data\StockItemInterface;
-use Magento\CatalogInventory\Model\Stock\StockItemRepository;
 use Magento\Framework\Model\AbstractModel;
 use Magento\Inventory\Model\SourceItem;
 use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
@@ -50,16 +48,13 @@ class ProductVariationTest extends TestCase
             ]
         );
 
-        $sourceItems = [1 => $this->createConfiguredMock(SourceItem::class, ['getStatus' => 1])];
-//        $sourceItems = [];
-
         $productVariation = new ProductVariation(
             $this->variantMock,
             $this->createMock(Product::class),
             new NumberFormatter(),
             $fieldProviderMock,
             $this->createConfiguredMock(GetSourceItemsBySku::class, [
-                'execute' => $sourceItems
+                'execute' => [$this->createConfiguredMock(SourceItem::class, ['getStatus' => 1])]
             ]),
             $this->configurableProductData
         );
@@ -99,11 +94,8 @@ class ProductVariationTest extends TestCase
             $this->createMock(Product::class),
             new NumberFormatter(),
             $fieldProviderMock,
-            $this->createConfiguredMock(StockItemRepository::class, [
-                'get' => $this->createConfiguredMock(
-                    StockItemInterface::class, [
-                    'getIsInStock' => true
-                ])
+            $this->createConfiguredMock(GetSourceItemsBySku::class, [
+                'execute' => [$this->createConfiguredMock(SourceItem::class, ['getStatus' => 1])]
             ]),
             ['FilterAttributes' => '|Color=Red|Size=XS|'] + $this->configurableProductData
         );

--- a/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
@@ -6,10 +6,10 @@ namespace Omikron\Factfinder\Model\Export\Catalog\ProductType;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
-use Magento\CatalogInventory\Api\Data\StockItemInterface;
-use Magento\CatalogInventory\Model\Stock\StockItemRepository;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableProductType;
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Inventory\Model\SourceItem;
+use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
 use Omikron\Factfinder\Api\Filter\FilterInterface;
 use Omikron\Factfinder\Model\Export\Catalog\Entity\ProductVariationFactory;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
@@ -114,11 +114,8 @@ class ConfigurableDataProviderTest extends TestCase
             $this->variantFactoryMock,
             $this->repositoryMock,
             $this->builderMock,
-            $this->createConfiguredMock(StockItemRepository::class, [
-                'get' => $this->createConfiguredMock(
-                    StockItemInterface::class, [
-                    'getIsInStock' => true
-                ])
+            $this->createConfiguredMock(GetSourceItemsBySku::class, [
+                'execute' => [$this->createConfiguredMock(SourceItem::class, ['getStatus' => 1])]
             ]),
         );
     }


### PR DESCRIPTION
- Solves issue:
    - FFWEB-3032
- Description:
    - Support MSI - checking all inventory sources during export feed
- Tested with Magento editions/versions:
    - For example: 2.4.6
- Tested with PHP versions:
    - For example: 8.1
