### PR TITLE
FFWEB-3320: Remove CategoryPath filter in URL and ASN on category page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fix
 - Handle ClientException for SSR (invalid credentials, API issue etc.)
+- Remove CategoryPath filter in URL and ASN on category page
 
 ## [v5.0.3] - 2025.01.20
 ### Fix

--- a/src/view/frontend/templates/category/category_page.phtml
+++ b/src/view/frontend/templates/category/category_page.phtml
@@ -6,13 +6,20 @@ $categoryPathFieldName = $block->getData('category_path_field_name');
 ?>
 
 <script>
-    document.addEventListener(`ffCoreReady`, ({ factfinder }) => {
+    document.addEventListener(`ffCoreReady`, ({ factfinder, initialSearch }) => {
         factfinder.config.setAppConfig({
             categoryPage: [
                 factfinder.utils.filterBuilders.categoryFilter('<?= /* @noEscape */ $categoryPathFieldName ?>', <?= /* @noEscape */ json_encode($categoryPath); ?>)
             ],
         });
 
-        factfinder.request.navigation({'filters': factfinder.config.get().appConfig.categoryPage}, { requestOptions: { origin: `searchImmediately` } });
+        factfinder.routing.setUrlParamOptionsListener(() => ({
+            blockFilters: [`<?= /* @noEscape */ $categoryPathFieldName ?>`],
+        }));
+
+        const initOptions = factfinder.config.get();
+        initialSearch({
+            filters: initOptions.appConfig.categoryPage,
+        });
     });
 </script>

--- a/src/view/frontend/templates/ff/asn.phtml
+++ b/src/view/frontend/templates/ff/asn.phtml
@@ -14,7 +14,7 @@ $isCategoryPage = (bool) $block->getData('is_category_page');
             <?= $block->getChildHtml('factfinder.asn_group') ?>
         </ff-asn-group>
 
-        <ff-asn-group for-group="<?= /* @noEscape */ $categoryPathFieldName ?>ROOT" <?php if($isCategoryPage):?> class="hidden" <?php endif;?>>
+        <ff-asn-group for-group="<?= /* @noEscape */ $categoryPathFieldName ?>" <?php if($isCategoryPage):?> class="hidden" <?php endif;?>>
             <?= $block->getChildHtml('factfinder.asn_group') ?>
         </ff-asn-group>
 


### PR DESCRIPTION
- Solves issue:
    - FFWEB-3320
- Description:
    - Remove CategoryPath filter in URL and ASN on category page
- Tested with Magento editions/versions:
    - 2.4.7
- Tested with PHP versions:
    - 8.3
