### PR TITLE
FFWEB-3377:  Rewrite less files to support Magento v2.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ## Unreleased
+### Change
+- Rewrite less files to support Magento v2.4.8
+
 ### Fix
 - Add price attribute for ff-checkout-tracking-item
 

--- a/src/view/frontend/web/css/source/ff/_recommendation.less
+++ b/src/view/frontend/web/css/source/ff/_recommendation.less
@@ -22,6 +22,6 @@ ff-recommendation {
 
 @media all and (min-width: 1024px), print {
   .page-layout-1column ff-recommendation ff-record {
-    width: percentage(1 / 6);
+    width: percentage(0.16666667);
   }
 }

--- a/src/view/frontend/web/css/source/ff/_similar.less
+++ b/src/view/frontend/web/css/source/ff/_similar.less
@@ -30,6 +30,6 @@ ff-similar-products {
 
 @media all and (min-width: 1024px), print {
   .page-layout-1column ff-similar-products ff-record {
-    width: percentage(1 / 6);
+    width: percentage(0.16666667); // 1/6
   }
 }

--- a/src/view/frontend/web/css/source/ff/_similar.less
+++ b/src/view/frontend/web/css/source/ff/_similar.less
@@ -30,6 +30,6 @@ ff-similar-products {
 
 @media all and (min-width: 1024px), print {
   .page-layout-1column ff-similar-products ff-record {
-    width: percentage(0.16666667); // 1/6
+    width: percentage(0.16666667);
   }
 }


### PR DESCRIPTION
- Solves issue:
    - FFWEB-3377
- Description:
    - Rewrite less files to support Magento v2.4.8
- Tested with Magento editions/versions:
    - 2.4.8
- Tested with PHP versions:
    - 8.3
