### PR TITLE
Fix uninitialized member variables access

### DIFF
--- a/src/Model/Export/Catalog/ProductField/GenericField.php
+++ b/src/Model/Export/Catalog/ProductField/GenericField.php
@@ -14,6 +14,8 @@ use Magento\Catalog\Model\Product;
 
 class GenericField implements FieldInterface
 {
+    private ?Attribute $attribute = null;
+
     public function __construct(
         private readonly ProductAttributeRepositoryInterface $attributeRepository,
         private readonly AttributeValuesExtractor $valuesExtractor,

--- a/src/Model/Stream/Csv.php
+++ b/src/Model/Stream/Csv.php
@@ -13,7 +13,7 @@ use SplFileObject;
 
 class Csv implements StreamInterface
 {
-    private ?WriteInterface $stream;
+    private ?WriteInterface $stream = null;
 
     public function __construct(
         private readonly Filesystem $filesystem,

--- a/src/Model/Stream/Csv.php
+++ b/src/Model/Stream/Csv.php
@@ -38,7 +38,7 @@ class Csv implements StreamInterface
 
     private function getStream(): WriteInterface
     {
-        if (!isset($this->stream)) {
+        if ($this->stream) {
             $directory    = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
             $this->stream = $directory->openFile($directory->getAbsolutePath($this->filename), 'w+');
             $this->stream->lock();

--- a/src/Model/Stream/Csv.php
+++ b/src/Model/Stream/Csv.php
@@ -38,7 +38,7 @@ class Csv implements StreamInterface
 
     private function getStream(): WriteInterface
     {
-        if ($this->stream) {
+        if (!$this->stream) {
             $directory    = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
             $this->stream = $directory->openFile($directory->getAbsolutePath($this->filename), 'w+');
             $this->stream->lock();


### PR DESCRIPTION
Under PHP 8 an error will occur for the `Csv::$stream` member variables, as it is being accessed before being initialized. This PR fixes that by initializing it with `null`.

Another error occurs because `GenericField` is creating a dynamic property `$attribute`. This PR fixes that by defining a member variable for this property.