### PR TITLE
FFWEB-3356: Fix filter cloud issue on category pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ## Unreleased 
+### Fix
+- Fix filter cloud issue on category pages
+
 ### Update
 - Update WebComponents library to version 5.1.1
 

--- a/src/view/frontend/templates/category/category_page.phtml
+++ b/src/view/frontend/templates/category/category_page.phtml
@@ -18,8 +18,10 @@ $categoryPathFieldName = $block->getData('category_path_field_name');
         }));
 
         const initOptions = factfinder.config.get();
-        initialSearch({
-            filters: initOptions.appConfig.categoryPage,
-        });
+        const searchParams = factfinder.utils.env.searchParamsFromUrl({ categoryFieldName: `<?= /* @noEscape */ $categoryPathFieldName ?>` });
+
+        searchParams.filters = searchParams.filters ?? [];
+        searchParams.filters.push(initOptions.appConfig.categoryPage[0]);
+        initialSearch(searchParams);
     });
 </script>


### PR DESCRIPTION
- Solves issue:
    - FFWEB-3356
- Description:
    - Fix filter cloud issue on category pages
- Tested with Magento editions/versions:
    - 2.4.7
- Tested with PHP versions:
    - 8.3
