### PR TITLE
FFWEB-3052: Refactor authorization by using API key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": "~8.1.0||~8.2.0||~8.3.0",
-    "omikron/factfinder-communication-sdk": "^0.9.8",
+    "omikron/factfinder-communication-sdk": "^0.9.9",
     "magento/framework": "^103.0.7",
     "magento/module-catalog": "^104.0.7",
     "magento/module-configurable-product": "^100.4.7",

--- a/src/Controller/Adminhtml/Export/Feed.php
+++ b/src/Controller/Adminhtml/Export/Feed.php
@@ -101,7 +101,7 @@ class Feed extends Action
                             $this->pushImport->execute($storeId);
                             $result = $this->pushImport->getPushImportResult();
                             $messages[] = __('<li>Push import result</li><ul>' . $result . '</ul>');
-                        } catch (Exception $exception) {
+                        } catch (\Exception $exception) {
                             $messages[] = __('<li>Push import failed.</li>');
                         }
                     }

--- a/src/Controller/Adminhtml/FieldRoles/Update.php
+++ b/src/Controller/Adminhtml/FieldRoles/Update.php
@@ -10,47 +10,34 @@ use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Resource\AdapterFactory;
-use Omikron\Factfinder\Model\Api\CredentialsFactory;
+use Omikron\Factfinder\Model\Config\AuthConfig;
 use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Omikron\Factfinder\Model\FieldRoles;
 use Psr\Http\Client\ClientExceptionInterface;
 
 class Update extends Action
 {
-    private JsonFactory $jsonResultFactory;
-    private StoreManagerInterface $storeManager;
-    private CommunicationConfig $communicationConfig;
-    private CredentialsFactory $credentialsFactory;
-    private FieldRoles $fieldRoles;
-    private ClientBuilder $clientBuilder;
-
     public function __construct(
         Context $context,
-        JsonFactory $jsonFactory,
-        StoreManagerInterface $storeManager,
-        CommunicationConfig $communicationConfig,
-        CredentialsFactory $credentialsFactory,
-        FieldRoles $fieldRoles,
-        ClientBuilder $clientBuilder
+        private readonly JsonFactory $jsonFactory,
+        private readonly StoreManagerInterface $storeManager,
+        private readonly CommunicationConfig $communicationConfig,
+        private readonly AuthConfig $authConfig,
+        private readonly FieldRoles $fieldRoles,
+        private readonly ClientBuilder $clientBuilder
     ) {
         parent::__construct($context);
-        $this->jsonResultFactory   = $jsonFactory;
-        $this->storeManager        = $storeManager;
-        $this->communicationConfig = $communicationConfig;
-        $this->credentialsFactory  = $credentialsFactory;
-        $this->fieldRoles          = $fieldRoles;
-        $this->clientBuilder       = $clientBuilder;
     }
 
     public function execute()
     {
-        $result = $this->jsonResultFactory->create();
+        $result = $this->jsonFactory->create();
         try {
             //@phpcs:ignore Magento2.Legacy.ObsoleteResponse.RedirectResponseMethodFound
             preg_match('@/store/([0-9]+)/@', (string) $this->_redirect->getRefererUrl(), $match);
             $storeId = (int) ($match[1] ?? $this->storeManager->getDefaultStoreView()->getId());
             $client  = $this->clientBuilder
-                ->withCredentials($this->credentialsFactory->create())
+                ->withApiKey($this->authConfig->getApiKey())
                 ->withServerUrl($this->communicationConfig->getAddress());
 
             $adapterFactory = new AdapterFactory(

--- a/src/Controller/Adminhtml/TestConnection/TestConnection.php
+++ b/src/Controller/Adminhtml/TestConnection/TestConnection.php
@@ -8,37 +8,24 @@ use Magento\Backend\App\Action;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\Phrase;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
-use Omikron\FactFinder\Communication\Credentials;
 use Omikron\FactFinder\Communication\Resource\AdapterFactory;
 use Omikron\FactFinder\Communication\Version;
 use Omikron\Factfinder\Logger\FactFinderLogger;
-use Omikron\Factfinder\Model\Api\CredentialsFactory;
 use Omikron\Factfinder\Model\Config\AuthConfig;
 use Psr\Http\Client\ClientExceptionInterface;
 
 class TestConnection extends Action
 {
     private string $obscuredValue = '******';
-    private JsonFactory $jsonResultFactory;
-    private CredentialsFactory $credentialsFactory;
-    private AuthConfig $authConfig;
-    private ClientBuilder $clientBuilder;
-    private FactFinderLogger $logger;
 
     public function __construct(
         Action\Context $context,
-        JsonFactory $jsonResultFactory,
-        CredentialsFactory $credentialsFactory,
-        AuthConfig $authConfig,
-        ClientBuilder $clientBuilder,
-        FactFinderLogger $logger
+        private readonly JsonFactory $jsonResultFactory,
+        private readonly AuthConfig $authConfig,
+        private readonly ClientBuilder $clientBuilder,
+        private readonly FactFinderLogger $logger
     ) {
         parent::__construct($context);
-        $this->jsonResultFactory  = $jsonResultFactory;
-        $this->credentialsFactory = $credentialsFactory;
-        $this->authConfig         = $authConfig;
-        $this->clientBuilder      = $clientBuilder;
-        $this->logger = $logger;
     }
 
     public function execute()
@@ -46,7 +33,7 @@ class TestConnection extends Action
         try {
             $request       = $this->getRequest();
             $clientBuilder = $this->clientBuilder
-                ->withCredentials($this->getCredentials($this->getRequest()->getParams()))
+                ->withApiKey($this->getApiKey($this->getRequest()->getParams()))
                 ->withServerUrl($request->getParam('address'));
 
             $adapterFactory = new AdapterFactory(
@@ -69,13 +56,13 @@ class TestConnection extends Action
         return $this->jsonResultFactory->create()->setData(['message' => $message]);
     }
 
-    private function getCredentials(array $params): Credentials
+    private function getApiKey(array $params): string
     {
         // The password wasn't edited, load it from config
-        if (!isset($params['password']) || $params['password'] === $this->obscuredValue) {
-            $params['password'] = $this->authConfig->getPassword();
+        if (!isset($params['ff_api_key']) || $params['ff_api_key'] === $this->obscuredValue) {
+            $params['ff_api_key'] = $this->authConfig->getApiKey();
         }
 
-        return $this->credentialsFactory->create($params);
+        return $params['ff_api_key'];
     }
 }

--- a/src/Controller/Proxy/Call.php
+++ b/src/Controller/Proxy/Call.php
@@ -15,7 +15,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NotFoundException;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\Factfinder\Controller\SkipCsrfValidation;
-use Omikron\Factfinder\Model\Api\CredentialsFactory;
+use Omikron\Factfinder\Model\Config\AuthConfig;
 use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -29,7 +29,7 @@ class Call extends Action\Action implements Action\HttpGetActionInterface, HttpP
         private readonly JsonResultFactory   $jsonResultFactory,
         private readonly RawResultFactory    $rawResultFactory,
         private readonly CommunicationConfig $communicationConfig,
-        private readonly CredentialsFactory  $credentialsFactory,
+        private readonly AuthConfig          $authConfig,
         private readonly ClientBuilder       $clientBuilder
     ) {
         parent::__construct($context);
@@ -47,12 +47,13 @@ class Call extends Action\Action implements Action\HttpGetActionInterface, HttpP
 
         try {
             $client = $this->clientBuilder
-                ->withCredentials($this->credentialsFactory->create())
+                ->withApiKey($this->authConfig->getApiKey())
                 ->withServerUrl($this->communicationConfig->getAddress())
                 ->withVersion($this->communicationConfig->getVersion())
                 ->build();
 
             $method = $this->getRequest()->getMethod();
+
             switch ($method) {
                 case 'GET':
                     $query = (string) parse_url($url, PHP_URL_QUERY); // phpcs:ignore
@@ -73,6 +74,7 @@ class Call extends Action\Action implements Action\HttpGetActionInterface, HttpP
     private function getEndpoint(string $currentUrl): string
     {
         preg_match('#/([A-Za-z]+\.ff|rest/v[^\?]*)#', $currentUrl, $match);
+
         return $match[1] ?? '';
     }
 

--- a/src/Model/Config/AuthConfig.php
+++ b/src/Model/Config/AuthConfig.php
@@ -9,8 +9,9 @@ use Magento\Store\Model\ScopeInterface as Scope;
 
 class AuthConfig
 {
-    private const PATH_USERNAME     = 'factfinder/general/username';
-    private const PATH_PASSWORD     = 'factfinder/general/password';
+    private const PATH_USERNAME = 'factfinder/general/username';
+    private const PATH_PASSWORD = 'factfinder/general/password';
+    private const PATH_API_KEY  = 'factfinder/general/ff_api_key';
 
     private ScopeConfigInterface $scopeConfig;
 
@@ -27,5 +28,10 @@ class AuthConfig
     public function getPassword(): string
     {
         return (string) $this->scopeConfig->getValue(self::PATH_PASSWORD, Scope::SCOPE_STORE);
+    }
+
+    public function getApiKey(): string
+    {
+        return (string) $this->scopeConfig->getValue(self::PATH_API_KEY, Scope::SCOPE_STORE);
     }
 }

--- a/src/Model/Ssr/SearchAdapter.php
+++ b/src/Model/Ssr/SearchAdapter.php
@@ -6,7 +6,7 @@ namespace Omikron\Factfinder\Model\Ssr;
 
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Client\ClientException;
-use Omikron\Factfinder\Model\Api\CredentialsFactory;
+use Omikron\Factfinder\Model\Config\AuthConfig;
 use Omikron\Factfinder\Model\Config\CommunicationConfig;
 use Psr\Http\Message\ResponseInterface;
 
@@ -15,7 +15,7 @@ class SearchAdapter
     public function __construct(
         private readonly ClientBuilder $clientBuilder,
         private readonly CommunicationConfig $communicationConfig,
-        private readonly CredentialsFactory $credentialsFactory,
+        private readonly AuthConfig $authConfig,
         private readonly PriceFormatter $priceFormatter,
     ) {
     }
@@ -24,7 +24,7 @@ class SearchAdapter
     {
         $client = $this->clientBuilder
             ->withServerUrl($this->communicationConfig->getAddress())
-            ->withCredentials($this->credentialsFactory->create())
+            ->withApiKey($this->authConfig->getApiKey())
             ->withVersion($this->communicationConfig->getVersion())
             ->build();
 

--- a/src/Test/Unit/Controller/Adminhtml/TestConnection/TestConnectionTest.php
+++ b/src/Test/Unit/Controller/Adminhtml/TestConnection/TestConnectionTest.php
@@ -10,9 +10,7 @@ use Magento\Framework\Controller\Result\Json as JsonResult;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Omikron\FactFinder\Communication\Client\ClientBuilder;
 use Omikron\FactFinder\Communication\Client\ClientInterface;
-use Omikron\FactFinder\Communication\Credentials;
 use Omikron\Factfinder\Logger\FactFinderLogger;
-use Omikron\Factfinder\Model\Api\CredentialsFactory;
 use Omikron\Factfinder\Model\Config\AuthConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -48,7 +46,6 @@ class TestConnectionTest extends TestCase
 
     protected function setUp(): void
     {
-        $credentialsFactory = $this->createConfiguredMock(CredentialsFactory::class, ['create' => $this->createMock(Credentials::class)]);
         $this->request      = $this->createMock(RequestInterface::class);
         $body               = $this->createConfiguredMock(StreamInterface::class, ['getContents' => '{"status":"200"}']);
         $clientMock         = $this->createConfiguredMock(ClientInterface::class, ['request' => $this->createConfiguredMock(ResponseInterface::class, ['getBody' => $body])]);
@@ -56,13 +53,12 @@ class TestConnectionTest extends TestCase
 
         $this->builderMock->method('withVersion')->willReturn($this->builderMock);
         $this->builderMock->method('withServerUrl')->willReturn($this->builderMock);
-        $this->builderMock->method('withCredentials')->willReturn($this->builderMock);
+        $this->builderMock->method('withApiKey')->willReturn($this->builderMock);
         $this->builderMock->method('build')->willReturn($clientMock);
 
         $this->controller = new TestConnection(
             $this->createConfiguredMock(Context::class, ['getRequest' => $this->request]),
             $this->createConfiguredMock(JsonFactory::class, ['create' => $this->createMock(JsonResult::class)]),
-            $credentialsFactory,
             $this->createMock(AuthConfig::class),
             $this->builderMock,
             $this->createMock(FactFinderLogger::class)

--- a/src/etc/adminhtml/system/general.xml
+++ b/src/etc/adminhtml/system/general.xml
@@ -19,21 +19,6 @@
             <label>Channel</label>
             <validate>required-entry</validate>
         </field>
-<!--        <field id="version" translate="label comment" type="select" sortOrder="12" showInDefault="1" showInWebsite="1" showInStore="1">-->
-<!--            <label>FACT-Finder version</label>-->
-<!--            <options>-->
-<!--                <option label="NG">ng</option>-->
-<!--                <option label="7.3">7.3</option>-->
-<!--                <option label="7.2">7.2</option>-->
-<!--            </options>-->
-<!--        </field>-->
-<!--        <field id="ff_api_version" translate="label comment" type="select" sortOrder="13" showInDefault="1" showInWebsite="1" showInStore="1">-->
-<!--            <label>FACT-Finder Api version</label>-->
-<!--            <options>-->
-<!--                <option label="v4">v4</option>-->
-<!--                <option label="v5">v5</option>-->
-<!--            </options>-->
-<!--        </field>-->
         <field id="username" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Username</label>
             <validate>required-entry</validate>


### PR DESCRIPTION

- Solves issue:
    - FFWEB-3052
- Description:
    - Refactor authorisation by using API key for: test connection btn, SSR search, Field Roles update, Proxy
- Tested with Magento editions/versions:
    - 2.4.7
- Tested with PHP versions:
    - For example: 8.3
