### PR TITLE
Export the real product salability as Availability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "magento/module-configurable-product": "^100.4.7",
     "magento/module-directory": "^100.4.7",
     "magento/module-store": "^101.1.7",
-    "magento/module-inventory": "1.2.*",
+    "magento/module-inventory-sales-api": "1.2.*",
     "salesforce/handlebars-php": "3.*",
     "ext-json": "*",
     "phpseclib/phpseclib": "~3.0"

--- a/src/Model/Export/Catalog/Entity/ProductVariation.php
+++ b/src/Model/Export/Catalog/Entity/ProductVariation.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Export\Catalog\Entity;
 
 use Magento\Catalog\Model\Product;
-use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
 use Omikron\Factfinder\Api\Export\ExportEntityInterface;
 use Omikron\Factfinder\Api\Export\FieldInterface;
 use Omikron\Factfinder\Model\Export\Catalog\FieldProvider;
+use Omikron\Factfinder\Model\Export\Catalog\ProductAvailability;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 
 class ProductVariation implements ExportEntityInterface
@@ -20,14 +20,14 @@ class ProductVariation implements ExportEntityInterface
 
     /** @var string[] */
     private array $configurableData;
-    private GetSourceItemsBySku $getSourceItemsBySku;
+    private ProductAvailability $productAvailability;
 
     public function __construct(
         Product $product,
         Product $configurable,
         NumberFormatter $numberFormatter,
         FieldProvider $variantFieldProvider,
-        GetSourceItemsBySku $getSourceItemsBySku,
+        ProductAvailability $productAvailability,
         array $data = []
     ) {
         $this->product          = $product;
@@ -35,7 +35,7 @@ class ProductVariation implements ExportEntityInterface
         $this->numberFormatter  = $numberFormatter;
         $this->configurableData = $data;
         $this->fieldprovider    = $variantFieldProvider;
-        $this->getSourceItemsBySku = $getSourceItemsBySku;
+        $this->productAvailability = $productAvailability;
     }
 
     public function getId(): int
@@ -87,18 +87,6 @@ class ProductVariation implements ExportEntityInterface
 
     private function getAvailability(): bool
     {
-        if ($this->product->hasData('is_salable')) {
-            return $this->product->isAvailable();
-        }
-
-        $sourceItems = $this->getSourceItemsBySku->execute($this->product->getSku());
-
-        foreach ($sourceItems as $sourceItem) {
-            if ($sourceItem->getStatus()) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->productAvailability->isAvailable($this->product);
     }
 }

