### PR TITLE
FFWEB-3373: Add price attribute for ff-checkout-tracking-item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fix
+- Add price attribute for ff-checkout-tracking-item
+
 ## [v5.1.1] - 2025.03.21
 ### Fix
 - Fix filter cloud issue on category pages

--- a/src/view/frontend/templates/ff/checkout-tracking.phtml
+++ b/src/view/frontend/templates/ff/checkout-tracking.phtml
@@ -5,9 +5,10 @@
 <ff-checkout-tracking>
     <?php foreach ($block->getData('items') as $item): ?>
         <ff-checkout-tracking-item
-            product-number="<?= /* @noEscape */ $item->getSku() ?>"
-            count="<?= /* @noEscape */ $item->getQty() ?>"
-            channel="<?= /* @noEscape */ $block->getData('channel') ?>">
+            product-number="<?= /* @noEscape */ $item->getSku(); ?>"
+            count="<?= /* @noEscape */ $item->getQty(); ?>"
+            price="<?= /* @noEscape */ $item->getPrice(); ?>"
+            channel="<?= /* @noEscape */ $block->getData('channel'); ?>">
         </ff-checkout-tracking-item>
     <?php endforeach; ?>
 </ff-checkout-tracking>


### PR DESCRIPTION
- Solves issue:
    - FFWEB-3373
- Description:
    - Add price attribute for ff-checkout-tracking-item
- Tested with Magento editions/versions:
    - 2.4.7
- Tested with PHP versions:
    - 8.3
