### PR TITLE
FFWEB-3043: Fix displaying add to cart button

### DIFF
--- a/src/view/frontend/templates/ff/record-list.phtml
+++ b/src/view/frontend/templates/ff/record-list.phtml
@@ -29,7 +29,6 @@ $isSearchRequest = (bool) $block->getData('is_search_request');
                     </div>
 
                     <?php if ($viewModel->isAddToCartEnabled()): ?>
-                        {{^masterValues.HasVariants}}
                         <div class="product-item-inner">
                             <div class="product actions product-item-actions">
                                 <div class="actions-primary">
@@ -43,8 +42,8 @@ $isSearchRequest = (bool) $block->getData('is_search_request');
                                 </div>
                             </div>
                         </div>
-                        {{/masterValues.HasVariants}}
                     <?php endif; ?>
+
                 </div>
             </div>
         </ff-record>


### PR DESCRIPTION
- Solves issue:
    - Issue or task number/code, for example: FFWEB-3043
- Description:
    - Fix displaying add to cart button
- Tested with Magento editions/versions:
    - For example: 2.4.7
- Tested with PHP versions:
    - For example: 8.3
