### PR TITLE
INT-349: Fix unit test for availability changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fix
 - Fix issue with cart btn if WebComponents library is disabled
 - Fix brand suggestion redirection url
+- Export the real product salability as Availability
 
 ## [v5.3.1] - 2026.07.02
 ### Fix

--- a/src/Test/Unit/Model/Export/Catalog/AttributeValuesExtractorTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/AttributeValuesExtractorTest.php
@@ -20,6 +20,9 @@ class AttributeValuesExtractorTest extends TestCase
     /** @var NumberFormatter|MockObject  */
     private MockObject $numberFormatter;
 
+    /** @var MockObject|FilterInterface */
+    private MockObject $filterMock;
+
     public function test_it_returns_scalar_value()
     {
         $attributeValue  = 'Value';

--- a/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
+++ b/src/Test/Unit/Model/Export/Catalog/ProductType/ConfigurableDataProviderTest.php
@@ -12,6 +12,7 @@ use Magento\Inventory\Model\SourceItem;
 use Magento\Inventory\Model\SourceItem\Command\GetSourceItemsBySku;
 use Omikron\Factfinder\Api\Filter\FilterInterface;
 use Omikron\Factfinder\Model\Export\Catalog\Entity\ProductVariationFactory;
+use Omikron\Factfinder\Model\Export\Catalog\ProductAvailability;
 use Omikron\Factfinder\Model\Formatter\NumberFormatter;
 use Omikron\Factfinder\Test\TestHelper;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -106,6 +107,8 @@ class ConfigurableDataProviderTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $productAvailabilityMock = $this->createMock(ProductAvailability::class);
+
         $this->configurableDataProvider = new ConfigurableDataProvider(
             $this->productMock,
             $this->numberFormatMock,
@@ -114,9 +117,7 @@ class ConfigurableDataProviderTest extends TestCase
             $this->variantFactoryMock,
             $this->repositoryMock,
             $this->builderMock,
-            $this->createConfiguredMock(GetSourceItemsBySku::class, [
-                'execute' => [$this->createConfiguredMock(SourceItem::class, ['getStatus' => 1])]
-            ]),
+            $productAvailabilityMock
         );
     }
 }


### PR DESCRIPTION
Fix unit test for availability changes

- Solves issue:
    - INT-349
- Description:
    - Fix unit test for availability changes
- Tested with Magento editions/versions:
    - 2.4.9
- Tested with PHP versions:
    - 8.4