--- a/src/Model/Export/Catalog/ProductAvailability.php
+++ b/src/Model/Export/Catalog/ProductAvailability.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Model\Export\Catalog;
+
+use Magento\Catalog\Model\Product;
+use Magento\InventorySalesApi\Api\AreProductsSalableInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\StockResolverInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Resolves the availability of a product the same way the storefront does.
+ *
+ * The MSI source items are not a reliable source of truth. In single source mode the salability is
+ * derived from the legacy stock tables, so an installation which writes stock data without going
+ * through the MSI synchronization ends up with products which are salable everywhere but have no
+ * source item at all.
+ */
+class ProductAvailability
+{
+    /** @var array<string, int> */
+    private array $stockIds = [];
+
+    public function __construct(
+        private readonly AreProductsSalableInterface $areProductsSalable,
+        private readonly StockResolverInterface $stockResolver,
+        private readonly StoreManagerInterface $storeManager,
+    ) {
+    }
+
+    public function isAvailable(Product $product): bool
+    {
+        if ($product->hasData('is_salable')) {
+            return $product->isAvailable();
+        }
+
+        foreach ($this->areProductsSalable->execute([(string) $product->getSku()], $this->getStockId()) as $result) {
+            if ($result->isSalable()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getStockId(): int
+    {
+        $websiteCode = (string) $this->storeManager->getWebsite()->getCode();
+
+        return $this->stockIds[$websiteCode] ??= (int) $this->stockResolver
+            ->execute(SalesChannelInterface::TYPE_WEBSITE, $websiteCode)
+            ->getStockId();
+    }
+}

--- a/src/Model/Export/Catalog/ProductType/BundleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/BundleDataProvider.php
@@ -6,8 +6,8 @@ namespace Omikron\Factfinder\Model\Export\Catalog\ProductType;
 
 use Magento\Bundle\Model\Product\CatalogPrice;
 use Magento\Catalog\Model\Product;
-use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
 use Magento\Directory\Model\PriceCurrency;
+use Omikron\Factfinder\Model\Export\Catalog\ProductAvailability;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 
 class BundleDataProvider extends SimpleDataProvider
@@ -17,10 +17,10 @@ class BundleDataProvider extends SimpleDataProvider
         protected NumberFormatter      $numberFormatter,
         private readonly PriceCurrency $priceCurrency,
         private readonly CatalogPrice  $priceModel,
-        protected GetSourceItemsBySku  $getSourceItemsBySku,
+        protected ProductAvailability  $productAvailability,
         protected array                $productFields = []
     ) {
-        parent::__construct($product, $numberFormatter, $getSourceItemsBySku, $productFields);
+        parent::__construct($product, $numberFormatter, $productAvailability, $productFields);
     }
 
     public function toArray(): array

--- a/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/ConfigurableDataProvider.php
@@ -9,10 +9,10 @@ use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableProductType;
 use Magento\Framework\Api\SearchCriteriaBuilder;
-use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
 use Omikron\Factfinder\Api\Export\ExportEntityInterface;
 use Omikron\Factfinder\Api\Filter\FilterInterface;
 use Omikron\Factfinder\Model\Export\Catalog\Entity\ProductVariationFactory;
+use Omikron\Factfinder\Model\Export\Catalog\ProductAvailability;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 
 class ConfigurableDataProvider extends SimpleDataProvider
@@ -25,10 +25,10 @@ class ConfigurableDataProvider extends SimpleDataProvider
         private readonly ProductVariationFactory    $variationFactory,
         private readonly ProductRepositoryInterface $productRepository,
         private readonly SearchCriteriaBuilder      $builder,
-        protected GetSourceItemsBySku               $getSourceItemsBySku,
+        protected ProductAvailability               $productAvailability,
         protected array                             $productFields = []
     ) {
-        parent::__construct($product, $numberFormatter, $getSourceItemsBySku, $productFields);
+        parent::__construct($product, $numberFormatter, $productAvailability, $productFields);
     }
 
     public function getEntities(): iterable

--- a/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Omikron\Factfinder\Model\Export\Catalog\ProductType;
 
 use Magento\Catalog\Model\Product;
-use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
 use Omikron\Factfinder\Api\Export\FieldInterface;
 use Omikron\Factfinder\Api\Export\DataProviderInterface;
 use Omikron\Factfinder\Api\Export\ExportEntityInterface;
+use Omikron\Factfinder\Model\Export\Catalog\ProductAvailability;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 
 class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
@@ -16,7 +16,7 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
     public function __construct(
         protected Product $product,
         protected NumberFormatter $numberFormatter,
-        protected GetSourceItemsBySku $getSourceItemsBySku,
+        protected ProductAvailability $productAvailability,
         protected array $productFields = [],
     ) {
     }
@@ -66,18 +66,6 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
 
     private function getAvailability(): bool
     {
-        if ($this->product->hasData('is_salable')) {
-            return $this->product->isAvailable();
-        }
-
-        $sourceItems = $this->getSourceItemsBySku->execute($this->product->getSku());
-
-        foreach ($sourceItems as $sourceItem) {
-            if ($sourceItem->getStatus()) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->productAvailability->isAvailable($this->product);
     }
 }

--- a/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/Entity/ProductVariationTest.php
@@ -6,10 +6,9 @@ namespace Omikron\Factfinder\Model\Export\Catalog\Entity;
 
 use Magento\Catalog\Model\Product;
 use Magento\Framework\Model\AbstractModel;
-use Magento\Inventory\Model\SourceItem;
-use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
 use Omikron\Factfinder\Model\Export\Catalog\FieldProvider;
 use Omikron\Factfinder\Model\Export\Catalog\ProductField\FilterAttributes;
+use Omikron\Factfinder\Model\Export\Catalog\ProductAvailability;
 use Omikron\Factfinder\Model\Export\Catalog\ProductField\ProductImage;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -53,9 +52,7 @@ class ProductVariationTest extends TestCase
             $this->createMock(Product::class),
             new NumberFormatter(),
             $fieldProviderMock,
-            $this->createConfiguredMock(GetSourceItemsBySku::class, [
-                'execute' => [$this->createConfiguredMock(SourceItem::class, ['getStatus' => 1])]
-            ]),
+            $this->createConfiguredMock(ProductAvailability::class, ['isAvailable' => true]),
             $this->configurableProductData
         );
 
@@ -94,9 +91,7 @@ class ProductVariationTest extends TestCase
             $this->createMock(Product::class),
             new NumberFormatter(),
             $fieldProviderMock,
-            $this->createConfiguredMock(GetSourceItemsBySku::class, [
-                'execute' => [$this->createConfiguredMock(SourceItem::class, ['getStatus' => 1])]
-            ]),
+            $this->createConfiguredMock(ProductAvailability::class, ['isAvailable' => true]),
             ['FilterAttributes' => '|Color=Red|Size=XS|'] + $this->configurableProductData
         );
 
@@ -104,6 +99,20 @@ class ProductVariationTest extends TestCase
             '|Color=Red|Size=XS|Eco Collection=No|New=No|Price=52.00|Quantity=In Stock|',
             $productVariation->toArray()['FilterAttributes']
         );
+    }
+
+    public function test_availability_is_taken_from_the_product_availability_service()
+    {
+        $productVariation = new ProductVariation(
+            $this->variantMock,
+            $this->createMock(Product::class),
+            new NumberFormatter(),
+            $this->createConfiguredMock(FieldProvider::class, ['getVariantFields' => []]),
+            $this->createConfiguredMock(ProductAvailability::class, ['isAvailable' => false]),
+            $this->configurableProductData
+        );
+
+        $this->assertSame(0, $productVariation->toArray()['Availability']);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
The Availability column was derived from the status flags of the inventory_source_item rows of a product. That is not the salability Magento itself uses: in single source mode the salability is read from the legacy stock tables (the inventory_stock_1 view), and installations which write stock data without going through the MSI synchronization end up with no source item at all. Those products were exported with Availability=0 although they are in stock and orderable, which makes ranking rules drop them from the search results.

The availability is now resolved through AreProductsSalableInterface, which returns the same result as the storefront in both single and multi source setups. GetSourceItemsBySku is no longer needed, so the module depends on magento/module-inventory-sales-api instead of magento/module-inventory.

- Tested with Magento editions/versions:
    - 2.4.8-p5
- Tested with PHP versions:
    - 8.4

Co-authored-by: Claude Opus 5.0