### PR TITLE
FFWEB-3051: Refactor basic auth for export features

### DIFF
--- a/src/Block/Adminhtml/System/Config/Button/TestApiConnection.php
+++ b/src/Block/Adminhtml/System/Config/Button/TestApiConnection.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Block\Adminhtml\System\Config\Button;
+
+class TestApiConnection extends Button
+{
+    protected function getLabel(): string
+    {
+        return (string) __('Test API Connection');
+    }
+
+    protected function getTargetUrl(): string
+    {
+        return $this->getUrl('factfinder/testconnection/testapiconnection');
+    }
+}

--- a/src/Controller/Adminhtml/TestConnection/TestApiConnection.php
+++ b/src/Controller/Adminhtml/TestConnection/TestApiConnection.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Controller\Adminhtml\TestConnection;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\Phrase;
+use Omikron\FactFinder\Communication\Client\ClientBuilder;
+use Omikron\FactFinder\Communication\Credentials;
+use Omikron\FactFinder\Communication\Resource\AdapterFactory;
+use Omikron\FactFinder\Communication\Version;
+use Omikron\Factfinder\Logger\FactFinderLogger;
+use Omikron\Factfinder\Model\Api\CredentialsFactory;
+use Omikron\Factfinder\Model\Config\AuthConfig;
+use Omikron\Factfinder\Model\Config\CommunicationConfig;
+use Psr\Http\Client\ClientExceptionInterface;
+
+class TestApiConnection extends Action
+{
+    private string $obscuredValue = '******';
+
+    public function __construct(
+        Action\Context $context,
+        private readonly JsonFactory $jsonResultFactory,
+        private readonly CredentialsFactory $credentialsFactory,
+        private readonly AuthConfig $authConfig,
+        private readonly CommunicationConfig $communicationConfig,
+        private readonly ClientBuilder $clientBuilder,
+        private readonly FactFinderLogger $logger
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute()
+    {
+        try {
+            $clientBuilder = $this->clientBuilder
+                ->withCredentials($this->getCredentials($this->getRequest()->getParams()))
+                ->withServerUrl($this->communicationConfig->getAddress());
+
+            $adapterFactory = new AdapterFactory(
+                $clientBuilder,
+                Version::NG,
+                'v5'
+            );
+            $searchAdapter = $adapterFactory->getSearchAdapter();
+            $searchAdapter->search($this->communicationConfig->getChannel(), '*');
+
+            $message = new Phrase('Connection successfully established.');
+        } catch (ClientExceptionInterface $e) {
+            $this->logger->error(new Phrase(
+                'FACT-Finder response exception: %1, thrown at %2',
+                [$e->getMessage(), $e->getTraceAsString()]
+            ));
+            $message = $e->getMessage();
+        }
+
+        return $this->jsonResultFactory->create()->setData(['message' => $message]);
+    }
+
+    private function getCredentials(array $params): Credentials
+    {
+        // The password wasn't edited, load it from config
+        if (!isset($params['ff_password']) || $params['ff_password'] === $this->obscuredValue) {
+            $params['ff_password'] = $this->authConfig->getPassword();
+        }
+
+        return $this->credentialsFactory->create([
+            'username' => $params['ff_username'],
+            'password' => $params['ff_password'],
+        ]);
+    }
+}

--- a/src/Helper/ConfigHelper.php
+++ b/src/Helper/ConfigHelper.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Helper;
+
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Store\Model\ScopeInterface;
+
+class ConfigHelper extends AbstractHelper
+{
+    public function getConfig($configPath)
+    {
+        return $this->scopeConfig->getValue(
+            $configPath,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+}

--- a/src/Model/Config/AuthConfig.php
+++ b/src/Model/Config/AuthConfig.php
@@ -9,8 +9,8 @@ use Magento\Store\Model\ScopeInterface as Scope;
 
 class AuthConfig
 {
-    private const PATH_USERNAME = 'factfinder/general/username';
-    private const PATH_PASSWORD = 'factfinder/general/password';
+    private const PATH_USERNAME = 'factfinder/data_transfer/ff_username';
+    private const PATH_PASSWORD = 'factfinder/data_transfer/ff_password';
     private const PATH_API_KEY  = 'factfinder/general/ff_api_key';
 
     private ScopeConfigInterface $scopeConfig;

--- a/src/etc/adminhtml/system/data_transfer.xml
+++ b/src/etc/adminhtml/system/data_transfer.xml
@@ -3,6 +3,21 @@
     <group id="data_transfer" translate="label comment" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
         <label>Data transfer settings</label>
 
+        <field id="ff_username" translate="label" type="text" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Username</label>
+            <validate>required-entry</validate>
+        </field>
+
+        <field id="ff_password" translate="label" type="obscure" sortOrder="7" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Password</label>
+            <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+        </field>
+
+        <field id="ff_test_api_connection" translate="label comment" type="button" sortOrder="8" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Test Connection</label>
+            <frontend_model>Omikron\Factfinder\Block\Adminhtml\System\Config\Button\TestApiConnection</frontend_model>
+        </field>
+
         <field id="ff_upload_type" translate="label comment" type="select" sortOrder="9" showInDefault="1" showInWebsite="0" showInStore="0">
             <label>Type</label>
             <options>

--- a/src/etc/adminhtml/system/general.xml
+++ b/src/etc/adminhtml/system/general.xml
@@ -19,14 +19,6 @@
             <label>Channel</label>
             <validate>required-entry</validate>
         </field>
-        <field id="username" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Username</label>
-            <validate>required-entry</validate>
-        </field>
-        <field id="password" translate="label" type="obscure" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Password</label>
-            <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
-        </field>
         <field id="ff_api_key" translate="label" type="obscure" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>API key</label>
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -5,7 +5,6 @@
             <general>
                 <is_enabled>0</is_enabled>
                 <logging_enabled>0</logging_enabled>
-                <password backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
                 <ff_api_key backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
                 <use_for_categories>1</use_for_categories>
                 <show_add_to_cart_button>1</show_add_to_cart_button>
@@ -23,6 +22,7 @@
                 <paging>1</paging>
             </components>
             <data_transfer>
+                <ff_password backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
                 <ff_upload_password backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
                 <ff_upload_key_passphrase backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
                 <ff_cron_enabled>0</ff_cron_enabled>


### PR DESCRIPTION
- Solves issue:
    - FFWEB-3051:
- Description:
    - Refactor basic auth for export features
- Tested with Magento editions/versions:
    - For example: 2.4.7
- Tested with PHP versions:
    - For example: 8.3
