### PR TITLE
FFWEB-3059: Remove deprecated routing parameters

### DIFF
--- a/src/Model/Config/Communication/BehaviourConfig.php
+++ b/src/Model/Config/Communication/BehaviourConfig.php
@@ -7,17 +7,11 @@ namespace Omikron\Factfinder\Model\Config\Communication;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
 use Omikron\Factfinder\Api\Config\ParametersSourceInterface;
-use Omikron\FactFinder\Communication\Version;
 
 class BehaviourConfig implements ParametersSourceInterface
 {
-    private const PATH_USE_URL_PARAMETER   = 'factfinder/advanced/use_url_parameter';
     private const PATH_ADD_PARAMS          = 'factfinder/advanced/add_params';
-    private const PATH_ADD_TRACKING_PARAMS = 'factfinder/advanced/add_tracking_params';
-    private const PATH_KEEP_URL_PARAMS     = 'factfinder/advanced/keep_url_param';
-    private const PATH_ONLY_SEARCH_PARAMS  = 'factfinder/advanced/only_search_params';
     private const PATH_PARAMETER_WHITELIST = 'factfinder/advanced/parameter_whitelist';
-    private const PATH_VERSION              = 'factfinder/general/version';
 
     private ScopeConfigInterface $scopeConfig;
 
@@ -29,33 +23,15 @@ class BehaviourConfig implements ParametersSourceInterface
     public function getParameters(): array
     {
         $parameters = [
-            'use-url-parameters'          => $this->getFlag(self::PATH_USE_URL_PARAMETER),
-            'add-params'                  => $this->getConfig(self::PATH_ADD_PARAMS),
-            'add-tracking-params'         => $this->getConfig(self::PATH_ADD_TRACKING_PARAMS),
-            'keep-url-params'             => $this->getConfig(self::PATH_KEEP_URL_PARAMS),
-            'only-search-params'          => $this->getFlag(self::PATH_ONLY_SEARCH_PARAMS),
-            'parameter-whitelist'         => $this->getConfig(self::PATH_PARAMETER_WHITELIST),
+            'add-params'                  => $this->getConfig(self::PATH_ADD_PARAMS), // postStringifier
+            'parameter-whitelist'         => $this->getConfig(self::PATH_PARAMETER_WHITELIST), // allow setUrlParamOptionsListener
         ];
 
-        if ($this->getVersion() === Version::NG) {
-            $parameters['category-page'] = '';
-        }
-
         return $parameters;
-    }
-
-    public function getVersion(): string
-    {
-        return (string) $this->scopeConfig->getValue(self::PATH_VERSION, ScopeInterface::SCOPE_STORES);
     }
 
     private function getConfig(string $path): string
     {
         return (string) $this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORES);
-    }
-
-    private function getFlag(string $path): string
-    {
-        return $this->scopeConfig->isSetFlag($path, ScopeInterface::SCOPE_STORES) ? 'true' : 'false';
     }
 }

--- a/src/ViewModel/Communication.php
+++ b/src/ViewModel/Communication.php
@@ -24,8 +24,6 @@ class Communication implements ArgumentInterface
         private readonly ScopeConfigInterface            $scopeConfig,
         array $mergeableParams = [
             'add-params',
-            'add-tracking-params',
-            'keep-url-params',
             'parameter-whitelist'
         ],
     ) {
@@ -39,6 +37,7 @@ class Communication implements ArgumentInterface
         }
 
         $params = $this->parametersProvider->getParameters();
+
         return ['version' => $params['version'] ?? 'ng']
             + array_filter($this->mergeParameters($blockParams, $params) + $blockParams + $params, 'boolval');
     }

--- a/src/etc/adminhtml/system/advanced.xml
+++ b/src/etc/adminhtml/system/advanced.xml
@@ -8,16 +8,6 @@
             <tooltip>Comma-separated value</tooltip>
             <comment>Requests from these IPs will be excluded from your license plan</comment>
         </field>
