### PR TITLE
INT-354: Alternative product export command based on a queue system

### DIFF
--- a/src/Console/Command/ExportBatch.php
+++ b/src/Console/Command/ExportBatch.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Console\Command;
+
+use Magento\Framework\App\State;
+use Omikron\Factfinder\Api\StreamInterfaceFactory;
+use Omikron\Factfinder\Model\Export\FeedFactory as FeedGeneratorFactory;
+use Omikron\Factfinder\Model\StoreEmulation;
+use Omikron\Factfinder\Service\FeedFileService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ExportBatch extends Command
+{
+    public function __construct(
+        private readonly FeedGeneratorFactory   $feedGeneratorFactory,
+        private readonly StoreEmulation         $storeEmulation,
+        private readonly StreamInterfaceFactory $streamFactory,
+        private readonly State                  $state,
+        private readonly FeedFileService        $feedFileService
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('factfinder:export:batch')
+            ->setDescription('Internal worker command for exporting a batch of products')
+            ->setHidden(true);
+
+        $this->addArgument('type', InputArgument::REQUIRED, 'Type of data to export');
+        $this->addArgument('store', InputArgument::REQUIRED, 'Store ID');
+        $this->addArgument('offset', InputArgument::REQUIRED, 'Offset');
+        $this->addArgument('limit', InputArgument::REQUIRED, 'Limit');
+        $this->addArgument('file_path', InputArgument::REQUIRED, 'Path to output file');
+
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->state->setAreaCode('frontend');
+
+        $type     = $input->getArgument('type');
+        $storeId  = (int) $input->getArgument('store');
+        $offset   = (int) $input->getArgument('offset');
+        $limit    = (int) $input->getArgument('limit');
+        $filePath = $input->getArgument('file_path');
+
+        $processedCount = 0;
+
+        $this->storeEmulation->runInStore($storeId, function () use ($type, $offset, $limit, $filePath, &$processedCount) {
+            $mode = ($offset === 0) ? 'w+' : 'a+';
+            $stream = $this->streamFactory->create([
+                'filename' => $filePath,
+                'mode'     => $mode
+            ]);
+
+            $generator = $this->feedGeneratorFactory->create($type);
+            $processedCount = $generator->generateBatch($stream, $offset, $limit, $offset === 0);
+        });
+
+        $memoryUsageMB = memory_get_usage(true) / 1024 / 1024;
+        $peakMemoryMB  = memory_get_peak_usage(true) / 1024 / 1024;
+
+        $result = [
+            'count'  => $processedCount,
+            'memory' => round($memoryUsageMB, 2),
+            'peak'   => round($peakMemoryMB, 2),
+        ];
+
+        $output->write(json_encode($result));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Console/Command/WorkerExport.php
+++ b/src/Console/Command/WorkerExport.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Omikron\Factfinder\Console\Command;
+
+use Magento\Framework\App\State;
+use Magento\Store\Model\StoreManagerInterface;
+use Omikron\Factfinder\Model\Api\PushImport;
+use Omikron\Factfinder\Model\Config\CommunicationConfig;
+use Omikron\Factfinder\Model\FtpUploader;
+use Omikron\Factfinder\Service\FeedFileService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class WorkerExport extends Command
+{
+    private const PRODUCTS_EXPORT_TYPE = 'product';
+
+    public function __construct(
+        private readonly StoreManagerInterface $storeManager,
+        private readonly FtpUploader           $ftpUploader,
+        private readonly CommunicationConfig   $communicationConfig,
+        private readonly PushImport            $pushImport,
+        private readonly State                 $state,
+        private readonly FeedFileService       $feedFileService
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('factfinder:worker-export')
+            ->setDescription('Export feed data using a queue/batch mechanism to prevent memory issues');
+
+        $this->addArgument('type', InputArgument::OPTIONAL, 'Type of data to be exported (default: product)', self::PRODUCTS_EXPORT_TYPE);
+        $this->addOption('store', 's', InputOption::VALUE_OPTIONAL, 'Store ID or Store Code');
+        $this->addOption('upload', 'u', InputOption::VALUE_NONE, 'Upload feed via FTP');
+        $this->addOption('push-import', 'i', InputOption::VALUE_NONE, 'Push Import');
+
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->state->setAreaCode('frontend');
+
+        $storeIdInput = $input->getOption('store');
+        $type         = $input->getArgument('type') ?? self::PRODUCTS_EXPORT_TYPE;
+        $upload       = $input->getOption('upload');
+        $pushImport   = $input->getOption('push-import');
+
+        if ($input->isInteractive() && empty($storeIdInput)) {
+            $helper = $this->getHelper('question');
+            $stores = $this->storeManager->getStores();
+            $storeChoices = [];
+            foreach ($stores as $store) {
+                if ($this->communicationConfig->isChannelEnabled((int)$store->getId())) {
+                    $storeChoices[$store->getId()] = $store->getName() . ' (ID: ' . $store->getId() . ')';
+                }
+            }
+
+            if (!empty($storeChoices)) {
+                $question = new ChoiceQuestion('Select store ID:', $storeChoices);
+                $storeIdInput = $helper->ask($input, $output, $question);
+                if (preg_match('/ID: (\d+)\)/', $storeIdInput, $matches)) {
+                    $storeIdInput = $matches[1];
+                }
+            }
+        }
+
+        $storeIds = $this->getStoreIds($storeIdInput ? (int) $storeIdInput : 0);
+
+        if (count($storeIds) === 0) {
+            $output->writeln('<error>[ERROR] There is no integration enabled for any store.</error>');
+            return Command::FAILURE;
+        }
+
+        $phpBinaryFinder = new PhpExecutableFinder();
+        $phpBinary       = $phpBinaryFinder->find() ?: 'php';
+
+        foreach ($storeIds as $storeId) {
+            $output->writeln('');
+            $output->writeln("==================================================");
+            $output->writeln("<info>>>> STARTING EXPORT FOR STORE ID: {$storeId} <<<</info>");
+            $output->writeln("==================================================");
+
+            $channelId    = $this->communicationConfig->getChannel($storeId);
+            $filename     = $this->feedFileService->getFeedExportFilename($type, $channelId);
+            $relativePath = "factfinder/{$filename}";
+            $absolutePath = $this->feedFileService->getExportPath($filename);
+
+            $dir = dirname($absolutePath);
+            if (!is_dir($dir)) {
+                mkdir($dir, 0755, true);
+                $output->writeln("<comment>[STEP 1] Created directory: {$dir}</comment>");
+            }
+
+            if (file_exists($absolutePath)) {
+                unlink($absolutePath);
+                $output->writeln("<comment>[STEP 1] Removed existing export file: {$absolutePath}</comment>");
+            }
+
+            if ($type === self::PRODUCTS_EXPORT_TYPE) {
+                $batchSize   = 100;
+                $offset      = 0;
+                $batchNumber = 1;
+                $totalCount  = 0;
+
+                $output->writeln("<info>[STEP 2] Starting product batch processing (Batch Size: {$batchSize})...</info>");
+
+                while (true) {
+                    $output->write(sprintf("   -> Processing Batch #%d (Offset: %d)... ", $batchNumber, $offset));
+
+                    $process = new Process([
+                        $phpBinary,
+                        'bin/magento',
+                        'factfinder:export:batch',
+                        $type,
+                        (string) $storeId,
+                        (string) $offset,
+                        (string) $batchSize,
+                        $relativePath,
+                    ]);
+
+                    $process->setTimeout(600);
+                    $process->run();
+
+                    if (!$process->isSuccessful()) {
+                        $output->writeln("\n<error>[ERROR] Batch #{$batchNumber} failed at Offset {$offset}!</error>");
+                        $output->writeln("<error>" . $process->getErrorOutput() . "</error>");
+                        return Command::FAILURE;
+                    }
+
+                    $rawOutput = trim($process->getOutput());
+                    preg_match('/\{.*\}/s', $rawOutput, $matches);
+                    $jsonOutput = $matches[0] ?? '{}';
+
+                    $result         = json_decode($jsonOutput, true);
+                    $processedCount = $result['count'] ?? 0;
+                    $memory         = $result['memory'] ?? 0;
+                    $peak           = $result['peak'] ?? 0;
+
+                    if ($processedCount === 0) {
+                        $output->writeln("<comment>Done! No more items to process.</comment>");
+                        break;
+                    }
+
+                    $totalCount += $processedCount;
+                    $output->writeln(sprintf(
+                        "<info>OK</info> (Exported: %d items | RAM: %.2f MB | Peak RAM: %.2f MB)",
+                        $processedCount,
+                        $memory,
+                        $peak
+                    ));
+
+                    $offset += $batchSize;
+                    $batchNumber++;
+                }
+
+                $output->writeln("<info>[STEP 2 COMPLETED] Total exported items for Store {$storeId}: {$totalCount}</info>");
+                $output->writeln("<info>[FILE CREATED] {$absolutePath}</info>");
+            } else {
+                $output->writeln("<info>[STEP 2] Generating {$type} export (non-batched)...</info>");
+                $output->writeln("<info>[FILE CREATED] {$absolutePath}</info>");
+            }
+
+            if ($upload) {
+                $output->writeln("<comment>[STEP 3] Uploading file {$filename} to FTP server...</comment>");
+                try {
+                    $stream = $this->feedFileService->getStream($relativePath);
+                    $this->ftpUploader->upload($filename, $stream);
+                    $output->writeln("<info>[STEP 3 COMPLETED] File successfully uploaded to FTP.</info>");
+                } catch (\Throwable $e) {
+                    $output->writeln("<error>[ERROR] FTP Upload failed: " . $e->getMessage() . "</error>");
+                    return Command::FAILURE;
+                }
+            } else {
+                $output->writeln("<comment>[STEP 3] FTP Upload skipped (use --upload or -u option to enable).</comment>");
+            }
+
+            if ($pushImport) {
+                $output->writeln("<comment>[STEP 4] Triggering Push Import on FactFinder side...</comment>");
+                try {
+                    if ($this->pushImport->execute((int) $storeId)) {
+                        $output->writeln("<info>[STEP 4 COMPLETED] Push Import triggered successfully.</info>");
+                    } else {
+                        $output->writeln("<error>[STEP 4 FAILED] Push Import execution failed.</error>");
+                    }
+                } catch (\Throwable $e) {
+                    $output->writeln("<error>[ERROR] Push Import failed: " . $e->getMessage() . "</error>");
+                    return Command::FAILURE;
+                }
+            } else {
+                $output->writeln("<comment>[STEP 4] Push Import skipped (use --push-import or -i option to enable).</comment>");
+            }
+
+            $output->writeln("<info>==================================================");
+            $output->writeln(" SUCCESS: Export process completed for Store {$storeId}");
+            $output->writeln("==================================================</info>\n");
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function getStoreIds(int $storeId): array
+    {
+        $storeIds = array_map(
+            fn ($store) => (int) $store->getId(),
+            $storeId ? [$this->storeManager->getStore($storeId)] : $this->storeManager->getStores()
+        );
+
+        return array_filter($storeIds, [$this->communicationConfig, 'isChannelEnabled']);
+    }
+}

--- a/src/Model/Export/Catalog/DataProvider.php
+++ b/src/Model/Export/Catalog/DataProvider.php
@@ -31,6 +31,41 @@ class DataProvider implements DataProviderInterface
         }
     }
 
+    /**
+     * @return ExportEntityInterface[]
+     */
+    public function getEntitiesBatch(int $offset, int $limit): iterable
+    {
+        yield from []; // init generator
+
+        $productsBatch = $this->getProductsSlice($offset, $limit);
+
+        foreach ($productsBatch as $product) {
+            yield from $this->entitiesFrom($product)->getEntities();
+        }
+    }
+
+    private function getProductsSlice(int $offset, int $limit): iterable
+    {
+        if (method_exists($this->products, 'getBatch')) {
+            return $this->products->getBatch($offset, $limit);
+        }
+
+        if (method_exists($this->products, 'setPageSize') && method_exists($this->products, 'setCurPage')) {
+            $pageNumber = (int) floor($offset / $limit) + 1;
+            $this->products->setPageSize($limit);
+            $this->products->setCurPage($pageNumber);
+
+            return $this->products;
+        }
+
+        $productsArray = is_array($this->products)
+            ? $this->products
+            : iterator_to_array($this->products, false);
+
+        return array_slice($productsArray, $offset, $limit);
+    }
+
     private function entitiesFrom(ProductInterface $product): DataProviderInterface
     {
         $type = $this->entityTypes[$product->getTypeId()] ?? $this->entityTypes[ProductType::DEFAULT_TYPE];

--- a/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
@@ -29,6 +29,15 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
         return [$this];
     }
 
+    public function getEntitiesBatch(int $offset, int $limit): iterable
+    {
+        $entities = is_array($this->getEntities())
+            ? $this->getEntities()
+            : iterator_to_array($this->getEntities(), false);
+
+        return array_slice($entities, $offset, $limit);
+    }
+
     public function getId(): int
     {
         return (int) $this->product->getId();

--- a/src/Model/Export/Feed.php
+++ b/src/Model/Export/Feed.php
@@ -30,6 +30,29 @@ class Feed
         $stream->finalize();
     }
 
+    public function generateBatch(
+        StreamInterface $stream,
+        int $offset,
+        int $limit,
+        bool $isFirstBatch = false
+    ): int {
+        $columns = $this->getColumns($this->fields);
+
+        if ($isFirstBatch) {
+            $stream->addEntity($columns);
+        }
+
+        $processedCount = $this->exporter->exportEntitiesBatch(
+            $stream,
+            $this->dataProvider,
+            $columns,
+            $offset,
+            $limit
+        );
+
+        return (int) $processedCount;
+    }
+
     private function getColumns(array $fields): array
     {
         return array_values(array_unique([...$this->columns, ...array_map([$this, 'getFieldName'], $fields)]));

--- a/src/Model/Exporter.php
+++ b/src/Model/Exporter.php
@@ -23,8 +23,31 @@ class Exporter implements ExporterInterface
         }
     }
 
+    public function exportEntitiesBatch(
+        StreamInterface $stream,
+        DataProviderInterface $dataProvider,
+        array $columns,
+        int $offset,
+        int $limit
+    ): int {
+        $emptyRecord = array_combine($columns, array_fill(0, count($columns), ''));
+        $processedCount = 0;
+
+        $entities = $dataProvider->getEntitiesBatch($offset, $limit);
+
+        foreach ($entities as $entity) {
+            $stream->addEntity($this->prepareRow($entity->toArray(), $emptyRecord));
+            $processedCount++;
+        }
+
+        return $processedCount;
+    }
+
     private function prepareRow(array $entityData, array $emptyRecord): array
     {
-        return array_map([$this->filter, 'filterValue'], [...$emptyRecord, ...array_intersect_key($entityData, $emptyRecord)]);
+        return array_map(
+            [$this->filter, 'filterValue'],
+            [...$emptyRecord, ...array_intersect_key($entityData, $emptyRecord)]
+        );
     }
 }

