### PR TITLE
FFWEB-3058: Remove FF version and API version

### DIFF
--- a/src/Controller/Adminhtml/FieldRoles/Update.php
+++ b/src/Controller/Adminhtml/FieldRoles/Update.php
@@ -10,7 +10,6 @@ use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Resource\AdapterFactory;
-use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Model\Api\CredentialsFactory;
 use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Omikron\Factfinder\Model\FieldRoles;
@@ -60,8 +59,7 @@ class Update extends Action
                 $this->communicationConfig->getApiVersion()
             );
             $searchAdapter = $adapterFactory->getSearchAdapter();
-            $response      = $searchAdapter->search($this->communicationConfig->getChannel($storeId), 'Search.ff');
-            $searchResult  = $this->communicationConfig->getVersion() === Version::NG ? $response : $response['searchResult'];
+            $searchResult  = $searchAdapter->search($this->communicationConfig->getChannel($storeId), 'Search.ff');
             $result->setData(['message' => __('Search result does not contain field roles')]);
 
             if (isset($searchResult['fieldRoles'])) {

--- a/src/Controller/Adminhtml/TestConnection/TestConnection.php
+++ b/src/Controller/Adminhtml/TestConnection/TestConnection.php
@@ -10,6 +10,7 @@ use Magento\Framework\Phrase;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Credentials;
 use Omikron\FactFinder\Communication\Resource\AdapterFactory;
+use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Logger\FactFinderLogger;
 use Omikron\Factfinder\Model\Api\CredentialsFactory;
 use Omikron\Factfinder\Model\Config\AuthConfig;
@@ -50,8 +51,8 @@ class TestConnection extends Action
 
             $adapterFactory = new AdapterFactory(
                 $clientBuilder,
-                $request->getParam('version'),
-                $request->getParam('ff_api_version')
+                Version::NG,
+                'v5'
             );
             $searchAdapter = $adapterFactory->getSearchAdapter();
             $searchAdapter->search($request->getParam('channel'), '*');

--- a/src/Model/Api/CredentialsFactory.php
+++ b/src/Model/Api/CredentialsFactory.php
@@ -25,8 +25,8 @@ class CredentialsFactory
               [
                 'username' => $this->authConfig->getUsername(),
                 'password' => $this->authConfig->getPassword(),
-                'prefix'   => $this->authConfig->getAuthenticationPrefix(),
-                'postfix'  => $this->authConfig->getAuthenticationPostfix()
+                'prefix'   => '',
+                'postfix'  => '',
               ]);
     }
 }

--- a/src/Model/Api/PushImport.php
+++ b/src/Model/Api/PushImport.php
@@ -7,7 +7,6 @@ namespace Omikron\Factfinder\Model\Api;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Client\ClientException;
 use Omikron\FactFinder\Communication\Resource\AdapterFactory;
-use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Omikron\Factfinder\Model\Config\ExportConfig;
 use Psr\Log\LoggerInterface;
@@ -54,7 +53,7 @@ class PushImport
             return false;
         }
 
