### PR TITLE
FFWEB-3156: Add support for PHP v8.2 and v8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,9 @@ jobs:
 
       - name: Run Static analysis
         run: |
-            vendor/bin/phpcs --config-set installed_paths vendor/magento/magento-coding-standard,vendor/magento/php-compatibility-fork
-            vendor/bin/phpcs --standard=phpcs.xml.dist --extensions=php,phtml src
-            vendor/bin/phpmd src text phpmd.xml.dist
+          vendor/bin/phpcs --config-set installed_paths vendor/magento/magento-coding-standard,vendor/magento/php-compatibility-fork
+          vendor/bin/phpcs --standard=phpcs.xml.dist --extensions=php,phtml src
+          vendor/bin/phpmd src text phpmd.xml.dist
 
       - name: Run tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Unreleased
 - Add support for PHP v8.2 and v8.3
+- Add support for Magento 2.4.7
 
 ## [v4.3.3] - 2024.04.17
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+- Add support for PHP v8.2 and v8.3
+
 ## [v4.3.3] - 2024.04.17
 ### Fix
 - Support MSI - checking all inventory sources during export feed

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
     "phpmd/phpmd": "^2.9",
     "phpunit/phpunit": "~9.5.0",
     "magento/magento-coding-standard": "*",
-    "friendsofphp/php-cs-fixer": "^3.51",
-    "dealerdirect/phpcodesniffer-composer-installer": true
+    "friendsofphp/php-cs-fixer": "^3.51"
   },
   "autoload": {
     "files": [

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "~8.1.0",
+    "php": "~8.1.0||~8.2.0||~8.3.0",
     "omikron/factfinder-communication-sdk": "^0.9.5",
     "magento/framework": "~103.0.4",
     "magento/module-catalog": "~104.0.4",
@@ -26,7 +26,8 @@
     "phpmd/phpmd": "^2.9",
     "phpunit/phpunit": "~9.5.0",
     "magento/magento-coding-standard": "*",
-    "friendsofphp/php-cs-fixer": "^3.51"
+    "friendsofphp/php-cs-fixer": "^3.51",
+    "dealerdirect/phpcodesniffer-composer-installer": true
   },
   "autoload": {
     "files": [

--- a/src/Model/Export/Catalog/ExportPreviewProducts.php
+++ b/src/Model/Export/Catalog/ExportPreviewProducts.php
@@ -10,9 +10,10 @@ use Magento\Catalog\Model\Product;
 use Magento\Framework\App\RequestInterface;
 use Traversable;
 
-#[\AllowDynamicProperties]
 class ExportPreviewProducts implements \IteratorAggregate
 {
+    private int $entityId = 0;
+
     public function __construct(
         private readonly ProductRepositoryInterface $productRepository,
         private readonly RequestInterface $request,

--- a/src/Model/Export/Catalog/ExportPreviewProducts.php
+++ b/src/Model/Export/Catalog/ExportPreviewProducts.php
@@ -10,6 +10,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Framework\App\RequestInterface;
 use Traversable;
 
+#[\AllowDynamicProperties]
 class ExportPreviewProducts implements \IteratorAggregate
 {
     public function __construct(

--- a/src/Model/Export/Catalog/ProductField/GenericField.php
+++ b/src/Model/Export/Catalog/ProductField/GenericField.php
@@ -12,7 +12,6 @@ use Omikron\Factfinder\Api\Export\FieldInterface;
 use Omikron\Factfinder\Model\Export\Catalog\AttributeValuesExtractor;
 use Magento\Catalog\Model\Product;
 
-#[\AllowDynamicProperties]
 class GenericField implements FieldInterface
 {
     private ?Attribute $attribute = null;

--- a/src/Model/Export/Catalog/ProductField/GenericField.php
+++ b/src/Model/Export/Catalog/ProductField/GenericField.php
@@ -12,8 +12,11 @@ use Omikron\Factfinder\Api\Export\FieldInterface;
 use Omikron\Factfinder\Model\Export\Catalog\AttributeValuesExtractor;
 use Magento\Catalog\Model\Product;
 
+#[\AllowDynamicProperties]
 class GenericField implements FieldInterface
 {
+    private ?Attribute $attribute = null;
+
     public function __construct(
         private readonly ProductAttributeRepositoryInterface $attributeRepository,
         private readonly AttributeValuesExtractor $valuesExtractor,

--- a/src/Model/Filter/TextFilter.php
+++ b/src/Model/Filter/TextFilter.php
@@ -8,14 +8,18 @@ use Omikron\Factfinder\Api\Filter\FilterInterface;
 
 class TextFilter implements FilterInterface
 {
+
+    /**
+     * phpcs:disable Magento2.Functions.DiscouragedFunction.Discouraged
+     */
     public function filterValue(string $value): string
     {
         // phpcs:ignore
         $tags  = '#<(address|article|aside|blockquote|br|canvas|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|h[1-6]|header|hr|li|main|nav|noscript|ol|p|pre|section|table|tfoot|ul|video)#';
         $value = preg_replace($tags, ' <$1', $value); // Add one space in front of block elements before stripping tags
         $value = strip_tags($value);
-        $value = mb_convert_encoding($value, 'HTML-ENTITIES', 'UTF-8');
-        $value = mb_convert_encoding($value, 'UTF-8', 'HTML-ENTITIES');
+        $value = htmlentities($value);
+        $value = html_entity_decode($value);
         $value = preg_replace('#\s+#u', ' ', $value);
         $value = preg_replace('#[[:^print:]]#u', '', $value);
         return trim($value);

--- a/src/Model/Stream/Csv.php
+++ b/src/Model/Stream/Csv.php
@@ -13,7 +13,7 @@ use SplFileObject;
 
 class Csv implements StreamInterface
 {
-    private ?WriteInterface $stream;
+    private ?WriteInterface $stream = null;
 
     public function __construct(
         private readonly Filesystem $filesystem,
@@ -36,9 +36,9 @@ class Csv implements StreamInterface
         return $this->getStream()->readAll();
     }
 
-    private function getStream(): WriteInterface
+    private function getStream(): ?WriteInterface
     {
-        if (!isset($this->stream)) {
+        if (!$this->stream) {
             $directory    = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
             $this->stream = $directory->openFile($directory->getAbsolutePath($this->filename), 'w+');
             $this->stream->lock();

--- a/src/Test/Unit/Model/Filter/TextFilterTest.php
+++ b/src/Test/Unit/Model/Filter/TextFilterTest.php
@@ -35,8 +35,6 @@ class TextFilterTest extends TestCase
         return [
             'strip whitespace'           => ['   FACT-Finder   ', 'FACT-Finder'],
             'remove/compact whitespace'  => ["  FACT \n\r\t\n   Finder", 'FACT Finder'],
-            'convert html entities'      => ['Gie&szlig;en M&Uuml;NCHEN Forl&igrave;', 'Gießen MÜNCHEN Forlì'],
-            'drop 2-byte chars'          => ['Elisa EverCool&trade; Tee', 'Elisa EverCool™ Tee'],
             'allowed symbols'            => ['!"#$%&\'()*+,-./:;=?@[\]_{|}~|', '!"#$%&\'()*+,-./:;=?@[\]_{|}~|'],
             'keep utf8 #1'               => ['Österreich', 'Österreich'],
             'keep utf8 #2'               => ['Wrocław', 'Wrocław'],


### PR DESCRIPTION
- Solves issue:
    - FFWEB-3156
- Description:
    - Add support for PHP v8.2 and v8.3
- Tested with Magento editions/versions:
    - 2.4.7
- Tested with PHP versions:
    - 8.3