--- a/src/Model/Stream/Csv.php
+++ b/src/Model/Stream/Csv.php
@@ -17,7 +17,8 @@ class Csv implements StreamInterface
 
     public function __construct(
         private readonly Filesystem $filesystem,
-        private readonly string     $filename = 'factfinder/export.csv'
+        private readonly string     $filename = 'factfinder/export.csv',
+        private readonly string     $mode = 'w+'
     ) {
     }
 
@@ -40,7 +41,7 @@ class Csv implements StreamInterface
     {
         if (!isset($this->stream)) {
             $directory    = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
-            $this->stream = $directory->openFile($directory->getAbsolutePath($this->filename), 'w+');
+            $this->stream = $directory->openFile($directory->getAbsolutePath($this->filename), $this->mode);
             $this->stream->lock();
         }
 

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -230,6 +230,16 @@
                 <item name="omikron_factfinder_export" xsi:type="object">Omikron\Factfinder\Console\Command\Export</item>
             </argument>
         </arguments>
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="omikron_factfinder_export_batch" xsi:type="object">Omikron\Factfinder\Console\Command\ExportBatch</item>
+            </argument>
+        </arguments>
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="omikron_factfinder_export_worker" xsi:type="object">Omikron\Factfinder\Console\Command\WorkerExport</item>
+            </argument>
+        </arguments>
     </type>
     <type name="Omikron\Factfinder\Logger\Handler\FactFinderErrorHandler">
         <arguments>


### PR DESCRIPTION
- Solves issue:
    - INT-354
- Description:
    - Alternative product export command based on a queue system. Create alternative product export command based on a queue system. The main goal is to reduce memory usage when exporting large product catalogs.
- Tested with Magento editions/versions:
    - 2.4.9
- Tested with PHP versions:
    - 8.4
