### PR TITLE
FFWEB-3055: initialSearch implementation

### DIFF
--- a/src/view/frontend/layout/default.xml
+++ b/src/view/frontend/layout/default.xml
@@ -6,14 +6,12 @@
             <arguments>
                 <argument name="subscribe" xsi:type="boolean">true</argument>
                 <argument name="view_model" xsi:type="object">Omikron\Factfinder\ViewModel\ProductBasedComponent</argument>
-                <argument name="is_search_request" xsi:type="boolean">true</argument>
             </arguments>
         </block>
         <block class="Magento\Framework\View\Element\Template" name="factfinder.recordlist.unsubscribed" template="Omikron_Factfinder::ff/record-list.phtml">
             <arguments>
                 <argument name="subscribe" xsi:type="boolean">false</argument>
                 <argument name="view_model" xsi:type="object">Omikron\Factfinder\ViewModel\ProductBasedComponent</argument>
-                <argument name="is_search_request" xsi:type="boolean">false</argument>
             </arguments>
         </block>
 

--- a/src/view/frontend/layout/factfinder_category_view.xml
+++ b/src/view/frontend/layout/factfinder_category_view.xml
@@ -20,6 +20,7 @@
                 <argument name="communication_parameters" xsi:type="array">
                     <item name="add-params" xsi:type="helper" helper="Omikron\Factfinder\ViewModel\CategoryPath::getAddParams" />
                     <item name="category-page" xsi:type="helper" helper="Omikron\Factfinder\ViewModel\CategoryPath::getCategoryPath" />
+                    <item name="search-immediate" xsi:type="string">false</item>
                 </argument>
             </arguments>
         </referenceBlock>

--- a/src/view/frontend/templates/ff/communication.phtml
+++ b/src/view/frontend/templates/ff/communication.phtml
@@ -5,11 +5,12 @@
 $viewModel  = $block->getViewModel();
 $communicationParameters = (array) $block->getData('communication_parameters');
 $parameters = $viewModel->getParameters($communicationParameters);
+$searchImmediate = $communicationParameters['search-immediate'] ?? 'false';
 ?>
 
-<!--Init webcomponents-->
+<!--Main FF Web-components Initialisation -->
 <script>
-    document.addEventListener(`ffCoreReady`, ({ factfinder }) => {
+    document.addEventListener(`ffCoreReady`, ({ factfinder, initialSearch }) => {
         //Debug webc
         factfinder.config.debug = true;
 
@@ -28,6 +29,11 @@ $parameters = $viewModel->getParameters($communicationParameters);
         };
 
         // This is also the best place to invoke a search request replacing the `search-immediate` attribute.
+
+        if (<?= /** @SuppressWarnings(PHPMD) */ $searchImmediate ?>){
+            const searchParams = factfinder.utils.env.searchParamsFromUrl();
+            initialSearch(searchParams, { requestOptions: { origin: `initialSearch` } });
+        }
 
         factfinder.request.before.search(({ searchParams, searchOptions }) => {
             // If the search request was invoked by `ff-searchbox`, `searchOptions.requestOptions.origin` will be a reference to the `ff-searchbox` element.
@@ -113,8 +119,5 @@ $parameters = $viewModel->getParameters($communicationParameters);
 <!--            }-->
 <!--        }-->
 <!---->
-<!--        if (--><?php //= /** @SuppressWarnings(PHPMD) */ $searchImmediate ?>
-<!--//            searchImmediate();-->
-<!--//        }-->
 <!--//    });-->
 <!--//</script>-->

--- a/src/view/frontend/templates/ff/record-list.phtml
+++ b/src/view/frontend/templates/ff/record-list.phtml
@@ -3,7 +3,6 @@
 /** @var Magento\Framework\View\Element\Template $block */
 /** @var Omikron\Factfinder\ViewModel\ProductBasedComponent $viewModel */
 $viewModel = $block->getViewModel();
-$isSearchRequest = (bool) $block->getData('is_search_request');
 ?>
 <div class="products wrapper grid products-grid">
     <ff-record-list class="products list items product-items"
@@ -51,17 +50,6 @@ $isSearchRequest = (bool) $block->getData('is_search_request');
         </template>
     </ff-record-list>
 </div>
-
-<?php if ($isSearchRequest && !$viewModel->isSsrEnable()): ?>
-    <script>
-        // Execute search request
-        document.addEventListener(`ffCoreReady`, ({ factfinder }) => {
-            const urlParams = new URLSearchParams(window.location.search);
-            const query = urlParams.get('query');
-            factfinder.request.search({ query: query }, { requestOptions: { origin: `searchImmediately` } });
-        });
-    </script>
-<?php endif; ?>
 
 <script>
     require(['jquery', 'underscore', 'catalogAddToCart'], function ($, _) {


### PR DESCRIPTION
- Solves issue:
    - FFWEB-3055:
- Description:
    - initialSearch implementation for all cases: search, category page, ssr
- Tested with Magento editions/versions:
    - For example: 2.4.6
- Tested with PHP versions:
    - For example: 8.1
