### PR TITLE
Unlock all PHP 8 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "~8.1.0||~8.2.0||~8.3.0",
+    "php": "^8.1",
     "omikron/factfinder-communication-sdk": "^0.9.5",
     "magento/framework": "~103.0.4",
     "magento/module-catalog": "~104.0.4",


### PR DESCRIPTION
I am still confused on why you (and so many other Magento extensions) disallow the usage of higher PHP feature versions. This unnecessarily forces you to either use `--ignore-platform-req=php` or lock down the PHP version in your project's `composer.json` to a supported version whenever you want to switch to a higher PHP version. What is the reasoning behind this?
