### PR TITLE
FFWEB-3079: Simplify cron export configuration

### DIFF
--- a/src/etc/crontab.xml
+++ b/src/etc/crontab.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="default">
         <job name="factfinder_feed_export" instance="ProductExportCron" method="execute">
-            <schedule>0 1 * * *</schedule>
+            <config_path>crontab/default/jobs/factfinder_feed_export/schedule/cron_expr</config_path>
         </job>
     </group>
 </config>

--- a/src/view/frontend/templates/ff/record-list.phtml
+++ b/src/view/frontend/templates/ff/record-list.phtml
@@ -23,7 +23,7 @@ $viewModel = $block->getViewModel();
                         <div class="price-box price-final_price" data-role="priceBox">
                             <span class="price-container price-final_price tax weee">
                                 <span data-price-amount="{{masterValues.Price}}" data-price-type="finalPrice" class="price-wrapper">
-                                    <span class="price">${{masterValues.Price}}</span>
+                                    <span class="price">{{$ masterValues.Price}}</span>
                                 </span>
                             </span>
                         </div>


### PR DESCRIPTION
- Solves issue:
    - FFWEB-3079
- Description:
    - Simplify cron export configuration
    - Fix currency displaying 
- Tested with Magento editions/versions:
    - 2.4.7
- Tested with PHP versions:
    - 8.3
