### PR TITLE
FFWEB-3285: Set correct CategoryPath field name for searchParamsFromUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Set correct CategoryPath field name for searchParamsFromUrl
+
 ## [v5.0.2] - 2024.12.08
 ### Improve
 - Add the ability to set a name for the CategoryPath field

--- a/src/Model/Config/CommunicationConfig.php
+++ b/src/Model/Config/CommunicationConfig.php
@@ -19,6 +19,7 @@ class CommunicationConfig implements ParametersSourceInterface
     private const PATH_DATA_TRANSFER_IMPORT = 'factfinder/data_transfer/ff_push_import_enabled';
     private const PATH_IS_LOGGING_ENABLED   = 'factfinder/general/logging_enabled';
     private const PATH_FF_API_KEY           = 'factfinder/general/ff_api_key';
+    private const PATH_CATEGORY_PATH_NAME = 'factfinder/general/category_path_name';
 
     private ScopeConfigInterface $scopeConfig;
 
@@ -65,12 +66,21 @@ class CommunicationConfig implements ParametersSourceInterface
         return $this->scopeConfig->isSetFlag(self::PATH_IS_LOGGING_ENABLED, ScopeInterface::SCOPE_STORES);
     }
 
+    public function getCategoryPathFieldName(): string
+    {
+        return $this->scopeConfig->getValue(
+            self::PATH_CATEGORY_PATH_NAME,
+            ScopeInterface::SCOPE_STORE
+        ) ?? 'CategoryPath';
+    }
+
     public function getParameters(): array
     {
         return [
-            'url'     => $this->getServerUrl(),
-            'channel' => $this->getChannel(),
-            'api_key' => $this->getApiKey(),
+            'url'                      => $this->getServerUrl(),
+            'channel'                  => $this->getChannel(),
+            'api_key'                  => $this->getApiKey(),
+            'category_path_field_name' => $this->getCategoryPathFieldName(),
         ];
     }
 

--- a/src/view/frontend/templates/ff/communication.phtml
+++ b/src/view/frontend/templates/ff/communication.phtml
@@ -64,7 +64,7 @@ $searchImmediate = $communicationParameters['search-immediate'] ?? 'false';
         <?php endif; ?>
 
         if (<?= /** @SuppressWarnings(PHPMD) */ $searchImmediate ?>) {
-            const searchParams = factfinder.utils.env.searchParamsFromUrl();
+            const searchParams = factfinder.utils.env.searchParamsFromUrl({ categoryFieldName: `<?= $escaper->escapeHtml($parameters['category_path_field_name'])?>` });
             initialSearch(searchParams, { requestOptions: { origin: `initialSearch` } });
         }
     });


### PR DESCRIPTION
Set correct CategoryPath field name for searchParamsFromUrl

- Solves issue: 
    - FFWEB-3285
- Description:
    - Set correct CategoryPath field name for searchParamsFromUrl
- Tested with Magento editions/versions:
    - For example: 2.4.7
- Tested with PHP versions:
    - For example: 8.3