-        <field id="use_url_parameter" translate="label comment" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Use URL parameters?</label>
-            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <comment>If set to true, the http parameters of the current search are pushed to the browser url.</comment>
-        </field>
-        <field id="only_search_params" translate="label comment" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Only search parameters?</label>
-            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <comment>If present, URL parameters like 'channel' and 'sid' are omitted in the URL. This can be used in conjunction with parameter-whitelist</comment>
-        </field>
         <field id="parameter_whitelist" translate="label comment tooltip" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Parameter whitelist</label>
             <comment>If any URL parameters are omitted through other attributes like use-url-parameter="false" or only-search-params you can add specific important parameters manually. Just use a comma separated list like: parameter-whitelist="param1,myParam"</comment>
@@ -26,16 +16,6 @@
         <field id="add_params" translate="label comment tooltip" type="text" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Add search parameters</label>
             <comment>With this property you can deliver standard parameters which will then be attached to the search request. Example: param1=abc,param2=xyz.</comment>
-            <tooltip>Comma-separated value</tooltip>
-        </field>
-        <field id="add_tracking_params" translate="label comment tooltip" type="text" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Add tracking parameters</label>
-            <comment>With this property you can deliver standard parameters which are attached to every tracking request. Example: param1=abc,param2=xyz.</comment>
-            <tooltip>Comma-separated value</tooltip>
-        </field>
-        <field id="keep_url_params" translate="label comment tooltip" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Keep URL parameters</label>
-            <comment>Determines if parameters which are written into the URL should be kept.</comment>
             <tooltip>Comma-separated value</tooltip>
         </field>
         <field id="anonymize_user_id" translate="label comment" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -15,8 +15,6 @@
             <advanced>
                 <version>7.3</version>
                 <ff_api_version>v4</ff_api_version>
-                <use_url_parameter>1</use_url_parameter>
-                <only_search_params>1</only_search_params>
             </advanced>
             <components>
                 <campaign_advisor>1</campaign_advisor>

--- a/src/view/frontend/templates/ff/breadcrumb.phtml
+++ b/src/view/frontend/templates/ff/breadcrumb.phtml
@@ -1,6 +1,6 @@
 <?php /** @var Magento\Framework\Escaper $escaper */ ?>
 <div class="ff-breadcrumb-trail">
-    <ff-template scope="Search" unresolved>
+    <ff-template scope="SearchAndNavigation" unresolved>
         <span class="description"><?= $escaper->escapeHtml(__('Your search for:')) ?></span>
     </ff-template>
 
@@ -8,7 +8,7 @@
         <ff-breadcrumb-trail-item type="search">{{breadCrumbTrail.text}} {{item.text}}</ff-breadcrumb-trail-item>
     </ff-breadcrumb-trail>
 
-    <ff-template scope="Search" unresolved>
+    <ff-template scope="SearchAndNavigation" unresolved>
         <?= $escaper->escapeHtml(__('produced <span>{{totalHits}}</span> results'), ['span']) ?>
     </ff-template>
 </div>

--- a/src/view/frontend/templates/ff/result_count.phtml
+++ b/src/view/frontend/templates/ff/result_count.phtml
@@ -1,6 +1,6 @@
 <?php /** @var Magento\Framework\Escaper $escaper */ ?>
 <div class="ff-result-count">
-    <ff-template scope="Search" unresolved>
+    <ff-template scope="SearchAndNavigation" unresolved>
         <span><?= $escaper->escapeHtml(__('{{totalHits}} Items')) ?></span>
     </ff-template>
 </div>


### PR DESCRIPTION
- Solves issue:
    - FFWEB-3059
- Description:
    - Remove deprecated routing parameters such as: use-url-parameters, add-tracking-params, keep-url-params, only-search-params
- Tested with Magento editions/versions:
    - For example: 2.4.6
- Tested with PHP versions:
    - For example: 8.1
