### PR TITLE
FFWEB-3210: Fix upload validation SSH key file issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fix
 - Support MSI - checking all inventory sources during export feed
 - Fix feed path for UI export type
+- Fix upload validation SSH key file issue
 
 ## [v5.0.0] - 2024.07.08
 ### BREAKING

--- a/src/Model/Config/Backend/Rsa.php
+++ b/src/Model/Config/Backend/Rsa.php
@@ -4,13 +4,63 @@ declare(strict_types=1);
 
 namespace Omikron\Factfinder\Model\Config\Backend;
 
+use Exception;
 use Magento\Config\Model\Config\Backend\File;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\MediaStorage\Model\File\Uploader;
 
 class Rsa extends File
 {
+    public function beforeSave()
+    {
+        $value = $this->getValue();
+        $file = $this->getFileData();
+
+        if (!empty($file)) {
+            $uploadDir = $this->_getUploadDir();
+            try {
+                /** @var Uploader $uploader */
+                $uploader = $this->_uploaderFactory->create(['fileId' => $file]);
+                $uploader->setAllowedExtensions($this->_getAllowedExtensions());
+                $uploader->setAllowRenameFiles(true);
+                $uploader->addValidateCallback('size', $this, 'validateMaxSize');
+                $result = $uploader->save($uploadDir);
+            } catch (Exception $e) {
+                throw new LocalizedException(__('%1', $e->getMessage()));
+            }
+            if ($result !== false) {
+                $filename = $result['file'];
+                if ($this->_addWhetherScopeInfo()) {
+                    $filename = $this->_prependScopeInfo($filename);
+                }
+                $this->setValue($filename);
+            }
+        } else {
+            if (is_array($value) && !empty($value['delete'])) {
+                $this->setValue('');
+            } elseif (is_array($value) && !empty($value['value'])) {
+                $this->setValueAfterValidation($value['value']);
+            } else {
+                $this->unsValue();
+            }
+        }
+
+        return $this;
+    }
+
     protected function getUploadDirPath($uploadDir)
     {
         return $this->_filesystem->getDirectoryWrite(DirectoryList::CONFIG)->getAbsolutePath($uploadDir);
+    }
+
+    private function setValueAfterValidation(string $value): void
+    {
+        // avoid intercepting value
+        if (preg_match('/[^a-z0-9_\/\\-\\.]+/i', $value)) {
+            throw new LocalizedException(__('Invalid file name'));
+        }
+
+        $this->setValue($value);
     }
 }

--- a/src/Model/Config/Backend/Rsa.php
+++ b/src/Model/Config/Backend/Rsa.php
@@ -10,6 +10,9 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\MediaStorage\Model\File\Uploader;
 
+/**
+ * @SuppressWarnings(PHPMD)
+ */
 class Rsa extends File
 {
     public function beforeSave()


### PR DESCRIPTION
- Solves issue: 
    - FFWEB-3210
- Description: 
    - Fix upload validation SSH key file issue
- Tested with Magento editions/versions:
    - For example: 2.4.7
- Tested with PHP versions:
    - For example: 8.2
