### PR TITLE
Make trailing slash optional

### DIFF
--- a/src/view/frontend/templates/ff/communication.phtml
+++ b/src/view/frontend/templates/ff/communication.phtml
@@ -48,7 +48,7 @@ $searchImmediate = $communicationParameters['search-immediate'] ?? 'false';
             }));
         <?php endif; ?>
 
-        <?php if (($request = $block->getRequest()) instanceof \Magento\Framework\App\Request\Http && '/factfinder/result' !== $request->getPathInfo()): ?>
+        <?php if (($request = $block->getRequest()) instanceof \Magento\Framework\App\Request\Http && '/factfinder/result' !== rtrim($request->getPathInfo(), '/')): ?>
             factfinder.request.before.search(({ searchParams, searchOptions }) => {
                 if (searchOptions?.requestOptions?.origin?.tagName === `FF-SEARCHBOX`) {
                     <?php if(!empty($parameters['add-params'])) : ?>


### PR DESCRIPTION
Follow up to https://github.com/FACT-Finder-Web-Components/magento2-module/pull/514 so that it does not matter whether you are on

* `https://example.com/factfinder/result/?query=test` or
* `https://example.com/factfinder/result?query=test`

(as both will be valid URLs in Magento)