-        if ($this->communicationConfig->getVersion() === Version::NG && $importAdapter->running($channel)) {
+        if ($importAdapter->running($channel)) {
             throw new ClientException("Can't start a new import process. Another one is still going");
         }
 
@@ -75,9 +74,7 @@ class PushImport
 
     private function prepareListFromPushImportResponses(array $responses): string
     {
-        return strtolower($this->communicationConfig->getVersion()) === 'ng'
-            ? $this->ngResponse($responses)
-            : $this->standardResponse($responses);
+        return $this->ngResponse($responses);
     }
 
     private function ngResponse(array $responses): string
@@ -97,24 +94,6 @@ class PushImport
 
             $importType .= $statusMessages;
             $listContent .= $importType;
-        }
-
-        return sprintf($list, $listContent);
-    }
-
-    private function standardResponse(array $responses): string
-    {
-        $list = '<ul>%s</ul>';
-        $listContent = '';
-
-        if (!empty($responses['status'])) {
-            $statusList = sprintf(
-                '<ul>%s</ul>',
-                implode('', array_map(fn (string $message): string => sprintf('<li>%s</li>', $message), $responses['status']))
-            );
-
-            $statusMessages = sprintf('<li><i>Status messages</i></li><li>%s</li>', $statusList);
-            $listContent .= $statusMessages;
         }
 
         return sprintf($list, $listContent);

--- a/src/Model/Config/AuthConfig.php
+++ b/src/Model/Config/AuthConfig.php
@@ -11,8 +11,6 @@ class AuthConfig
 {
     private const PATH_USERNAME     = 'factfinder/general/username';
     private const PATH_PASSWORD     = 'factfinder/general/password';
-    private const PATH_AUTH_PREFIX  = 'factfinder/general/prefix';
-    private const PATH_AUTH_POSTFIX = 'factfinder/general/postfix';
 
     private ScopeConfigInterface $scopeConfig;
 
@@ -29,15 +27,5 @@ class AuthConfig
     public function getPassword(): string
     {
         return (string) $this->scopeConfig->getValue(self::PATH_PASSWORD, Scope::SCOPE_STORE);
-    }
-
-    public function getAuthenticationPrefix(): string
-    {
-        return (string) $this->scopeConfig->getValue(self::PATH_AUTH_PREFIX, Scope::SCOPE_STORE);
-    }
-
-    public function getAuthenticationPostfix(): string
-    {
-        return (string) $this->scopeConfig->getValue(self::PATH_AUTH_POSTFIX, Scope::SCOPE_STORE);
     }
 }

--- a/src/Model/Config/CommunicationConfig.php
+++ b/src/Model/Config/CommunicationConfig.php
@@ -8,15 +8,12 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\ScopeInterface;
 use Omikron\Factfinder\Api\Config\ParametersSourceInterface;
-use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Controller\Router;
 
 class CommunicationConfig implements ParametersSourceInterface
 {
     private const PATH_CHANNEL              = 'factfinder/general/channel';
     private const PATH_ADDRESS              = 'factfinder/general/address';
-    private const PATH_VERSION              = 'factfinder/general/version';
-    private const PATH_API_VERSION          = 'factfinder/general/ff_api_version';
     private const PATH_IS_ENABLED           = 'factfinder/general/is_enabled';
     private const PATH_USE_PROXY            = 'factfinder/general/ff_enrichment';
     private const PATH_DATA_TRANSFER_IMPORT = 'factfinder/data_transfer/ff_push_import_enabled';
@@ -55,7 +52,7 @@ class CommunicationConfig implements ParametersSourceInterface
 
     public function getVersion(): string
     {
-        return (string) $this->scopeConfig->getValue(self::PATH_VERSION, ScopeInterface::SCOPE_STORES);
+        return 'ng';
     }
 
     public function getApiKey(): string
@@ -79,7 +76,7 @@ class CommunicationConfig implements ParametersSourceInterface
 
     public function getApiVersion(): string
     {
-        return (string) $this->scopeConfig->getValue(self::PATH_API_VERSION, ScopeInterface::SCOPE_STORES) ?? 'v4';
+        return 'v5';
     }
 
     private function getServerUrl(): string

--- a/src/Model/Config/ExportConfig.php
+++ b/src/Model/Config/ExportConfig.php
@@ -7,7 +7,6 @@ namespace Omikron\Factfinder\Model\Config;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Store\Model\ScopeInterface;
-use Omikron\FactFinder\Communication\Version;
 
 class ExportConfig
 {
@@ -44,20 +43,21 @@ class ExportConfig
     {
         $configPath = 'factfinder/data_transfer/ff_push_import_type';
         $dataTypes  = (string) $this->scopeConfig->getValue($configPath, ScopeInterface::SCOPE_STORES, $scopeId);
-        $isNg       = $this->communicationConfig->getVersion() === Version::NG;
 
-        return explode(',', $isNg ? $dataTypes : str_replace('search', 'data', $dataTypes));
+        return explode(',', $dataTypes);
     }
 
     private function getAttributeCodes(?int $storeId, callable $condition): array
     {
         $rows = array_filter($this->getConfigValue($storeId), $condition);
+
         return array_values(array_unique(array_column($rows, 'code')));
     }
 
     private function getConfigValue(?int $storeId): array
     {
         $value = $this->scopeConfig->getValue(self::CONFIG_PATH, ScopeInterface::SCOPE_STORES, $storeId);
+
         return array_map(
             fn (array $row): array => ['multi' => !!$row['multi']] + $row,
             (array) $this->serializer->unserialize($value ?: '[]')

--- a/src/Model/Ssr/PriceFormatter.php
+++ b/src/Model/Ssr/PriceFormatter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Ssr;
 
 use Magento\Framework\Pricing\PriceCurrencyInterface;
-use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Omikron\Factfinder\Model\FieldRoles;
 
@@ -21,11 +20,8 @@ class PriceFormatter
     public function format(array $searchResult): array
     {
         $priceField  = $this->fieldRoles->getFieldRole('price');
-        $isNG        = $this->communicationConfig->getVersion() === Version::NG;
-        $records     = $isNG ? $searchResult['hits'] : $searchResult['searchResult']['records'];
-        $recordField = $isNG ? 'masterValues' : 'record';
 
-        return ['records' => array_map($this->price($priceField, $recordField), $records)] + $searchResult;
+        return ['records' => array_map($this->price($priceField, 'masterValues'), $searchResult['hits'])] + $searchResult;
     }
 
     protected function price(string $priceField, string $recordField): callable

--- a/src/Model/Ssr/SearchAdapter.php
+++ b/src/Model/Ssr/SearchAdapter.php
@@ -6,7 +6,6 @@ namespace Omikron\Factfinder\Model\Ssr;
 
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Client\ClientException;
-use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Model\Api\CredentialsFactory;
 use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Psr\Http\Message\ResponseInterface;
@@ -50,8 +49,6 @@ class SearchAdapter
         $apiVersion  = $this->communicationConfig->getApiVersion();
         $endpoint = $navigationRequest ? 'navigation' : 'search';
 
-        return $this->communicationConfig->getVersion() == Version::NG
-            ? "rest/{$apiVersion}/{$endpoint}/{$channel}?{$paramString}"
-            : "Search.ff?channel={$channel}&{$paramString}&format=json";
+        return "rest/{$apiVersion}/{$endpoint}/{$channel}?{$paramString}";
     }
 }

--- a/src/Plugin/MapFieldRoles.php
+++ b/src/Plugin/MapFieldRoles.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\Plugin;
 
-use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Omikron\Factfinder\Model\FieldRoles;
 
@@ -24,9 +23,7 @@ class MapFieldRoles
      */
     public function aroundSaveFieldRoles(FieldRoles $subject, callable $proceed, array $fieldRoles, int $storeId)
     {
-        $isNg = $this->communicationConfig->getVersion() === Version::NG;
-
-        return $proceed($isNg ? $this->map($fieldRoles) : $fieldRoles, $storeId);
+        return $proceed($this->map($fieldRoles), $storeId);
     }
 
     protected function map(array $fieldRoles): array

--- a/src/Test/Unit/Model/Config/ExportConfigTest.php
+++ b/src/Test/Unit/Model/Config/ExportConfigTest.php
@@ -44,12 +44,8 @@ class ExportConfigTest extends TestCase
         $this->assertCount(2, $result);
     }
 
-    public function test_correct_push_data_types_are_returned_for_different_ff_versions()
+    public function test_correct_push_data_types_are_returned()
     {
-        $result = $this->testee->getPushImportDataTypes(1);
-        $this->assertContains('data', $result);
-        $this->assertNotContains('search', $result);
-
         $result = $this->testee->getPushImportDataTypes(1);
         $this->assertContains('search', $result);
         $this->assertNotContains('data', $result);
@@ -63,7 +59,7 @@ class ExportConfigTest extends TestCase
             ['factfinder/export/attributes', Scope::SCOPE_STORES, 42,'{"_1":{"code":"color","multi":"0","numerical":"0"},"_2":{"code":"climate","multi":"1","numerical":"0"},"_3":{"code":"gender","multi":"0","numerical":"0"},"_4":{"code":"size","multi":"1","numerical":"1"}}']
         ]);
         $communicationConfig = $this->createMock(CommunicationConfig::class);
-        $communicationConfig->method('getVersion')->willReturnOnConsecutiveCalls('7.3', 'ng');
+        $communicationConfig->method('getVersion')->willReturn('ng');
         $this->testee = new ExportConfig($scopeConfig, new Json(), $communicationConfig);
     }
 }

