### PR TITLE
FFWEB-3090: Support feedbacktext for label above search result

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ component as respectively `currency-code` and `country-code` parameters. You can
 Some of the custom elements we offer works only when specific additional FACT-Finder modules has been purchased.
 Here you can disabled them, if you do not use utilize this part of FACT-Finder functionality
 
+**Note:** Feedback campaign support only labels: **above search result**. More labels needs some simple code customisation.
+
 **Note:** Paging has been added cause with infinite scrolling enabled in ff-record list, this custom element is redundant  
 
 **Note:** Page id in Landing page campaign base on Magento CMS page Identifier name

--- a/src/view/frontend/layout/default.xml
+++ b/src/view/frontend/layout/default.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0"?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Framework\View\Element\Template" name="factfinder.feedbacktext" ifconfig="factfinder/components/campaign_feedbacktext" template="Omikron_Factfinder::ff/campaign-feedbacktext.phtml" />
+        <block class="Magento\Framework\View\Element\Template" name="factfinder.feedbacktext" ifconfig="factfinder/components/campaign_feedbacktext" template="Omikron_Factfinder::ff/campaign-feedbacktext.phtml">
+            <arguments>
+                <argument name="label" xsi:type="string">above search result</argument>
+            </arguments>
+        </block>
         <block class="Magento\Framework\View\Element\Template" name="factfinder.recordlist" template="Omikron_Factfinder::ff/record-list.phtml">
             <arguments>
                 <argument name="subscribe" xsi:type="boolean">true</argument>
@@ -43,11 +47,6 @@
 
         <referenceContainer name="content">
             <block class="Magento\Framework\View\Element\Template" name="factfinder.campaignlandingpage" ifconfig="factfinder/components/campaign_landing_page" template="Omikron_Factfinder::ff/campaign-landing-page.phtml" />
-            <referenceBlock name="factfinder.feedbacktext">
-                <arguments>
-                    <argument name="flag" xsi:type="string">is-landing-page-campaign</argument>
-                </arguments>
-            </referenceBlock>
             <block class="Magento\Framework\View\Element\Template" name="factfinder.campaign.pushed.products" ifconfig="factfinder/components/campaign_landing_page" template="Omikron_Factfinder::ff/campaign-pushed-products.phtml">
                 <arguments>
                     <argument name="flag" xsi:type="string">is-landing-page-campaign</argument>


### PR DESCRIPTION
- Solves issue:
    - FFWEB-3090
- Description:
    - Support feedbacktext for label above search result
- Tested with Magento editions/versions:
    - For example: 2.4.7
- Tested with PHP versions:
    - For example: 8.2