--- a/src/Test/Unit/Plugin/MapFieldRolesTest.php
+++ b/src/Test/Unit/Plugin/MapFieldRolesTest.php
@@ -38,14 +38,6 @@ class MapFieldRolesTest extends TestCase
         $this->plugin->aroundSaveFieldRoles($this->createMock(FieldRoles::class), $callbackMock, $this->fieldRoles, 1);
     }
 
-    public function test_it_will_not_map_field_roles_in_pre_ng()
-    {
-        $this->configMock->method('getVersion')->willReturn('7.3');
-        //in fact, this field role does exist in 7.3 but mocked field roles are of NG format
-        $callbackMock = fn (array $fieldRoles, int $storeId) => $this->assertArrayNotHasKey('masterArticleNumber', $fieldRoles);
-        $this->plugin->aroundSaveFieldRoles($this->createMock(FieldRoles::class), $callbackMock, $this->fieldRoles, 1);
-    }
-
     protected function setUp(): void
     {
         $this->configMock = $this->createMock(CommunicationConfig::class);

--- a/src/Test/Unit/ViewModel/CommunicationTest.php
+++ b/src/Test/Unit/ViewModel/CommunicationTest.php
@@ -63,7 +63,7 @@ class CommunicationTest extends TestCase
 
         $this->parametersProviderMock->method('getParameters')->willReturn([
             'url'        => 'http://some-url',
-            'version'    => '7.3',
+            'version'    => 'ng',
             'user-id'    => null,
             'channel'    => 'some-channel',
             'use-cache'  => 'true',

--- a/src/ViewModel/CategoryPath.php
+++ b/src/ViewModel/CategoryPath.php
@@ -7,7 +7,6 @@ namespace Omikron\Factfinder\ViewModel;
 use Magento\Catalog\Model\Category;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
-use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Model\Config\CommunicationConfig;
 
 class CategoryPath implements ArgumentInterface
@@ -18,12 +17,6 @@ class CategoryPath implements ArgumentInterface
         private readonly string              $param = 'CategoryPath',
         private readonly array               $initial = [],
     ) {
-    }
-
-    public function __toString()
-    {
-        return $this->communicationConfig->getVersion() === Version::NG ? $this->getCategoryPath(
-        ) : '';
     }
 
     public function getCategoryPath(): array

--- a/src/ViewModel/Communication.php
+++ b/src/ViewModel/Communication.php
@@ -30,7 +30,7 @@ class Communication implements ArgumentInterface
 
         $params = $this->parametersProvider->getParameters();
 
-        return ['version' => $params['version'] ?? 'ng']
+        return ['version' => 'ng']
             + array_filter($this->mergeParameters($blockParams, $params) + $blockParams + $params, 'boolval');
     }
 

--- a/src/etc/adminhtml/system/general.xml
+++ b/src/etc/adminhtml/system/general.xml
@@ -19,21 +19,21 @@
             <label>Channel</label>
             <validate>required-entry</validate>
         </field>
-        <field id="version" translate="label comment" type="select" sortOrder="12" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>FACT-Finder version</label>
-            <options>
-                <option label="NG">ng</option>
-                <option label="7.3">7.3</option>
-                <option label="7.2">7.2</option>
-            </options>
-        </field>
-        <field id="ff_api_version" translate="label comment" type="select" sortOrder="13" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>FACT-Finder Api version</label>
-            <options>
-                <option label="v4">v4</option>
-                <option label="v5">v5</option>
-            </options>
-        </field>
+<!--        <field id="version" translate="label comment" type="select" sortOrder="12" showInDefault="1" showInWebsite="1" showInStore="1">-->
+<!--            <label>FACT-Finder version</label>-->
+<!--            <options>-->
+<!--                <option label="NG">ng</option>-->
+<!--                <option label="7.3">7.3</option>-->
+<!--                <option label="7.2">7.2</option>-->
+<!--            </options>-->
+<!--        </field>-->
+<!--        <field id="ff_api_version" translate="label comment" type="select" sortOrder="13" showInDefault="1" showInWebsite="1" showInStore="1">-->
+<!--            <label>FACT-Finder Api version</label>-->
+<!--            <options>-->
+<!--                <option label="v4">v4</option>-->
+<!--                <option label="v5">v5</option>-->
+<!--            </options>-->
+<!--        </field>-->
         <field id="username" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Username</label>
             <validate>required-entry</validate>
@@ -45,18 +45,6 @@
         <field id="ff_api_key" translate="label" type="obscure" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>API key</label>
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
-        </field>
-        <field id="prefix" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Authentication Prefix</label>
-            <depends>
-                <field negative="1" id="factfinder/general/version">ng</field>
-            </depends>
-        </field>
-        <field id="postfix" translate="label" type="text" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Authentication Postfix</label>
-            <depends>
-                <field negative="1" id="factfinder/general/version">ng</field>
-            </depends>
         </field>
         <field id="ff_build_connection" translate="label comment" type="button" sortOrder="71" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Test Connection</label>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -12,10 +12,6 @@
                 <ff_enrichment>0</ff_enrichment>
                 <tracking_product_number_field_role>{"brand":"Brand","campaignProductNumber":"ProductNumber","deeplink":"Deeplink","description":"Description","displayProductNumber":"ProductNumber","ean":"EAN","imageUrl":"ImageURL","masterArticleNumber":"Master","price":"Price","productName":"Name","trackingProductNumber":"ProductNumber"}</tracking_product_number_field_role>
             </general>
-            <advanced>
-                <version>7.3</version>
-                <ff_api_version>v4</ff_api_version>
-            </advanced>
             <components>
                 <campaign_advisor>1</campaign_advisor>
                 <campaign_redirect>1</campaign_redirect>


### PR DESCRIPTION
 Remove FF version and API version with refactoring. New SDK support only ng and v5 for API.

- Solves issue:
    - FFWEB-3058
- Description:
    -  Remove FF version and API version with refactoring. New SDK support only ng and v5 for API.
- Tested with Magento editions/versions:
    - For example: 2.4.6
- Tested with PHP versions:
    - For example: 8.1
